### PR TITLE
feat(app) Used dnd-kit for drag-and-drop functionality

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",
+        "@dnd-kit/modifiers": "^9.0.0",
         "@dnd-kit/sortable": "^10.0.0",
         "@dnd-kit/utilities": "^3.2.2",
         "@hookform/resolvers": "^5.2.2",
@@ -734,6 +735,20 @@
       "peerDependencies": {
         "react": ">=16.8.0",
         "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/modifiers": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/modifiers/-/modifiers-9.0.0.tgz",
+      "integrity": "sha512-ybiLc66qRGuZoC20wdSSG6pDXFikui/dCNGthxv4Ndy8ylErY0N3KVxY2bgo7AWwIbxDmXDg3ylAFmnrjcbVvw==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "@dnd-kit/core": "^6.3.0",
+        "react": ">=16.8.0"
       }
     },
     "node_modules/@dnd-kit/sortable": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,9 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
+        "@dnd-kit/core": "^6.3.1",
+        "@dnd-kit/sortable": "^10.0.0",
+        "@dnd-kit/utilities": "^3.2.2",
         "@hookform/resolvers": "^5.2.2",
         "@monaco-editor/react": "^4.7.0",
         "@radix-ui/react-accordion": "^1.2.12",
@@ -705,6 +708,59 @@
     "node_modules/@date-fns/tz": {
       "version": "1.4.1",
       "license": "MIT"
+    },
+    "node_modules/@dnd-kit/accessibility": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/accessibility/-/accessibility-3.1.1.tgz",
+      "integrity": "sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/core": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/core/-/core-6.3.1.tgz",
+      "integrity": "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/accessibility": "^3.1.1",
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/sortable": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/sortable/-/sortable-10.0.0.tgz",
+      "integrity": "sha512-+xqhmIIzvAYMGfBYYnbKuNicfSsk4RksY2XdmJhT+HAC01nix6fHCztU68jooFiMUB01Ky3F0FyOvhG/BZrWkg==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "@dnd-kit/core": "^6.3.0",
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/utilities": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/utilities/-/utilities-3.2.2.tgz",
+      "integrity": "sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
     },
     "node_modules/@emnapi/runtime": {
       "version": "1.8.1",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   },
   "dependencies": {
     "@dnd-kit/core": "^6.3.1",
+    "@dnd-kit/modifiers": "^9.0.0",
     "@dnd-kit/sortable": "^10.0.0",
     "@dnd-kit/utilities": "^3.2.2",
     "@hookform/resolvers": "^5.2.2",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,9 @@
     "preview:worker": "wrangler dev"
   },
   "dependencies": {
+    "@dnd-kit/core": "^6.3.1",
+    "@dnd-kit/sortable": "^10.0.0",
+    "@dnd-kit/utilities": "^3.2.2",
     "@hookform/resolvers": "^5.2.2",
     "@monaco-editor/react": "^4.7.0",
     "@radix-ui/react-accordion": "^1.2.12",

--- a/src/components/EditorToolbar.test.tsx
+++ b/src/components/EditorToolbar.test.tsx
@@ -71,7 +71,7 @@ describe('EditorToolbar', () => {
       </TooltipProvider>
     )
 
-    const pipeline1 = screen.getByLabelText('Pipeline 1').closest('div[draggable="true"]')
+    const pipeline1 = screen.getByLabelText('Pipeline 1').closest('button')
     expect(pipeline1).toBeDefined()
 
     const dragStartEvent = fireEvent.dragStart(pipeline1!, {

--- a/src/components/EditorToolbar.tsx
+++ b/src/components/EditorToolbar.tsx
@@ -7,6 +7,7 @@ import {
   PointerSensor,
   type DragStartEvent,
   type DragEndEvent,
+  type DraggableAttributes,
   closestCenter,
 } from '@dnd-kit/core'
 import type { SyntheticListenerMap } from '@dnd-kit/core/dist/hooks/utilities'
@@ -88,8 +89,7 @@ interface ToolbarButtonProps {
   active?: boolean
   allowDrag?: boolean
   className?: string
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  dragAttributes?: any
+  dragAttributes?: DraggableAttributes
   dragListeners?: SyntheticListenerMap
   tooltipDisabled?: boolean
 }

--- a/src/components/EditorToolbar.tsx
+++ b/src/components/EditorToolbar.tsx
@@ -5,8 +5,6 @@ import {
   useSensor,
   useSensors,
   PointerSensor,
-  TouchSensor,
-  MouseSensor,
   type DragStartEvent,
   type DragEndEvent,
   closestCenter,
@@ -123,6 +121,7 @@ const ToolbarButton = forwardRef<HTMLButtonElement, ToolbarButtonProps>(
             size="icon-sm"
             onClick={onClick}
             onMouseDown={allowDrag ? undefined : (e) => e.preventDefault()}
+            style={{ touchAction: allowDrag ? 'none' : undefined }}
             className={cn(
               'text-muted-foreground hover:text-foreground',
               active && 'bg-accent text-foreground',
@@ -318,13 +317,6 @@ export function EditorToolbar({
     useSensor(PointerSensor, {
       activationConstraint: {
         distance: 8,
-      },
-    }),
-    useSensor(MouseSensor),
-    useSensor(TouchSensor, {
-      activationConstraint: {
-        delay: 150,
-        tolerance: 5,
       },
     })
   )

--- a/src/components/EditorToolbar.tsx
+++ b/src/components/EditorToolbar.tsx
@@ -1,4 +1,24 @@
-import { type ElementType } from 'react'
+import { type ElementType, forwardRef } from 'react'
+import {
+  DndContext,
+  DragOverlay,
+  useSensor,
+  useSensors,
+  PointerSensor,
+  TouchSensor,
+  MouseSensor,
+  type DragStartEvent,
+  type DragEndEvent,
+  closestCenter,
+} from '@dnd-kit/core'
+import type { SyntheticListenerMap } from '@dnd-kit/core/dist/hooks/utilities'
+import {
+  SortableContext,
+  useSortable,
+  horizontalListSortingStrategy,
+  arrayMove,
+} from '@dnd-kit/sortable'
+import { CSS } from '@dnd-kit/utilities'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import { Button } from '@/components/ui/button'
 import {
@@ -70,6 +90,9 @@ interface ToolbarButtonProps {
   active?: boolean
   allowDrag?: boolean
   className?: string
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  dragAttributes?: any 
+  dragListeners?: SyntheticListenerMap
 }
 
 /**
@@ -77,34 +100,119 @@ interface ToolbarButtonProps {
  * @param props - Component props
  * @returns Toolbar button component
  */
-function ToolbarButton({
-  icon: Icon,
-  label,
-  onClick,
-  active = false,
-  allowDrag = false,
-  className,
-}: ToolbarButtonProps): ReactElement {
+const ToolbarButton = forwardRef<HTMLButtonElement, ToolbarButtonProps>(
+  (
+    {
+      icon: Icon,
+      label,
+      onClick,
+      active = false,
+      allowDrag = false,
+      className,
+      dragAttributes,
+      dragListeners,
+    },
+    ref
+  ) => {
+    return (
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <Button
+            ref={ref}
+            variant="ghost"
+            size="icon-sm"
+            onClick={onClick}
+            onMouseDown={allowDrag ? undefined : (e) => e.preventDefault()}
+            className={cn(
+              'text-muted-foreground hover:text-foreground',
+              active && 'bg-accent text-foreground',
+              className
+            )}
+            {...dragAttributes}
+            {...dragListeners}
+          >
+            <Icon className="size-4" />
+            <span className="sr-only">{label}</span>
+          </Button>
+        </TooltipTrigger>
+        <TooltipContent>{label}</TooltipContent>
+      </Tooltip>
+    )
+  }
+)
+ToolbarButton.displayName = 'ToolbarButton'
+
+// Sortable Button Wrapper for Pipelines
+function SortablePipelineButton({
+  pipeline,
+  isActive,
+  onApply,
+  onEdit,
+  onDeleteRequest,
+}: {
+  pipeline: TransformationPipeline
+  isActive: boolean
+  onApply?: (pipeline: TransformationPipeline) => void
+  onEdit?: (pipeline: TransformationPipeline) => void
+  onDeleteRequest?: (pipeline: TransformationPipeline) => void
+}) {
+  const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
+    id: pipeline.id,
+    data: { pipeline },
+  })
+
+  const style = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+    opacity: isDragging ? 0.4 : 1,
+  }
+
+  const PipelineIcon = ICON_MAP[pipeline.icon]
+
   return (
-    <Tooltip>
-      <TooltipTrigger asChild>
-        <Button
-          variant="ghost"
-          size="icon-sm"
-          onClick={onClick}
-          onMouseDown={allowDrag ? undefined : (e) => e.preventDefault()}
-          className={cn(
-            'text-muted-foreground hover:text-foreground',
-            active && 'bg-accent text-foreground',
-            className
-          )}
-        >
-          <Icon className="size-4" />
-          <span className="sr-only">{label}</span>
-        </Button>
-      </TooltipTrigger>
-      <TooltipContent>{label}</TooltipContent>
-    </Tooltip>
+    <div
+      ref={setNodeRef}
+      style={style}
+      className={cn(
+        'transition-opacity flex items-center',
+        isActive && 'cursor-grabbing',
+        !isActive && 'cursor-grab'
+      )}
+    >
+      <ContextMenu>
+        <ContextMenuTrigger asChild>
+          <div>
+            <ToolbarButton
+              icon={() =>
+                PipelineIcon ? (
+                  <PipelineIcon className="size-4" />
+                ) : (
+                  <span className="text-sm px-0.5" role="img" aria-label={pipeline.name}>
+                    {pipeline.icon}
+                  </span>
+                )
+              }
+              label={pipeline.name}
+              onClick={() => onApply?.(pipeline)}
+              allowDrag
+              className={!PipelineIcon ? 'w-auto px-2 min-w-8' : undefined}
+              dragAttributes={attributes}
+              dragListeners={listeners}
+            />
+          </div>
+        </ContextMenuTrigger>
+        <ContextMenuContent>
+          <ContextMenuItem onClick={() => onEdit?.(pipeline)}>
+            <Pencil className="size-4" />
+            Edit Transformer
+          </ContextMenuItem>
+          <ContextMenuItem variant="destructive" onClick={() => onDeleteRequest?.(pipeline)}>
+            <Trash2 className="size-4" />
+            Delete Transformer
+          </ContextMenuItem>
+        </ContextMenuContent>
+      </ContextMenu>
+    </div>
   )
 }
 
@@ -148,7 +256,6 @@ import { useState, useRef } from 'react'
 
 /**
  * Main editor toolbar with document controls, formatting tools, and settings
-
  * @param props - Component props
  * @returns Editor toolbar component
  */
@@ -188,7 +295,7 @@ export function EditorToolbar({
 }: EditorToolbarProps): ReactElement {
   const [isConfirmingClear, setIsConfirmingClear] = useState(false)
   const [pipelineToDelete, setPipelineToDelete] = useState<TransformationPipeline | null>(null)
-  const [draggedPipelineId, setDraggedPipelineId] = useState<string | null>(null)
+  const [activeDragPipeline, setActiveDragPipeline] = useState<TransformationPipeline | null>(null)
   const clearTimerRef = useRef<NodeJS.Timeout | null>(null)
 
   const handleClearClick = (e: React.MouseEvent) => {
@@ -206,45 +313,43 @@ export function EditorToolbar({
     }
   }
 
-  const handleDragStart = (e: React.DragEvent, id: string) => {
-    if (e.dataTransfer) {
-      e.dataTransfer.effectAllowed = 'move'
-      // Chrome requires setData to be called for drag to work
-      e.dataTransfer.setData?.('text/plain', id)
+  // DnD Sensors
+  const sensors = useSensors(
+    useSensor(PointerSensor, {
+      activationConstraint: {
+        distance: 8,
+      },
+    }),
+    useSensor(MouseSensor),
+    useSensor(TouchSensor, {
+      activationConstraint: {
+        delay: 150,
+        tolerance: 5,
+      },
+    })
+  )
+
+  const handleDragStart = (event: DragStartEvent) => {
+    if (event.active.data.current?.pipeline) {
+      setActiveDragPipeline(event.active.data.current.pipeline)
     }
-    // Chrome bug: DOM manipulation during dragStart cancels the drag
-    // Delay state update to avoid this
-    setTimeout(() => {
-      setDraggedPipelineId(id)
-    }, 10)
   }
 
-  const handleDragOver = (e: React.DragEvent) => {
-    e.preventDefault()
-    e.dataTransfer.dropEffect = 'move'
-  }
+  const handleDragEnd = (event: DragEndEvent) => {
+    setActiveDragPipeline(null)
+    const { active, over } = event
 
-  const handleDrop = (e: React.DragEvent, targetId: string) => {
-    e.preventDefault()
-    if (!draggedPipelineId || !pipelines || draggedPipelineId === targetId) {
-      setDraggedPipelineId(null)
-      return
+    if (!over || !pipelines) return
+
+    if (active.id !== over.id) {
+      const oldIndex = pipelines.findIndex((p) => p.id === active.id)
+      const newIndex = pipelines.findIndex((p) => p.id === over.id)
+
+      if (oldIndex !== -1 && newIndex !== -1) {
+        const newPipelines = arrayMove(pipelines, oldIndex, newIndex)
+        onReorderPipelines?.(newPipelines)
+      }
     }
-
-    const draggedIndex = pipelines.findIndex((p) => p.id === draggedPipelineId)
-    const targetIndex = pipelines.findIndex((p) => p.id === targetId)
-
-    if (draggedIndex === -1 || targetIndex === -1) {
-      setDraggedPipelineId(null)
-      return
-    }
-
-    const newPipelines = [...pipelines]
-    const [dragged] = newPipelines.splice(draggedIndex, 1)
-    newPipelines.splice(targetIndex, 0, dragged)
-
-    onReorderPipelines?.(newPipelines)
-    setDraggedPipelineId(null)
   }
 
   return (
@@ -360,98 +465,82 @@ export function EditorToolbar({
         <ToolbarButton icon={Wand2} label="Transform Selection" onClick={onOpenTransformer} />
 
         {pipelines && pipelines.length > 0 && (
-          <>
+          <DndContext
+            sensors={sensors}
+            collisionDetection={closestCenter}
+            onDragStart={handleDragStart}
+            onDragEnd={handleDragEnd}
+          >
             <div className="w-px h-5 bg-border mx-1" />
             <div className="flex items-center gap-1">
-              {pipelines.map((pipeline) => {
-                const PipelineIcon = ICON_MAP[pipeline.icon]
-                return (
-                  <div
+              <SortableContext items={pipelines} strategy={horizontalListSortingStrategy}>
+                {pipelines.map((pipeline) => (
+                  <SortablePipelineButton
                     key={pipeline.id}
-                    draggable
-                    onDragStart={(e) => handleDragStart(e, pipeline.id)}
-                    onDragOver={handleDragOver}
-                    onDrop={(e) => handleDrop(e, pipeline.id)}
-                    onDragEnd={() => setDraggedPipelineId(null)}
-                    className={cn(
-                      'transition-opacity flex items-center cursor-grab',
-                      draggedPipelineId === pipeline.id && 'opacity-50 pointer-events-none',
-                      draggedPipelineId && draggedPipelineId !== pipeline.id && 'cursor-pointer'
-                    )}
-                  >
-                    <ContextMenu>
-                      <ContextMenuTrigger asChild>
-                        <div>
-                          <ToolbarButton
-                            icon={() =>
-                              PipelineIcon ? (
-                                <PipelineIcon className="size-4" />
-                              ) : (
-                                <span
-                                  className="text-sm px-0.5"
-                                  role="img"
-                                  aria-label={pipeline.name}
-                                >
-                                  {pipeline.icon}
-                                </span>
-                              )
-                            }
-                            label={pipeline.name}
-                            onClick={() => onApplyPipeline?.(pipeline)}
-                            allowDrag
-                            className={!PipelineIcon ? 'w-auto px-2 min-w-8' : undefined}
-                          />
-                        </div>
-                      </ContextMenuTrigger>
-                      <ContextMenuContent>
-                        <ContextMenuItem onClick={() => onEditPipeline?.(pipeline)}>
-                          <Pencil className="size-4" />
-                          Edit Transformer
-                        </ContextMenuItem>
-                        <ContextMenuItem
-                          variant="destructive"
-                          onClick={() => setPipelineToDelete(pipeline)}
-                        >
-                          <Trash2 className="size-4" />
-                          Delete Transformer
-                        </ContextMenuItem>
-                      </ContextMenuContent>
-                    </ContextMenu>
-                  </div>
-                )
-              })}
+                    pipeline={pipeline}
+                    isActive={activeDragPipeline?.id === pipeline.id}
+                    onApply={onApplyPipeline}
+                    onEdit={onEditPipeline}
+                    onDeleteRequest={setPipelineToDelete}
+                  />
+                ))}
+              </SortableContext>
             </div>
-
-            <AlertDialog
-              open={!!pipelineToDelete}
-              onOpenChange={(open) => !open && setPipelineToDelete(null)}
-            >
-              <AlertDialogContent>
-                <AlertDialogHeader>
-                  <AlertDialogTitle>Delete Transformer?</AlertDialogTitle>
-                  <AlertDialogDescription>
-                    Are you sure you want to delete &ldquo;{pipelineToDelete?.name}&rdquo;? This
-                    action cannot be undone.
-                  </AlertDialogDescription>
-                </AlertDialogHeader>
-                <AlertDialogFooter>
-                  <AlertDialogCancel>Cancel</AlertDialogCancel>
-                  <AlertDialogAction
-                    className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
-                    onClick={() => {
-                      if (pipelineToDelete) {
-                        onDeletePipeline?.(pipelineToDelete.id)
-                        setPipelineToDelete(null)
-                      }
+            <DragOverlay>
+              {activeDragPipeline ? (
+                <div className="opacity-80">
+                  <ToolbarButton
+                    icon={() => {
+                      const Icon = ICON_MAP[activeDragPipeline.icon]
+                      return Icon ? (
+                        <Icon className="size-4" />
+                      ) : (
+                        <span
+                          className="text-sm px-0.5"
+                          role="img"
+                          aria-label={activeDragPipeline.name}
+                        >
+                          {activeDragPipeline.icon}
+                        </span>
+                      )
                     }}
-                  >
-                    Delete
-                  </AlertDialogAction>
-                </AlertDialogFooter>
-              </AlertDialogContent>
-            </AlertDialog>
-          </>
+                    label={activeDragPipeline.name}
+                    className={!ICON_MAP[activeDragPipeline.icon] ? 'w-auto px-2 min-w-8' : undefined}
+                  />
+                </div>
+              ) : null}
+            </DragOverlay>
+          </DndContext>
         )}
+
+        <AlertDialog
+          open={!!pipelineToDelete}
+          onOpenChange={(open) => !open && setPipelineToDelete(null)}
+        >
+          <AlertDialogContent>
+            <AlertDialogHeader>
+              <AlertDialogTitle>Delete Transformer?</AlertDialogTitle>
+              <AlertDialogDescription>
+                Are you sure you want to delete &ldquo;{pipelineToDelete?.name}&rdquo;? This action
+                cannot be undone.
+              </AlertDialogDescription>
+            </AlertDialogHeader>
+            <AlertDialogFooter>
+              <AlertDialogCancel>Cancel</AlertDialogCancel>
+              <AlertDialogAction
+                className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+                onClick={() => {
+                  if (pipelineToDelete) {
+                    onDeletePipeline?.(pipelineToDelete.id)
+                    setPipelineToDelete(null)
+                  }
+                }}
+              >
+                Delete
+              </AlertDialogAction>
+            </AlertDialogFooter>
+          </AlertDialogContent>
+        </AlertDialog>
       </div>
 
       <div className="flex items-center gap-1 order-2 md:order-none ml-auto md:ml-0">

--- a/src/components/transformer/TransformerDialog.tsx
+++ b/src/components/transformer/TransformerDialog.tsx
@@ -10,7 +10,6 @@ import {
   type DragEndEvent,
   closestCenter,
 } from '@dnd-kit/core'
-import { snapCenterToCursor } from '@dnd-kit/modifiers'
 import { arrayMove } from '@dnd-kit/sortable'
 import { useToast } from '@/hooks/useToast'
 import {
@@ -35,6 +34,7 @@ import { IconPicker } from './IconPicker'
 import { TransformerToolbox, DraggableToolboxItem } from './TransformerToolbox'
 import { TransformerWorkbench } from './TransformerWorkbench'
 import { TransformerPreview } from './TransformerPreview'
+import { TransformerStep } from './TransformerStep'
 import type { TransformationPipeline, PipelineStep, TransformerOperation } from './types'
 
 interface TransformerDialogProps {
@@ -435,13 +435,22 @@ export function TransformerDialog({
         </DialogContent>
       </Dialog>
       {createPortal(
-        <DragOverlay
-          className="z-[100] pointer-events-none"
-          modifiers={[snapCenterToCursor]}
-          dropAnimation={null}
-        >
+        <DragOverlay className="z-[100] pointer-events-none" modifiers={[]} dropAnimation={null}>
           {activeDragItem ? (
-            'operationId' in activeDragItem ? null : (
+            'operationId' in activeDragItem ? (
+              // It's a Step
+              <div className="opacity-80">
+                <TransformerStep
+                  step={activeDragItem as PipelineStep}
+                  index={-1}
+                  onUpdate={() => {}}
+                  onRemove={() => {}}
+                  onToggle={() => {}}
+                  isOverlay
+                  style={{ width: activeDragWidth, margin: 0 }}
+                />
+              </div>
+            ) : (
               // It's a new Operation
               <div className="opacity-80">
                 <DraggableToolboxItem

--- a/src/components/transformer/TransformerDialog.tsx
+++ b/src/components/transformer/TransformerDialog.tsx
@@ -398,7 +398,7 @@ export function TransformerDialog({
                     </Button>
                   </div>
                   <div className="flex-1 overflow-hidden">
-                    <TransformerToolbox onAddStep={handleAddOperation} />
+                    <TransformerToolbox onAddStep={handleAddOperation} enableDrag={false} />
                   </div>
                 </div>
               )}

--- a/src/components/transformer/TransformerDialog.tsx
+++ b/src/components/transformer/TransformerDialog.tsx
@@ -5,8 +5,6 @@ import {
   useSensor,
   useSensors,
   PointerSensor,
-  TouchSensor,
-  MouseSensor,
   type DragStartEvent,
   type DragEndEvent,
   closestCenter,
@@ -76,18 +74,12 @@ export function TransformerDialog({
   const wasOpenRef = useRef(open)
 
   // Configure sensors for drag and drop
+  // Using PointerSensor exclusively provides the best compatibility for both mouse and touch
+  // when touch-action: none is applied to draggable elements.
   const sensors = useSensors(
     useSensor(PointerSensor, {
       activationConstraint: {
         distance: 8,
-      },
-    }),
-    useSensor(MouseSensor),
-    useSensor(TouchSensor, {
-      // Small delay helps distinguish between scroll and drag
-      activationConstraint: {
-        delay: 150,
-        tolerance: 5,
       },
     })
   )

--- a/src/components/transformer/TransformerDialog.tsx
+++ b/src/components/transformer/TransformerDialog.tsx
@@ -1,4 +1,17 @@
 import { useState, useCallback, useEffect, useRef, type ReactElement } from 'react'
+import {
+  DndContext,
+  DragOverlay,
+  useSensor,
+  useSensors,
+  PointerSensor,
+  TouchSensor,
+  MouseSensor,
+  type DragStartEvent,
+  type DragEndEvent,
+  closestCenter,
+} from '@dnd-kit/core'
+import { arrayMove } from '@dnd-kit/sortable'
 import { useToast } from '@/hooks/useToast'
 import {
   Dialog,
@@ -19,9 +32,10 @@ import {
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu'
 import { IconPicker } from './IconPicker'
-import { TransformerToolbox } from './TransformerToolbox'
+import { TransformerToolbox, DraggableToolboxItem } from './TransformerToolbox'
 import { TransformerWorkbench } from './TransformerWorkbench'
 import { TransformerPreview } from './TransformerPreview'
+import { TransformerStep } from './TransformerStep'
 import type { TransformationPipeline, PipelineStep, TransformerOperation } from './types'
 
 interface TransformerDialogProps {
@@ -54,9 +68,29 @@ export function TransformerDialog({
   const [pipelineIcon, setPipelineIcon] = useState('🪄')
   const [steps, setSteps] = useState<PipelineStep[]>([])
   const [isToolboxOpen, setIsToolboxOpen] = useState(false)
+  const [activeDragItem, setActiveDragItem] = useState<PipelineStep | TransformerOperation | null>(
+    null
+  )
 
   // Track previous open state to detect dialog open transition
   const wasOpenRef = useRef(open)
+
+  // Configure sensors for drag and drop
+  const sensors = useSensors(
+    useSensor(PointerSensor, {
+      activationConstraint: {
+        distance: 8,
+      },
+    }),
+    useSensor(MouseSensor),
+    useSensor(TouchSensor, {
+      // Small delay helps distinguish between scroll and drag
+      activationConstraint: {
+        delay: 150,
+        tolerance: 5,
+      },
+    })
+  )
 
   // Load edit state only when dialog transitions from closed to open
   useEffect(() => {
@@ -110,14 +144,49 @@ export function TransformerDialog({
     setSteps((prev) => prev.map((s) => (s.id === id ? { ...s, enabled: !s.enabled } : s)))
   }, [])
 
-  const handleMoveStep = useCallback((dragIndex: number, hoverIndex: number) => {
-    setSteps((prev) => {
-      const newSteps = [...prev]
-      const [removed] = newSteps.splice(dragIndex, 1)
-      newSteps.splice(hoverIndex, 0, removed)
-      return newSteps
-    })
-  }, [])
+  // DnD Handlers
+  const handleDragStart = (event: DragStartEvent) => {
+    const { active } = event
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const activeData = active.data.current as any
+
+    if (activeData?.sortable?.index !== undefined) {
+      // It's a step being reordered
+      // Find the step object
+      const step = steps.find((s) => s.id === active.id)
+      if (step) setActiveDragItem(step)
+    } else if (activeData?.operation) {
+      // It's a new operation from toolbox
+      setActiveDragItem(activeData.operation)
+    }
+  }
+
+  const handleDragEnd = (event: DragEndEvent) => {
+    const { active, over } = event
+    setActiveDragItem(null)
+
+    if (!over) return
+
+    // Case 1: Reordering steps
+    if (
+      active.data.current?.sortable?.index !== undefined &&
+      over.data.current?.sortable?.index !== undefined &&
+      active.id !== over.id
+    ) {
+      setSteps((items) => {
+        const oldIndex = items.findIndex((item) => item.id === active.id)
+        const newIndex = items.findIndex((item) => item.id === over.id)
+        return arrayMove(items, oldIndex, newIndex)
+      })
+      return
+    }
+
+    // Case 2: Dropping new operation from toolbox
+    if (active.data.current?.operation && over.id === 'workbench-container') {
+      const operation = active.data.current.operation as TransformerOperation
+      handleAddOperation(operation)
+    }
+  }
 
   const handleSave = () => {
     if (!pipelineName.trim()) {
@@ -268,94 +337,124 @@ export function TransformerDialog({
           </div>
         </DialogHeader>
 
-        {/* Mobile View */}
-        <div className="flex-1 lg:hidden overflow-hidden flex flex-col relative">
-          <Tabs value={activeTab} onValueChange={setActiveTab} className="h-full flex flex-col">
-            <TabsList className="w-full justify-start rounded-none border-b bg-background p-0 h-10">
-              <TabsTrigger
+        <DndContext
+          sensors={sensors}
+          collisionDetection={closestCenter}
+          onDragStart={handleDragStart}
+          onDragEnd={handleDragEnd}
+        >
+          {/* Mobile View */}
+          <div className="flex-1 lg:hidden overflow-hidden flex flex-col relative">
+            <Tabs value={activeTab} onValueChange={setActiveTab} className="h-full flex flex-col">
+              <TabsList className="w-full justify-start rounded-none border-b bg-background p-0 h-10">
+                <TabsTrigger
+                  value="pipeline"
+                  className="flex-1 h-10 rounded-none border-b-2 border-transparent data-[state=active]:border-primary data-[state=active]:shadow-none"
+                >
+                  Edit ({steps.length})
+                </TabsTrigger>
+                <TabsTrigger
+                  value="preview"
+                  className="flex-1 h-10 rounded-none border-b-2 border-transparent data-[state=active]:border-primary data-[state=active]:shadow-none"
+                >
+                  Preview
+                </TabsTrigger>
+              </TabsList>
+              <TabsContent
                 value="pipeline"
-                className="flex-1 h-10 rounded-none border-b-2 border-transparent data-[state=active]:border-primary data-[state=active]:shadow-none"
+                className="flex-1 m-0 overflow-hidden h-full overflow-y-auto"
               >
-                Edit ({steps.length})
-              </TabsTrigger>
-              <TabsTrigger
-                value="preview"
-                className="flex-1 h-10 rounded-none border-b-2 border-transparent data-[state=active]:border-primary data-[state=active]:shadow-none"
-              >
-                Preview
-              </TabsTrigger>
-            </TabsList>
-            <TabsContent
-              value="pipeline"
-              className="flex-1 m-0 overflow-hidden h-full overflow-y-auto"
-            >
-              <TransformerWorkbench
-                steps={steps}
-                onUpdateStep={handleUpdateStep}
-                onRemoveStep={handleRemoveStep}
-                onToggleStep={handleToggleStep}
-                onMoveStep={handleMoveStep}
-                onAddOperation={handleAddOperation}
-                onAddRequest={() => setIsToolboxOpen(true)}
-              />
-            </TabsContent>
-            <TabsContent
-              value="preview"
-              className="flex-1 m-0 overflow-hidden h-full overflow-y-auto"
-            >
-              <TransformerPreview pipeline={currentPipeline} initialText={initialPreviewText} />
-            </TabsContent>
-          </Tabs>
-
-          {/* Toolbox Overlay */}
-          {isToolboxOpen && (
-            <div className="absolute inset-0 z-50 bg-background flex flex-col animate-in slide-in-from-bottom duration-200">
-              <div className="flex items-center justify-between p-3 border-b bg-background">
-                <h3 className="font-semibold text-lg">Add Operation</h3>
-                <Button variant="ghost" size="icon" onClick={() => setIsToolboxOpen(false)}>
-                  <X className="w-5 h-5" />
-                </Button>
-              </div>
-              <div className="flex-1 overflow-hidden">
-                <TransformerToolbox onAddStep={handleAddOperation} />
-              </div>
-            </div>
-          )}
-        </div>
-
-        {/* Desktop View */}
-        <div className="flex-1 hidden lg:block overflow-hidden h-full">
-          <ResizablePanelGroup orientation="horizontal" className="h-full w-full">
-            <ResizablePanel defaultSize={30} minSize={20}>
-              <div className="h-full overflow-y-auto bg-muted/5">
-                <TransformerToolbox onAddStep={handleAddOperation} />
-              </div>
-            </ResizablePanel>
-
-            <ResizableHandle withHandle />
-
-            <ResizablePanel defaultSize={40} minSize={30}>
-              <div className="h-full overflow-y-auto bg-background/50">
                 <TransformerWorkbench
                   steps={steps}
                   onUpdateStep={handleUpdateStep}
                   onRemoveStep={handleRemoveStep}
                   onToggleStep={handleToggleStep}
-                  onMoveStep={handleMoveStep}
                   onAddOperation={handleAddOperation}
+                  onAddRequest={() => setIsToolboxOpen(true)}
                 />
-              </div>
-            </ResizablePanel>
-
-            <ResizableHandle withHandle />
-
-            <ResizablePanel defaultSize={30} minSize={20}>
-              <div className="h-full overflow-y-auto">
+              </TabsContent>
+              <TabsContent
+                value="preview"
+                className="flex-1 m-0 overflow-hidden h-full overflow-y-auto"
+              >
                 <TransformerPreview pipeline={currentPipeline} initialText={initialPreviewText} />
+              </TabsContent>
+            </Tabs>
+
+            {/* Toolbox Overlay */}
+            {isToolboxOpen && (
+              <div className="absolute inset-0 z-50 bg-background flex flex-col animate-in slide-in-from-bottom duration-200">
+                <div className="flex items-center justify-between p-3 border-b bg-background">
+                  <h3 className="font-semibold text-lg">Add Operation</h3>
+                  <Button variant="ghost" size="icon" onClick={() => setIsToolboxOpen(false)}>
+                    <X className="w-5 h-5" />
+                  </Button>
+                </div>
+                <div className="flex-1 overflow-hidden">
+                  <TransformerToolbox onAddStep={handleAddOperation} />
+                </div>
               </div>
-            </ResizablePanel>
-          </ResizablePanelGroup>
-        </div>
+            )}
+          </div>
+
+          {/* Desktop View */}
+          <div className="flex-1 hidden lg:block overflow-hidden h-full">
+            <ResizablePanelGroup orientation="horizontal" className="h-full w-full">
+              <ResizablePanel defaultSize={30} minSize={20}>
+                <div className="h-full overflow-y-auto bg-muted/5">
+                  <TransformerToolbox onAddStep={handleAddOperation} />
+                </div>
+              </ResizablePanel>
+
+              <ResizableHandle withHandle />
+
+              <ResizablePanel defaultSize={40} minSize={30}>
+                <div className="h-full overflow-y-auto bg-background/50">
+                  <TransformerWorkbench
+                    steps={steps}
+                    onUpdateStep={handleUpdateStep}
+                    onRemoveStep={handleRemoveStep}
+                    onToggleStep={handleToggleStep}
+                    onAddOperation={handleAddOperation}
+                  />
+                </div>
+              </ResizablePanel>
+
+              <ResizableHandle withHandle />
+
+              <ResizablePanel defaultSize={30} minSize={20}>
+                <div className="h-full overflow-y-auto">
+                  <TransformerPreview pipeline={currentPipeline} initialText={initialPreviewText} />
+                </div>
+              </ResizablePanel>
+            </ResizablePanelGroup>
+          </div>
+
+          <DragOverlay>
+            {activeDragItem ? (
+              'operationId' in activeDragItem ? (
+                // It's a Step
+                <div className="opacity-80">
+                  <TransformerStep
+                    step={activeDragItem as PipelineStep}
+                    index={-1}
+                    onUpdate={() => {}}
+                    onRemove={() => {}}
+                    onToggle={() => {}}
+                  />
+                </div>
+              ) : (
+                // It's a new Operation
+                <div className="opacity-80">
+                  <DraggableToolboxItem
+                    operation={activeDragItem as TransformerOperation}
+                    onAddStep={() => {}}
+                  />
+                </div>
+              )
+            ) : null}
+          </DragOverlay>
+        </DndContext>
       </DialogContent>
     </Dialog>
   )

--- a/src/components/transformer/TransformerDialog.tsx
+++ b/src/components/transformer/TransformerDialog.tsx
@@ -47,6 +47,11 @@ interface TransformerDialogProps {
   initialPreviewText?: string
 }
 
+interface DragData {
+  sortable?: { index: number }
+  operation?: TransformerOperation
+}
+
 const generateId = (): string => Math.random().toString(36).substring(2, 9)
 
 /**
@@ -144,8 +149,7 @@ export function TransformerDialog({
   // DnD Handlers
   const handleDragStart = (event: DragStartEvent) => {
     const { active } = event
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const activeData = active.data.current as any
+    const activeData = active.data.current as DragData | undefined
 
     if (activeData?.sortable?.index !== undefined) {
       // It's a step being reordered

--- a/src/components/transformer/TransformerDialog.tsx
+++ b/src/components/transformer/TransformerDialog.tsx
@@ -35,7 +35,6 @@ import { IconPicker } from './IconPicker'
 import { TransformerToolbox, DraggableToolboxItem } from './TransformerToolbox'
 import { TransformerWorkbench } from './TransformerWorkbench'
 import { TransformerPreview } from './TransformerPreview'
-import { TransformerStep } from './TransformerStep'
 import type { TransformationPipeline, PipelineStep, TransformerOperation } from './types'
 
 interface TransformerDialogProps {
@@ -280,7 +279,6 @@ export function TransformerDialog({
   }
 
   return (
-
     <DndContext
       sensors={sensors}
       collisionDetection={closestCenter}
@@ -402,42 +400,40 @@ export function TransformerDialog({
             )}
           </div>
 
+          {/* Desktop View */}
+          <div className="flex-1 hidden lg:block overflow-hidden h-full">
+            <ResizablePanelGroup orientation="horizontal" className="h-full w-full">
+              <ResizablePanel defaultSize={30} minSize={20}>
+                <div className="h-full overflow-y-auto bg-muted/5">
+                  <TransformerToolbox onAddStep={handleAddOperation} />
+                </div>
+              </ResizablePanel>
 
+              <ResizableHandle withHandle />
 
-            {/* Desktop View */}
-            <div className="flex-1 hidden lg:block overflow-hidden h-full">
-              <ResizablePanelGroup orientation="horizontal" className="h-full w-full">
-                <ResizablePanel defaultSize={30} minSize={20}>
-                  <div className="h-full overflow-y-auto bg-muted/5">
-                    <TransformerToolbox onAddStep={handleAddOperation} />
-                  </div>
-                </ResizablePanel>
+              <ResizablePanel defaultSize={40} minSize={30}>
+                <div className="h-full overflow-y-auto bg-background/50">
+                  <TransformerWorkbench
+                    steps={steps}
+                    onUpdateStep={handleUpdateStep}
+                    onRemoveStep={handleRemoveStep}
+                    onToggleStep={handleToggleStep}
+                    onAddOperation={handleAddOperation}
+                  />
+                </div>
+              </ResizablePanel>
 
-                <ResizableHandle withHandle />
+              <ResizableHandle withHandle />
 
-                <ResizablePanel defaultSize={40} minSize={30}>
-                  <div className="h-full overflow-y-auto bg-background/50">
-                    <TransformerWorkbench
-                      steps={steps}
-                      onUpdateStep={handleUpdateStep}
-                      onRemoveStep={handleRemoveStep}
-                      onToggleStep={handleToggleStep}
-                      onAddOperation={handleAddOperation}
-                    />
-                  </div>
-                </ResizablePanel>
-
-                <ResizableHandle withHandle />
-
-                <ResizablePanel defaultSize={30} minSize={20}>
-                  <div className="h-full overflow-y-auto">
-                    <TransformerPreview pipeline={currentPipeline} initialText={initialPreviewText} />
-                  </div>
-                </ResizablePanel>
-              </ResizablePanelGroup>
-            </div>
-          </DialogContent>
-        </Dialog>
+              <ResizablePanel defaultSize={30} minSize={20}>
+                <div className="h-full overflow-y-auto">
+                  <TransformerPreview pipeline={currentPipeline} initialText={initialPreviewText} />
+                </div>
+              </ResizablePanel>
+            </ResizablePanelGroup>
+          </div>
+        </DialogContent>
+      </Dialog>
       {createPortal(
         <DragOverlay
           className="z-[100] pointer-events-none"
@@ -445,20 +441,7 @@ export function TransformerDialog({
           dropAnimation={null}
         >
           {activeDragItem ? (
-            'operationId' in activeDragItem ? (
-              // It's a Step
-              <div className="opacity-80">
-                <TransformerStep
-                  step={activeDragItem as PipelineStep}
-                  index={-1}
-                  onUpdate={() => {}}
-                  onRemove={() => {}}
-                  onToggle={() => {}}
-                  isOverlay
-                  style={{ width: activeDragWidth, margin: 0 }}
-                />
-              </div>
-            ) : (
+            'operationId' in activeDragItem ? null : (
               // It's a new Operation
               <div className="opacity-80">
                 <DraggableToolboxItem

--- a/src/components/transformer/TransformerDialog.tsx
+++ b/src/components/transformer/TransformerDialog.tsx
@@ -12,6 +12,7 @@ import {
 } from '@dnd-kit/core'
 import { arrayMove } from '@dnd-kit/sortable'
 import { useToast } from '@/hooks/useToast'
+import { useMediaQuery } from '@/hooks/useMediaQuery'
 import {
   Dialog,
   DialogContent,
@@ -71,6 +72,8 @@ export function TransformerDialog({
     null
   )
   const [activeDragWidth, setActiveDragWidth] = useState<number | undefined>(undefined)
+
+  const isDesktop = useMediaQuery('(min-width: 1024px)')
 
   // Track previous open state to detect dialog open transition
   const wasOpenRef = useRef(open)
@@ -347,91 +350,98 @@ export function TransformerDialog({
           </DialogHeader>
 
           {/* Mobile View */}
-          <div className="flex-1 lg:hidden overflow-hidden flex flex-col relative">
-            <Tabs value={activeTab} onValueChange={setActiveTab} className="h-full flex flex-col">
-              <TabsList className="w-full justify-start rounded-none border-b bg-background p-0 h-10">
-                <TabsTrigger
+          {!isDesktop && (
+            <div className="flex-1 overflow-hidden flex flex-col relative">
+              <Tabs value={activeTab} onValueChange={setActiveTab} className="h-full flex flex-col">
+                <TabsList className="w-full justify-start rounded-none border-b bg-background p-0 h-10">
+                  <TabsTrigger
+                    value="pipeline"
+                    className="flex-1 h-10 rounded-none border-b-2 border-transparent data-[state=active]:border-primary data-[state=active]:shadow-none"
+                  >
+                    Edit ({steps.length})
+                  </TabsTrigger>
+                  <TabsTrigger
+                    value="preview"
+                    className="flex-1 h-10 rounded-none border-b-2 border-transparent data-[state=active]:border-primary data-[state=active]:shadow-none"
+                  >
+                    Preview
+                  </TabsTrigger>
+                </TabsList>
+                <TabsContent
                   value="pipeline"
-                  className="flex-1 h-10 rounded-none border-b-2 border-transparent data-[state=active]:border-primary data-[state=active]:shadow-none"
+                  className="flex-1 m-0 overflow-hidden h-full overflow-y-auto"
                 >
-                  Edit ({steps.length})
-                </TabsTrigger>
-                <TabsTrigger
-                  value="preview"
-                  className="flex-1 h-10 rounded-none border-b-2 border-transparent data-[state=active]:border-primary data-[state=active]:shadow-none"
-                >
-                  Preview
-                </TabsTrigger>
-              </TabsList>
-              <TabsContent
-                value="pipeline"
-                className="flex-1 m-0 overflow-hidden h-full overflow-y-auto"
-              >
-                <TransformerWorkbench
-                  steps={steps}
-                  onUpdateStep={handleUpdateStep}
-                  onRemoveStep={handleRemoveStep}
-                  onToggleStep={handleToggleStep}
-                  onAddOperation={handleAddOperation}
-                  onAddRequest={() => setIsToolboxOpen(true)}
-                />
-              </TabsContent>
-              <TabsContent
-                value="preview"
-                className="flex-1 m-0 overflow-hidden h-full overflow-y-auto"
-              >
-                <TransformerPreview pipeline={currentPipeline} initialText={initialPreviewText} />
-              </TabsContent>
-            </Tabs>
-
-            {/* Toolbox Overlay */}
-            {isToolboxOpen && (
-              <div className="absolute inset-0 z-50 bg-background flex flex-col animate-in slide-in-from-bottom duration-200">
-                <div className="flex items-center justify-between p-3 border-b bg-background">
-                  <h3 className="font-semibold text-lg">Add Operation</h3>
-                  <Button variant="ghost" size="icon" onClick={() => setIsToolboxOpen(false)}>
-                    <X className="w-5 h-5" />
-                  </Button>
-                </div>
-                <div className="flex-1 overflow-hidden">
-                  <TransformerToolbox onAddStep={handleAddOperation} />
-                </div>
-              </div>
-            )}
-          </div>
-
-          {/* Desktop View */}
-          <div className="flex-1 hidden lg:block overflow-hidden h-full">
-            <ResizablePanelGroup orientation="horizontal" className="h-full w-full">
-              <ResizablePanel defaultSize={30} minSize={20}>
-                <div className="h-full overflow-y-auto bg-muted/5">
-                  <TransformerToolbox onAddStep={handleAddOperation} />
-                </div>
-              </ResizablePanel>
-
-              <ResizableHandle withHandle />
-
-              <ResizablePanel defaultSize={40} minSize={30}>
-                <div className="h-full overflow-y-auto bg-background/50">
                   <TransformerWorkbench
                     steps={steps}
                     onUpdateStep={handleUpdateStep}
                     onRemoveStep={handleRemoveStep}
                     onToggleStep={handleToggleStep}
                     onAddOperation={handleAddOperation}
+                    onAddRequest={() => setIsToolboxOpen(true)}
                   />
-                </div>
-              </ResizablePanel>
-
-              <ResizableHandle withHandle />
-
-              <ResizablePanel defaultSize={30} minSize={20}>
-                <div className="h-full overflow-y-auto">
+                </TabsContent>
+                <TabsContent
+                  value="preview"
+                  className="flex-1 m-0 overflow-hidden h-full overflow-y-auto"
+                >
                   <TransformerPreview pipeline={currentPipeline} initialText={initialPreviewText} />
+                </TabsContent>
+              </Tabs>
+
+              {/* Toolbox Overlay */}
+              {isToolboxOpen && (
+                <div className="absolute inset-0 z-50 bg-background flex flex-col animate-in slide-in-from-bottom duration-200">
+                  <div className="flex items-center justify-between p-3 border-b bg-background">
+                    <h3 className="font-semibold text-lg">Add Operation</h3>
+                    <Button variant="ghost" size="icon" onClick={() => setIsToolboxOpen(false)}>
+                      <X className="w-5 h-5" />
+                    </Button>
+                  </div>
+                  <div className="flex-1 overflow-hidden">
+                    <TransformerToolbox onAddStep={handleAddOperation} />
+                  </div>
                 </div>
-              </ResizablePanel>
-            </ResizablePanelGroup>
-          </div>
+              )}
+            </div>
+          )}
+
+          {/* Desktop View */}
+          {isDesktop && (
+            <div className="flex-1 overflow-hidden h-full">
+              <ResizablePanelGroup orientation="horizontal" className="h-full w-full">
+                <ResizablePanel defaultSize={30} minSize={20}>
+                  <div className="h-full overflow-y-auto bg-muted/5">
+                    <TransformerToolbox onAddStep={handleAddOperation} />
+                  </div>
+                </ResizablePanel>
+
+                <ResizableHandle withHandle />
+
+                <ResizablePanel defaultSize={40} minSize={30}>
+                  <div className="h-full overflow-y-auto bg-background/50">
+                    <TransformerWorkbench
+                      steps={steps}
+                      onUpdateStep={handleUpdateStep}
+                      onRemoveStep={handleRemoveStep}
+                      onToggleStep={handleToggleStep}
+                      onAddOperation={handleAddOperation}
+                    />
+                  </div>
+                </ResizablePanel>
+
+                <ResizableHandle withHandle />
+
+                <ResizablePanel defaultSize={30} minSize={20}>
+                  <div className="h-full overflow-y-auto">
+                    <TransformerPreview
+                      pipeline={currentPipeline}
+                      initialText={initialPreviewText}
+                    />
+                  </div>
+                </ResizablePanel>
+              </ResizablePanelGroup>
+            </div>
+          )}
         </DialogContent>
       </Dialog>
       {createPortal(

--- a/src/components/transformer/TransformerStep.tsx
+++ b/src/components/transformer/TransformerStep.tsx
@@ -34,6 +34,8 @@ interface TransformerStepProps {
   onUpdate: (id: string, config: Record<string, unknown>) => void
   onRemove: (id: string) => void
   onToggle: (id: string) => void
+  isOverlay?: boolean
+  style?: React.CSSProperties
 }
 
 // Operations that support line-by-line mode
@@ -50,11 +52,14 @@ export function TransformerStep({
   onUpdate,
   onRemove,
   onToggle,
+  isOverlay,
+  style: styleProp,
 }: TransformerStepProps): ReactElement | null {
   const [showConfig, setShowConfig] = useState(true) // Default open configuration
 
   const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
     id: step.id,
+    disabled: isOverlay,
     data: {
       sortable: { index },
       // Pass step data for DnD DragOverlay
@@ -66,6 +71,7 @@ export function TransformerStep({
     transform: CSS.Transform.toString(transform),
     transition,
     opacity: isDragging ? 0.4 : 1,
+    ...styleProp,
   }
 
   const operation = OPERATIONS.find((op) => op.id === step.operationId)
@@ -153,6 +159,7 @@ export function TransformerStep({
 
   return (
     <div
+      id={!isOverlay ? step.id : undefined}
       ref={setNodeRef}
       style={style}
       data-index={index}

--- a/src/components/transformer/TransformerStep.tsx
+++ b/src/components/transformer/TransformerStep.tsx
@@ -78,6 +78,22 @@ export function TransformerStep({
   const operation = OPERATIONS.find((op) => op.id === step.operationId)
   if (!operation) return null
 
+  // If this is the drag overlay, render a simplified high-contrast placeholder
+  if (isOverlay) {
+    return (
+      <div
+        ref={setNodeRef}
+        style={style}
+        className="flex items-center gap-3 p-3 rounded-xl border-2 border-primary bg-primary/20 shadow-xl w-full max-w-full min-w-0"
+      >
+        <div className="p-2 rounded-lg bg-primary/20 text-primary">
+          <GripVertical className="h-4 w-4" />
+        </div>
+        <span className="font-medium text-sm text-primary">{operation.name}</span>
+      </div>
+    )
+  }
+
   const Icon = ICON_MAP[operation.icon]
 
   /* 
@@ -173,7 +189,7 @@ export function TransformerStep({
     >
       {/* Drag Handle - Aligned with icon */}
       <div
-        className="mt-2 -ml-2 p-2 text-muted-foreground/30 group-hover:text-muted-foreground cursor-grab active:cursor-grabbing transition-colors self-start outline-none"
+        className="mt-0 -ml-2 p-2 text-muted-foreground/30 group-hover:text-muted-foreground cursor-grab active:cursor-grabbing transition-colors self-start outline-none"
         style={{ touchAction: 'none' }}
         {...attributes}
         {...listeners}

--- a/src/components/transformer/TransformerStep.tsx
+++ b/src/components/transformer/TransformerStep.tsx
@@ -70,7 +70,7 @@ export function TransformerStep({
   const style = {
     transform: CSS.Transform.toString(transform),
     transition,
-    opacity: isDragging ? 0.4 : 1,
+    opacity: isDragging ? 0 : 1,
     ...styleProp,
   }
 

--- a/src/components/transformer/TransformerStep.tsx
+++ b/src/components/transformer/TransformerStep.tsx
@@ -71,10 +71,7 @@ export function TransformerStep({
     transform: CSS.Transform.toString(transform),
     transition,
     zIndex: isDragging ? 999 : 'auto',
-    boxShadow: isDragging
-      ? '0 10px 15px -3px rgb(0 0 0 / 0.1), 0 4px 6px -4px rgb(0 0 0 / 0.1)'
-      : undefined,
-    opacity: 1,
+    opacity: isDragging ? 0 : 1,
     ...styleProp,
   }
 

--- a/src/components/transformer/TransformerStep.tsx
+++ b/src/components/transformer/TransformerStep.tsx
@@ -165,7 +165,8 @@ export function TransformerStep({
     >
       {/* Drag Handle - Aligned with icon */}
       <div
-        className="mt-2 text-muted-foreground/30 group-hover:text-muted-foreground cursor-grab active:cursor-grabbing transition-colors self-start pt-0.5 touch-none outline-none"
+        className="mt-2 -ml-2 p-2 text-muted-foreground/30 group-hover:text-muted-foreground cursor-grab active:cursor-grabbing transition-colors self-start outline-none"
+        style={{ touchAction: 'none' }}
         {...attributes}
         {...listeners}
       >

--- a/src/components/transformer/TransformerStep.tsx
+++ b/src/components/transformer/TransformerStep.tsx
@@ -221,7 +221,7 @@ export function TransformerStep({
           <div
             className={cn(
               'flex items-center gap-1 transition-opacity',
-              isDragging ? 'opacity-0' : 'opacity-0 group-hover:opacity-100'
+              isDragging ? 'opacity-0' : 'opacity-100 md:opacity-0 md:group-hover:opacity-100'
             )}
           >
             {supportsLineMode && (

--- a/src/components/transformer/TransformerStep.tsx
+++ b/src/components/transformer/TransformerStep.tsx
@@ -1,5 +1,7 @@
 import { useState, type ReactElement } from 'react'
 import { GripVertical, Settings2, Trash2, WrapText, TextSelect } from 'lucide-react'
+import { useSortable } from '@dnd-kit/sortable'
+import { CSS } from '@dnd-kit/utilities'
 import { Switch } from '@/components/ui/switch'
 import { Button } from '@/components/ui/button'
 import { OPERATIONS, ICON_MAP } from './constants'
@@ -32,9 +34,6 @@ interface TransformerStepProps {
   onUpdate: (id: string, config: Record<string, unknown>) => void
   onRemove: (id: string) => void
   onToggle: (id: string) => void
-  onDragStart: (index: number) => void
-  onDragEnter: (index: number) => void
-  onDragEnd: () => void
 }
 
 // Operations that support line-by-line mode
@@ -51,11 +50,23 @@ export function TransformerStep({
   onUpdate,
   onRemove,
   onToggle,
-  onDragStart,
-  onDragEnter,
-  onDragEnd,
 }: TransformerStepProps): ReactElement | null {
   const [showConfig, setShowConfig] = useState(true) // Default open configuration
+
+  const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
+    id: step.id,
+    data: {
+      sortable: { index },
+      // Pass step data for DnD DragOverlay
+      step: step,
+    },
+  })
+
+  const style = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+    opacity: isDragging ? 0.4 : 1,
+  }
 
   const operation = OPERATIONS.find((op) => op.id === step.operationId)
   if (!operation) return null
@@ -140,52 +151,23 @@ export function TransformerStep({
     }
   }
 
-  const handleTouchStart = (e: React.TouchEvent) => {
-    // Prevent scrolling when starting drag on handle
-    if (e.cancelable) e.preventDefault()
-    onDragStart(index)
-  }
-
-  const handleTouchMove = (e: React.TouchEvent) => {
-    // Prevent scrolling
-    const touch = e.touches[0]
-    const target = document.elementFromPoint(touch.clientX, touch.clientY)
-    const stepElement = target?.closest('[data-index]') as HTMLElement
-
-    if (stepElement && stepElement.dataset.index) {
-      const targetIndex = parseInt(stepElement.dataset.index, 10)
-      if (!isNaN(targetIndex)) {
-        onDragEnter(targetIndex)
-      }
-    }
-  }
-
-  const handleTouchEnd = () => {
-    onDragEnd()
-  }
-
   return (
     <div
+      ref={setNodeRef}
+      style={style}
       data-index={index}
       className={cn(
-        'group relative flex items-start gap-3 p-3 rounded-xl border bg-card transition-all duration-200 w-full max-w-full min-w-0',
+        'group relative flex items-start gap-3 p-3 rounded-xl border bg-card w-full max-w-full min-w-0 transition-shadow',
         step.enabled
           ? 'shadow-sm border-muted-foreground/10 hover:border-primary/30'
           : 'opacity-60 border-transparent bg-muted/5'
       )}
-      draggable
-      onDragStart={() => onDragStart(index)}
-      onDragEnter={() => onDragEnter(index)}
-      onDragEnd={onDragEnd}
-      onDragOver={(e) => e.preventDefault()}
-      onDrop={(e) => e.stopPropagation()}
     >
       {/* Drag Handle - Aligned with icon */}
       <div
-        className="mt-2 text-muted-foreground/30 group-hover:text-muted-foreground cursor-grab active:cursor-grabbing transition-colors self-start pt-0.5 touch-none"
-        onTouchStart={handleTouchStart}
-        onTouchMove={handleTouchMove}
-        onTouchEnd={handleTouchEnd}
+        className="mt-2 text-muted-foreground/30 group-hover:text-muted-foreground cursor-grab active:cursor-grabbing transition-colors self-start pt-0.5 touch-none outline-none"
+        {...attributes}
+        {...listeners}
       >
         <GripVertical className="h-4 w-4" />
       </div>
@@ -211,7 +193,12 @@ export function TransformerStep({
             {operation.name}
           </span>
 
-          <div className="flex items-center gap-1 opacity-0 group-hover:opacity-100 transition-opacity">
+          <div
+            className={cn(
+              'flex items-center gap-1 transition-opacity',
+              isDragging ? 'opacity-0' : 'opacity-0 group-hover:opacity-100'
+            )}
+          >
             {supportsLineMode && (
               <Button
                 variant="ghost"

--- a/src/components/transformer/TransformerStep.tsx
+++ b/src/components/transformer/TransformerStep.tsx
@@ -70,7 +70,11 @@ export function TransformerStep({
   const style = {
     transform: CSS.Transform.toString(transform),
     transition,
-    opacity: isDragging ? 0 : 1,
+    zIndex: isDragging ? 999 : 'auto',
+    boxShadow: isDragging
+      ? '0 10px 15px -3px rgb(0 0 0 / 0.1), 0 4px 6px -4px rgb(0 0 0 / 0.1)'
+      : undefined,
+    opacity: 1,
     ...styleProp,
   }
 

--- a/src/components/transformer/TransformerToolbox.test.tsx
+++ b/src/components/transformer/TransformerToolbox.test.tsx
@@ -4,11 +4,28 @@ import userEvent from '@testing-library/user-event'
 import { TransformerToolbox } from './TransformerToolbox'
 import { OPERATIONS } from './constants'
 
+// Mock dnd-kit's useDraggable
+const mockUseDraggable = vi.fn()
+vi.mock('@dnd-kit/core', async () => {
+  const actual = await vi.importActual('@dnd-kit/core')
+  return {
+    ...actual,
+    useDraggable: (args: any) => mockUseDraggable(args),
+  }
+})
+
 describe('TransformerToolbox', () => {
   const mockOnAddStep = vi.fn()
 
   beforeEach(() => {
     vi.clearAllMocks()
+    // Default mock implementation for useDraggable
+    mockUseDraggable.mockReturnValue({
+      attributes: { 'data-testid': 'draggable-attr' },
+      listeners: { 'data-testid': 'draggable-listener' },
+      setNodeRef: vi.fn(),
+      isDragging: false,
+    })
   })
 
   it('should render all operations initially', () => {
@@ -93,30 +110,28 @@ describe('TransformerToolbox', () => {
   it('should set drag data when operation is dragged', () => {
     render(<TransformerToolbox onAddStep={mockOnAddStep} />)
 
-    const trimButton = screen.getByText('Trim Whitespace').closest('button')
-    expect(trimButton).not.toBeNull()
-
-    const dataTransfer = {
-      setData: vi.fn(),
-    }
-
-    fireEvent.dragStart(trimButton!, { dataTransfer })
-
-    expect(dataTransfer.setData).toHaveBeenCalledWith(
-      'application/json',
-      expect.stringContaining('"id":"trim"')
+    // Verify useDraggable was called with correct data for each operation
+    const trimOp = OPERATIONS.find((op) => op.id === 'trim')
+    expect(mockUseDraggable).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: 'toolbox-trim',
+        data: {
+          operation: trimOp,
+        },
+      })
     )
   })
 
-  it('should make all operation buttons draggable', () => {
+  it('should apply draggable attributes to buttons', () => {
     render(<TransformerToolbox onAddStep={mockOnAddStep} />)
 
     const buttons = screen.getAllByRole('button').filter((btn) => {
       return OPERATIONS.some((op) => btn.textContent?.includes(op.name))
     })
 
+    // Check if our mock attributes were applied
     buttons.forEach((button) => {
-      expect(button).toHaveAttribute('draggable', 'true')
+      expect(button).toHaveAttribute('data-testid', 'draggable-attr')
     })
   })
 

--- a/src/components/transformer/TransformerToolbox.test.tsx
+++ b/src/components/transformer/TransformerToolbox.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, fireEvent } from '@testing-library/react'
+import { render, screen } from '@testing-library/react'
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import userEvent from '@testing-library/user-event'
 import { TransformerToolbox } from './TransformerToolbox'
@@ -10,7 +10,7 @@ vi.mock('@dnd-kit/core', async () => {
   const actual = await vi.importActual('@dnd-kit/core')
   return {
     ...actual,
-    useDraggable: (args: any) => mockUseDraggable(args),
+    useDraggable: (args: unknown) => mockUseDraggable(args),
   }
 })
 

--- a/src/components/transformer/TransformerToolbox.tsx
+++ b/src/components/transformer/TransformerToolbox.tsx
@@ -32,6 +32,7 @@ export function DraggableToolboxItem({
       {...listeners}
       {...attributes}
       variant="outline"
+      style={{ touchAction: 'none' }}
       className={cn(
         'justify-start h-auto py-3 px-4 w-full text-left font-normal bg-background hover:bg-accent border-muted-foreground/20 hover:border-primary/50 group transition-all',
         isDragging ? 'opacity-50' : ''

--- a/src/components/transformer/TransformerToolbox.tsx
+++ b/src/components/transformer/TransformerToolbox.tsx
@@ -13,6 +13,7 @@ interface DraggableToolboxItemProps {
   onAddStep: (operation: TransformerOperation) => void
   isOverlay?: boolean
   style?: React.CSSProperties
+  enableDrag?: boolean
 }
 
 export function DraggableToolboxItem({
@@ -20,10 +21,11 @@ export function DraggableToolboxItem({
   onAddStep,
   isOverlay,
   style: styleProp,
+  enableDrag = true,
 }: DraggableToolboxItemProps): ReactElement {
   const { attributes, listeners, setNodeRef, isDragging } = useDraggable({
     id: `toolbox-${operation.id}`,
-    disabled: isOverlay,
+    disabled: isOverlay || !enableDrag,
     data: {
       operation,
     },
@@ -54,7 +56,7 @@ export function DraggableToolboxItem({
       {...listeners}
       {...attributes}
       variant="outline"
-      style={{ touchAction: 'none', ...styleProp }}
+      style={{ touchAction: enableDrag ? 'none' : 'auto', ...styleProp }}
       className={cn(
         'justify-start h-auto py-3 px-4 w-full text-left font-normal bg-background hover:bg-accent border-muted-foreground/20 hover:border-primary/50 group transition-all',
         isDragging ? 'opacity-50' : ''
@@ -75,6 +77,7 @@ export function DraggableToolboxItem({
 
 interface TransformerToolboxProps {
   onAddStep: (operation: TransformerOperation) => void
+  enableDrag?: boolean
 }
 
 /**
@@ -82,7 +85,10 @@ interface TransformerToolboxProps {
  * @param props - Component props
  * @returns Transformer toolbox component
  */
-export function TransformerToolbox({ onAddStep }: TransformerToolboxProps): ReactElement {
+export function TransformerToolbox({
+  onAddStep,
+  enableDrag = true,
+}: TransformerToolboxProps): ReactElement {
   const [searchQuery, setSearchQuery] = useState('')
   const [activeCategory, setActiveCategory] = useState<OperationCategory | 'All'>('All')
 
@@ -137,7 +143,12 @@ export function TransformerToolbox({ onAddStep }: TransformerToolboxProps): Reac
       <ScrollArea className="flex-1">
         <div className="p-4 grid gap-2">
           {filteredOperations.map((op) => (
-            <DraggableToolboxItem key={op.id} operation={op} onAddStep={onAddStep} />
+            <DraggableToolboxItem
+              key={op.id}
+              operation={op}
+              onAddStep={onAddStep}
+              enableDrag={enableDrag}
+            />
           ))}
 
           {filteredOperations.length === 0 && (

--- a/src/components/transformer/TransformerToolbox.tsx
+++ b/src/components/transformer/TransformerToolbox.tsx
@@ -1,5 +1,5 @@
 import { useState, type ReactElement } from 'react'
-import { Search, Plus } from 'lucide-react'
+import { Search, Plus, GripVertical } from 'lucide-react'
 import { useDraggable } from '@dnd-kit/core'
 import { OPERATIONS, ICON_MAP } from './constants'
 import { Input } from '@/components/ui/input'
@@ -30,6 +30,22 @@ export function DraggableToolboxItem({
   })
 
   const Icon = ICON_MAP[operation.icon] || Plus
+
+  if (isOverlay) {
+    return (
+      <Button
+        ref={setNodeRef}
+        variant="outline"
+        style={{ ...styleProp }}
+        className="flex items-center gap-3 p-3 rounded-xl border-2 border-primary bg-primary/20 shadow-xl w-full max-w-full min-w-0 h-auto"
+      >
+        <div className="p-2 rounded-lg bg-primary/20 text-primary">
+          <GripVertical className="h-4 w-4" />
+        </div>
+        <span className="font-medium text-sm text-primary">{operation.name}</span>
+      </Button>
+    )
+  }
 
   return (
     <Button

--- a/src/components/transformer/TransformerToolbox.tsx
+++ b/src/components/transformer/TransformerToolbox.tsx
@@ -1,11 +1,54 @@
 import { useState, type ReactElement } from 'react'
 import { Search, Plus } from 'lucide-react'
+import { useDraggable } from '@dnd-kit/core'
 import { OPERATIONS, ICON_MAP } from './constants'
 import { Input } from '@/components/ui/input'
 import { Button } from '@/components/ui/button'
 import { ScrollArea } from '@/components/ui/scroll-area'
 import { cn } from '@/utils/classnames'
 import type { TransformerOperation, OperationCategory } from './types'
+
+interface DraggableToolboxItemProps {
+  operation: TransformerOperation
+  onAddStep: (operation: TransformerOperation) => void
+}
+
+export function DraggableToolboxItem({
+  operation,
+  onAddStep,
+}: DraggableToolboxItemProps): ReactElement {
+  const { attributes, listeners, setNodeRef, isDragging } = useDraggable({
+    id: `toolbox-${operation.id}`,
+    data: {
+      operation,
+    },
+  })
+
+  const Icon = ICON_MAP[operation.icon] || Plus
+
+  return (
+    <Button
+      ref={setNodeRef}
+      {...listeners}
+      {...attributes}
+      variant="outline"
+      className={cn(
+        'justify-start h-auto py-3 px-4 w-full text-left font-normal bg-background hover:bg-accent border-muted-foreground/20 hover:border-primary/50 group transition-all',
+        isDragging ? 'opacity-50' : ''
+      )}
+      onClick={() => onAddStep(operation)}
+    >
+      <div className="p-2 rounded-md bg-muted group-hover:bg-primary/10 text-muted-foreground group-hover:text-primary mr-3 transition-colors">
+        <Icon className="w-4 h-4" />
+      </div>
+      <div>
+        <div className="text-sm font-medium text-foreground">{operation.name}</div>
+        <div className="text-xs text-muted-foreground line-clamp-1">{operation.description}</div>
+      </div>
+      <Plus className="w-4 h-4 ml-auto opacity-0 group-hover:opacity-100 text-primary transition-opacity" />
+    </Button>
+  )
+}
 
 interface TransformerToolboxProps {
   onAddStep: (operation: TransformerOperation) => void
@@ -70,31 +113,9 @@ export function TransformerToolbox({ onAddStep }: TransformerToolboxProps): Reac
 
       <ScrollArea className="flex-1">
         <div className="p-4 grid gap-2">
-          {filteredOperations.map((op) => {
-            const Icon = ICON_MAP[op.icon] || Plus
-            return (
-              <Button
-                key={op.id}
-                variant="outline"
-                className="justify-start h-auto py-3 px-4 w-full text-left font-normal bg-background hover:bg-accent border-muted-foreground/20 hover:border-primary/50 group transition-all"
-                onClick={() => onAddStep(op)}
-                draggable
-                onDragStart={(e) => {
-                  e.dataTransfer.setData('application/json', JSON.stringify(op))
-                  e.dataTransfer.setData('application/x-poe-operation', 'true')
-                }}
-              >
-                <div className="p-2 rounded-md bg-muted group-hover:bg-primary/10 text-muted-foreground group-hover:text-primary mr-3 transition-colors">
-                  <Icon className="w-4 h-4" />
-                </div>
-                <div>
-                  <div className="text-sm font-medium text-foreground">{op.name}</div>
-                  <div className="text-xs text-muted-foreground line-clamp-1">{op.description}</div>
-                </div>
-                <Plus className="w-4 h-4 ml-auto opacity-0 group-hover:opacity-100 text-primary transition-opacity" />
-              </Button>
-            )
-          })}
+          {filteredOperations.map((op) => (
+            <DraggableToolboxItem key={op.id} operation={op} onAddStep={onAddStep} />
+          ))}
 
           {filteredOperations.length === 0 && (
             <div className="text-center py-8 text-sm text-muted-foreground">

--- a/src/components/transformer/TransformerToolbox.tsx
+++ b/src/components/transformer/TransformerToolbox.tsx
@@ -11,14 +11,19 @@ import type { TransformerOperation, OperationCategory } from './types'
 interface DraggableToolboxItemProps {
   operation: TransformerOperation
   onAddStep: (operation: TransformerOperation) => void
+  isOverlay?: boolean
+  style?: React.CSSProperties
 }
 
 export function DraggableToolboxItem({
   operation,
   onAddStep,
+  isOverlay,
+  style: styleProp,
 }: DraggableToolboxItemProps): ReactElement {
   const { attributes, listeners, setNodeRef, isDragging } = useDraggable({
     id: `toolbox-${operation.id}`,
+    disabled: isOverlay,
     data: {
       operation,
     },
@@ -28,11 +33,12 @@ export function DraggableToolboxItem({
 
   return (
     <Button
+      id={!isOverlay ? `toolbox-${operation.id}` : undefined}
       ref={setNodeRef}
       {...listeners}
       {...attributes}
       variant="outline"
-      style={{ touchAction: 'none' }}
+      style={{ touchAction: 'none', ...styleProp }}
       className={cn(
         'justify-start h-auto py-3 px-4 w-full text-left font-normal bg-background hover:bg-accent border-muted-foreground/20 hover:border-primary/50 group transition-all',
         isDragging ? 'opacity-50' : ''

--- a/src/hooks/useMediaQuery.ts
+++ b/src/hooks/useMediaQuery.ts
@@ -1,0 +1,17 @@
+import { useSyncExternalStore } from 'react'
+
+/**
+ * Hook to listen for media query matches.
+ * @param query - The media query to listen for (e.g. '(min-width: 1024px)')
+ * @returns Boolean indicating if the media query matches
+ */
+export function useMediaQuery(query: string): boolean {
+  return useSyncExternalStore(
+    (callback) => {
+      const mql = window.matchMedia(query)
+      mql.addEventListener('change', callback)
+      return () => mql.removeEventListener('change', callback)
+    },
+    () => window.matchMedia(query).matches
+  )
+}


### PR DESCRIPTION
# Change Summary

## Package Dependencies
Added four @dnd-kit packages for drag-and-drop functionality:
- `@dnd-kit/core` (^6.3.1) - Core drag-and-drop context and hooks
- `@dnd-kit/modifiers` (^9.0.0) - Drag modifiers and transforms
- `@dnd-kit/sortable` (^10.0.0) - Sortable list utilities
- `@dnd-kit/utilities` (^3.2.2) - Utility functions for transforms

## EditorToolbar Component
**Refactored from HTML5 drag-and-drop to @dnd-kit:**
- Converted `ToolbarButton` to `forwardRef` component to support drag attributes and listeners
- Created new `SortablePipelineButton` wrapper component that integrates `useSortable` hook
- Replaced manual drag state management (`draggedPipelineId`) with `activeDragPipeline` tracking
- Implemented `DndContext` with `PointerSensor` for 8px activation constraint
- Added `DragOverlay` for visual feedback during pipeline reordering
- Simplified `handleDragStart` and `handleDragEnd` using @dnd-kit event types
- Removed custom drag event handlers (`handleDragOver`, `handleDrop`)
- Applied `horizontalListSortingStrategy` for pipeline list ordering
- Enhanced `ToolbarButton` with `dragAttributes`, `dragListeners`, and `tooltipDisabled` props

## TransformerDialog Component
**Migrated drag-and-drop and implemented responsive layout:**
- Wrapped entire dialog in `DndContext` with `PointerSensor`
- Implemented dual-mode rendering: mobile (responsive tabs) and desktop (resizable panels) using new `useMediaQuery` hook
- Added `activeDragItem` and `activeDragWidth` state to track dragged operations and steps
- Refactored `handleDragStart` to distinguish between reordering steps and adding new operations
- Refactored `handleDragEnd` to handle two cases: step reordering and new operation drops
- Integrated `DragOverlay` with `createPortal` to render drag previews outside dialog
- Mobile mode: Tabs interface with slide-in toolbox overlay
- Desktop mode: Resizable three-panel layout (toolbox, workbench, preview)
- Removed `handleMoveStep` callback (now handled by @dnd-kit)
- Updated `TransformerToolbox` call with `enableDrag={false}` for mobile view

## TransformerStep Component
**Converted to @dnd-kit sortable:**
- Integrated `useSortable` hook with step ID and data
- Applied `CSS.Transform.toString()` for transform calculations
- Added `isOverlay` and `style` props for drag overlay rendering
- Removed HTML5 drag event handlers (`onDragStart`, `onDragEnter`, `onDragEnd`)
- Removed touch-specific handlers (`handleTouchStart`, `handleTouchMove`, `handleTouchEnd`)
- Applied `touchAction: none` style to drag handle
- Updated drag handle to use `attributes` and `listeners` from `useSortable`
- Added visual feedback for drag state (opacity changes, cursor styles)
- Created overlay render mode for high-contrast drag preview

## TransformerToolbox Component
**Implemented @dnd-kit draggable items:**
- Extracted `DraggableToolboxItem` component using `useDraggable` hook
- Added `enableDrag` prop to conditionally enable/disable dragging
- Applied `touchAction: none` to draggable buttons
- Added `isOverlay` mode for drag preview rendering
- Replaced HTML5 `draggable` and `onDragStart` with @dnd-kit integration
- Each operation button gets unique ID: `toolbox-{operationId}`
- Updated component to render `DraggableToolboxItem` instances

## TransformerWorkbench Component
**Integrated @dnd-kit drop target:**
- Added `useDroppable` hook on container with ID `workbench-container`
- Wrapped step list in `SortableContext` with `verticalListSortingStrategy`
- Removed manual drag-over state management
- Removed custom `handleDrop`, `handleDragStart`, `handleDragEnter`, `handleDragEnd` implementations
- Removed `onMoveStep` callback prop (handled by parent DndContext)
- Added visual feedback when drop zone is active (`isOver` state)
- Steps now managed by @dnd-kit's sortable context

## EditorToolbar Test
- Updated selector from `div[draggable="true"]` to `button` for Pipeline 1 element

## New Hook: useMediaQuery
- Created `/src/hooks/useMediaQuery.ts` for responsive layout detection
- Uses `useSyncExternalStore` for external store subscription
- Supports media query matching with automatic listener cleanup
- Used by TransformerDialog to toggle between mobile and desktop layouts

## Testing Updates
**TransformerToolbox.test.tsx:**
- Added mock for `@dnd-kit/core` `useDraggable` hook
- Updated tests to verify `useDraggable` was called with correct operation data
- Changed assertions from `draggable="true"` attribute to `data-testid` attributes
- Removed `fireEvent.dragStart` test (HTML5 drag simulation)
