### PR TITLE
fix(app): Mobile issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,17 @@ npm run test:e2e   # Run end-to-end tests
 npm run deploy     # Deploy to Cloudflare Workers
 ```
 
+## Manual Testing Features
+
+The editor includes several built-in utilities to assist with manual testing and debugging:
+
+- **Debug Commands**:
+  - `/add-all`: Type this in the Transformer Toolbox search bar to add all available operations to the workbench.
+- **URL Parameters**:
+  - `?limit=[number]`: Override the default URL length limit (default: 32,000 chars). Useful for testing storage limits.
+- **UI Testing**:
+  - **Show Splash**: Accessed via the Menu (three dots) > Show Splash. Displays the splash screen for debugging.
+
 ## Keyboard Shortcuts
 
 | Shortcut               | Action                  |

--- a/src/components/AboutDialog.tsx
+++ b/src/components/AboutDialog.tsx
@@ -28,7 +28,7 @@ export function AboutDialog({ open, onOpenChange }: AboutDialogProps): ReactElem
         </DialogHeader>
         <div className="space-y-4">
           <div className="space-y-2">
-            <h3 className="font-semibold text-sm">Features:</h3>
+            <h3 className="font-semibold text-sm">Features</h3>
             <ul className="text-sm text-muted-foreground space-y-1 list-disc list-inside">
               <li>Live preview with split-pane layout</li>
               <li>Vim mode</li>

--- a/src/components/PoeEditor.tsx
+++ b/src/components/PoeEditor.tsx
@@ -313,17 +313,19 @@ ${htmlContent}
 
   // Effects
   useEffect(() => {
-    // This is needed to track if the component has mounted for theme and and layout purposes.
-    // We suppress the warning as this is a common pattern for hydration/mounting checks in SPAs.
-    // eslint-disable-next-line react-hooks/set-state-in-effect
-    setMounted(true)
+    // Defer setState to avoid cascading renders while still tracking mount state
+    const timeoutId = setTimeout(() => {
+      setMounted(true)
+    }, 0)
 
     // Notify parent that the editor is ready
     // Use requestAnimationFrame to ensure DOM is painted
     requestAnimationFrame(() => {
       onReady?.()
     })
-  }, [onReady])
+
+    return () => clearTimeout(timeoutId)
+  }, [onReady, setMounted])
 
   useEffect(() => {
     const handleEscape = (e: KeyboardEvent): void => {
@@ -513,10 +515,7 @@ ${htmlContent}
 
               {/* Preview Pane - Always mounted, hidden when not active */}
               <div
-                className={cn(
-                  'flex-1 p-4 mt-0 overflow-auto',
-                  activeTab !== 'preview' && 'hidden'
-                )}
+                className={cn('flex-1 p-4 mt-0 overflow-auto', activeTab !== 'preview' && 'hidden')}
               >
                 <PreviewPane ref={targetRef} htmlContent={htmlContent} />
               </div>

--- a/src/components/PoeEditor.tsx
+++ b/src/components/PoeEditor.tsx
@@ -14,7 +14,7 @@ import { PreviewPane } from '@/components/PreviewPane'
 import { SplashScreen } from '@/components/SplashScreen'
 import { TooltipProvider } from '@/components/ui/tooltip'
 import { ResizablePanelGroup, ResizablePanel, ResizableHandle } from '@/components/ui/resizable'
-import { Tabs, TabsList, TabsTrigger, TabsContent } from '@/components/ui/tabs'
+import { cn } from '@/utils/classnames'
 import { AboutDialog } from '@/components/AboutDialog'
 import { KeyboardShortcutsDialog } from '@/components/KeyboardShortcutsDialog'
 import { EditorToolbar } from '@/components/EditorToolbar'
@@ -84,6 +84,9 @@ export function PoeEditor({ onReady }: PoeEditorProps): ReactElement {
     lineNumber: 1,
     column: 1,
   })
+
+  /* Mobile tab state */
+  const [activeTab, setActiveTab] = useState<'editor' | 'preview'>('editor')
 
   const isMobile = useIsMobile()
   const editorRef = useRef<EditorPaneHandle>(null)
@@ -468,32 +471,55 @@ ${htmlContent}
             </div>
           ) : (
             <div className="h-full flex flex-col">
-              <Tabs defaultValue="editor" className="flex-1 flex flex-col">
-                <TabsList className="w-full rounded-none border-b border-border/60 bg-background h-10">
-                  <TabsTrigger value="editor" className="flex-1">
-                    Editor
-                  </TabsTrigger>
-                  <TabsTrigger value="preview" className="flex-1">
-                    Preview
-                  </TabsTrigger>
-                </TabsList>
-                <TabsContent value="editor" className="flex-1 p-4 mt-0">
-                  <EditorPane
-                    ref={editorRef}
-                    value={content}
-                    onChange={setContent}
-                    onCursorChange={setCursorPosition}
-                    theme={mounted && theme === 'dark' ? 'dark' : 'light'}
-                    onFormat={handleFormat}
-                    onCodeBlock={handleFormatCodeBlock}
-                    vimMode={vimModeEnabled}
-                    scrollRef={sourceRef}
-                  />
-                </TabsContent>
-                <TabsContent value="preview" className="flex-1 p-4 mt-0">
-                  <PreviewPane ref={targetRef} htmlContent={htmlContent} />
-                </TabsContent>
-              </Tabs>
+              <div className="w-full border-b border-border/60 bg-background h-10 flex">
+                <button
+                  onClick={() => setActiveTab('editor')}
+                  className={cn(
+                    'flex-1 inline-flex items-center justify-center text-sm font-medium transition-colors border-b-2',
+                    activeTab === 'editor'
+                      ? 'border-primary text-foreground'
+                      : 'border-transparent text-muted-foreground hover:text-foreground'
+                  )}
+                >
+                  Editor
+                </button>
+                <button
+                  onClick={() => setActiveTab('preview')}
+                  className={cn(
+                    'flex-1 inline-flex items-center justify-center text-sm font-medium transition-colors border-b-2',
+                    activeTab === 'preview'
+                      ? 'border-primary text-foreground'
+                      : 'border-transparent text-muted-foreground hover:text-foreground'
+                  )}
+                >
+                  Preview
+                </button>
+              </div>
+
+              {/* Editor Pane - Always mounted, hidden when not active */}
+              <div className={cn('flex-1 p-4 mt-0', activeTab !== 'editor' && 'hidden')}>
+                <EditorPane
+                  ref={editorRef}
+                  value={content}
+                  onChange={setContent}
+                  onCursorChange={setCursorPosition}
+                  theme={mounted && theme === 'dark' ? 'dark' : 'light'}
+                  onFormat={handleFormat}
+                  onCodeBlock={handleFormatCodeBlock}
+                  vimMode={vimModeEnabled}
+                  scrollRef={sourceRef}
+                />
+              </div>
+
+              {/* Preview Pane - Always mounted, hidden when not active */}
+              <div
+                className={cn(
+                  'flex-1 p-4 mt-0 overflow-auto',
+                  activeTab !== 'preview' && 'hidden'
+                )}
+              >
+                <PreviewPane ref={targetRef} htmlContent={htmlContent} />
+              </div>
             </div>
           )}
         </main>

--- a/src/components/SplashScreen.tsx
+++ b/src/components/SplashScreen.tsx
@@ -135,10 +135,24 @@ export function SplashScreen({
               &copy; 2026 Paul Chiu - All rights reserved
             </p>
             {debug && (
-              <p className="mt-2 text-xs font-medium text-yellow-500">
-                Debug Mode: Press Esc to exit, &apos;L&apos; toggles loading, &apos;R&apos;
-                refreshes tagline
-              </p>
+              <div className="mt-2 flex flex-col items-start gap-2">
+                <p className="text-xs font-medium text-yellow-500">
+                  Debug Mode: Press Esc to exit, &apos;L&apos; toggles loading, &apos;R&apos;
+                  refreshes tagline
+                </p>
+                <button
+                  onClick={() => {
+                    setIsFading(true)
+                    setTimeout(() => {
+                      setIsVisible(false)
+                      onComplete()
+                    }, 500)
+                  }}
+                  className="rounded bg-yellow-500/10 px-3 py-1 text-xs font-medium text-yellow-500 hover:bg-yellow-500/20 active:bg-yellow-500/30 lg:hidden"
+                >
+                  Exit Debug
+                </button>
+              </div>
             )}
           </div>
         </div>

--- a/src/components/transformer/IconPicker.tsx
+++ b/src/components/transformer/IconPicker.tsx
@@ -46,6 +46,9 @@ export function IconPicker({ value, onChange }: IconPickerProps): ReactElement {
               <Input
                 value={value}
                 onChange={(e) => onChange(e.target.value)}
+                // Stop propagation to prevent dnd-kit in parent TransformerDialog from capturing the event
+                // (due to React Portal bubbling) and preventing input focus.
+                onPointerDown={(e) => e.stopPropagation()}
                 placeholder="Type emoji or text..."
                 className="h-8"
               />

--- a/src/components/transformer/IconPicker.tsx
+++ b/src/components/transformer/IconPicker.tsx
@@ -39,46 +39,48 @@ export function IconPicker({ value, onChange }: IconPickerProps): ReactElement {
           )}
           onOpenAutoFocus={(e) => e.preventDefault()}
         >
-        <div className="space-y-3">
-          <div className="space-y-2">
-            <h4 className="text-xs font-semibold text-muted-foreground uppercase">Text / Emoji</h4>
-            <div className="flex gap-2">
-              <Input
-                value={value}
-                onChange={(e) => onChange(e.target.value)}
-                // Stop propagation to prevent dnd-kit in parent TransformerDialog from capturing the event
-                // (due to React Portal bubbling) and preventing input focus.
-                onPointerDown={(e) => e.stopPropagation()}
-                placeholder="Type emoji or text..."
-                className="h-8"
-              />
+          <div className="space-y-3">
+            <div className="space-y-2">
+              <h4 className="text-xs font-semibold text-muted-foreground uppercase">
+                Text / Emoji
+              </h4>
+              <div className="flex gap-2">
+                <Input
+                  value={value}
+                  onChange={(e) => onChange(e.target.value)}
+                  // Stop propagation to prevent dnd-kit in parent TransformerDialog from capturing the event
+                  // (due to React Portal bubbling) and preventing input focus.
+                  onPointerDown={(e) => e.stopPropagation()}
+                  placeholder="Type emoji or text..."
+                  className="h-8"
+                />
+              </div>
             </div>
-          </div>
 
-          <div className="space-y-2">
-            <h4 className="text-xs font-semibold text-muted-foreground uppercase">Icons</h4>
-            <div className="grid grid-cols-5 gap-1">
-              {COMMON_ICONS.map(({ icon: Icon, label }) => (
-                <button
-                  key={label}
-                  onClick={() => {
-                    onChange(label)
-                    setIsOpen(false)
-                  }}
-                  className={cn(
-                    'p-1.5 rounded-md hover:bg-accent hover:text-foreground transition-colors flex items-center justify-center',
-                    value === label ? 'bg-primary/10 text-primary' : 'text-muted-foreground'
-                  )}
-                  title={label}
-                >
-                  <Icon className="w-4 h-4" />
-                </button>
-              ))}
+            <div className="space-y-2">
+              <h4 className="text-xs font-semibold text-muted-foreground uppercase">Icons</h4>
+              <div className="grid grid-cols-5 gap-1">
+                {COMMON_ICONS.map(({ icon: Icon, label }) => (
+                  <button
+                    key={label}
+                    onClick={() => {
+                      onChange(label)
+                      setIsOpen(false)
+                    }}
+                    className={cn(
+                      'p-1.5 rounded-md hover:bg-accent hover:text-foreground transition-colors flex items-center justify-center',
+                      value === label ? 'bg-primary/10 text-primary' : 'text-muted-foreground'
+                    )}
+                    title={label}
+                  >
+                    <Icon className="w-4 h-4" />
+                  </button>
+                ))}
+              </div>
             </div>
           </div>
-        </div>
-      </PopoverPrimitive.Content>
-    </PopoverPrimitive.Portal>
-  </Popover>
+        </PopoverPrimitive.Content>
+      </PopoverPrimitive.Portal>
+    </Popover>
   )
 }

--- a/src/components/transformer/IconPicker.tsx
+++ b/src/components/transformer/IconPicker.tsx
@@ -29,58 +29,54 @@ export function IconPicker({ value, onChange }: IconPickerProps): ReactElement {
           {CurrentIcon ? <CurrentIcon className="w-5 h-5" /> : value || '🪄'}
         </Button>
       </PopoverTrigger>
-      <PopoverPrimitive.Portal>
-        <PopoverPrimitive.Content
-          align="center"
-          sideOffset={4}
-          className={cn(
-            'z-[60] rounded-md border bg-popover text-popover-foreground shadow-md outline-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2',
-            'w-64 p-3'
-          )}
-          onOpenAutoFocus={(e) => e.preventDefault()}
-        >
-          <div className="space-y-3">
-            <div className="space-y-2">
-              <h4 className="text-xs font-semibold text-muted-foreground uppercase">
-                Text / Emoji
-              </h4>
-              <div className="flex gap-2">
-                <Input
-                  value={value}
-                  onChange={(e) => onChange(e.target.value)}
-                  // Stop propagation to prevent dnd-kit in parent TransformerDialog from capturing the event
-                  // (due to React Portal bubbling) and preventing input focus.
-                  onPointerDown={(e) => e.stopPropagation()}
-                  placeholder="Type emoji or text..."
-                  className="h-8"
-                />
-              </div>
-            </div>
-
-            <div className="space-y-2">
-              <h4 className="text-xs font-semibold text-muted-foreground uppercase">Icons</h4>
-              <div className="grid grid-cols-5 gap-1">
-                {COMMON_ICONS.map(({ icon: Icon, label }) => (
-                  <button
-                    key={label}
-                    onClick={() => {
-                      onChange(label)
-                      setIsOpen(false)
-                    }}
-                    className={cn(
-                      'p-1.5 rounded-md hover:bg-accent hover:text-foreground transition-colors flex items-center justify-center',
-                      value === label ? 'bg-primary/10 text-primary' : 'text-muted-foreground'
-                    )}
-                    title={label}
-                  >
-                    <Icon className="w-4 h-4" />
-                  </button>
-                ))}
-              </div>
+      <PopoverPrimitive.Content
+        align="center"
+        sideOffset={4}
+        className={cn(
+          'z-50 rounded-md border bg-popover text-popover-foreground shadow-md outline-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2',
+          'w-64 p-3'
+        )}
+        onOpenAutoFocus={(e) => e.preventDefault()}
+      >
+        <div className="space-y-3">
+          <div className="space-y-2">
+            <h4 className="text-xs font-semibold text-muted-foreground uppercase">Text / Emoji</h4>
+            <div className="flex gap-2">
+              <Input
+                value={value}
+                onChange={(e) => onChange(e.target.value)}
+                // Stop propagation to prevent dnd-kit in parent TransformerDialog from capturing the event
+                // (due to React Portal bubbling) and preventing input focus.
+                onPointerDown={(e) => e.stopPropagation()}
+                placeholder="Type emoji or text..."
+                className="h-8"
+              />
             </div>
           </div>
-        </PopoverPrimitive.Content>
-      </PopoverPrimitive.Portal>
+
+          <div className="space-y-2">
+            <h4 className="text-xs font-semibold text-muted-foreground uppercase">Icons</h4>
+            <div className="grid grid-cols-5 gap-1">
+              {COMMON_ICONS.map(({ icon: Icon, label }) => (
+                <button
+                  key={label}
+                  onClick={() => {
+                    onChange(label)
+                    setIsOpen(false)
+                  }}
+                  className={cn(
+                    'p-1.5 rounded-md hover:bg-accent hover:text-foreground transition-colors flex items-center justify-center',
+                    value === label ? 'bg-primary/10 text-primary' : 'text-muted-foreground'
+                  )}
+                  title={label}
+                >
+                  <Icon className="w-4 h-4" />
+                </button>
+              ))}
+            </div>
+          </div>
+        </div>
+      </PopoverPrimitive.Content>
     </Popover>
   )
 }

--- a/src/components/transformer/IconPicker.tsx
+++ b/src/components/transformer/IconPicker.tsx
@@ -25,7 +25,10 @@ export function IconPicker({ value, onChange }: IconPickerProps): ReactElement {
   return (
     <Popover open={isOpen} onOpenChange={setIsOpen}>
       <PopoverTrigger asChild>
-        <Button variant="outline" className="w-10 h-10 p-0 text-xl flex-shrink-0">
+        <Button
+          variant="outline"
+          className={cn('h-10 text-xl flex-shrink-0', CurrentIcon ? 'w-10 p-0' : 'min-w-10 px-2.5')}
+        >
           {CurrentIcon ? <CurrentIcon className="w-5 h-5" /> : value || '🪄'}
         </Button>
       </PopoverTrigger>

--- a/src/components/transformer/IconPicker.tsx
+++ b/src/components/transformer/IconPicker.tsx
@@ -29,15 +29,16 @@ export function IconPicker({ value, onChange }: IconPickerProps): ReactElement {
           {CurrentIcon ? <CurrentIcon className="w-5 h-5" /> : value || '🪄'}
         </Button>
       </PopoverTrigger>
-      <PopoverPrimitive.Content
-        align="center"
-        sideOffset={4}
-        className={cn(
-          'z-50 rounded-md border bg-popover text-popover-foreground shadow-md outline-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2',
-          'w-64 p-3'
-        )}
-        onOpenAutoFocus={(e) => e.preventDefault()}
-      >
+      <PopoverPrimitive.Portal>
+        <PopoverPrimitive.Content
+          align="center"
+          sideOffset={4}
+          className={cn(
+            'z-[60] rounded-md border bg-popover text-popover-foreground shadow-md outline-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2',
+            'w-64 p-3'
+          )}
+          onOpenAutoFocus={(e) => e.preventDefault()}
+        >
         <div className="space-y-3">
           <div className="space-y-2">
             <h4 className="text-xs font-semibold text-muted-foreground uppercase">Text / Emoji</h4>
@@ -74,6 +75,7 @@ export function IconPicker({ value, onChange }: IconPickerProps): ReactElement {
           </div>
         </div>
       </PopoverPrimitive.Content>
-    </Popover>
+    </PopoverPrimitive.Portal>
+  </Popover>
   )
 }

--- a/src/components/transformer/TransformerToolbox.test.tsx
+++ b/src/components/transformer/TransformerToolbox.test.tsx
@@ -122,17 +122,15 @@ describe('TransformerToolbox', () => {
     )
   })
 
-  it('should apply draggable attributes to buttons', () => {
+  it('should apply draggable attributes to drag handles', () => {
     render(<TransformerToolbox onAddStep={mockOnAddStep} />)
 
-    const buttons = screen.getAllByRole('button').filter((btn) => {
-      return OPERATIONS.some((op) => btn.textContent?.includes(op.name))
-    })
+    // The draggable attributes are now on a separate div (drag handle), not the button
+    // We look for elements with the draggable mock attribute
+    const dragHandles = screen.getAllByTestId('draggable-attr')
 
-    // Check if our mock attributes were applied
-    buttons.forEach((button) => {
-      expect(button).toHaveAttribute('data-testid', 'draggable-attr')
-    })
+    // Should have one drag handle for each operation
+    expect(dragHandles.length).toBe(OPERATIONS.length)
   })
 
   it('should clear search when input is cleared', async () => {

--- a/src/components/transformer/TransformerToolbox.tsx
+++ b/src/components/transformer/TransformerToolbox.tsx
@@ -150,9 +150,7 @@ export function TransformerToolbox({
       ))}
 
       {filteredOperations.length === 0 && (
-        <div className="text-center py-8 text-sm text-muted-foreground">
-          No operations found.
-        </div>
+        <div className="text-center py-8 text-sm text-muted-foreground">No operations found.</div>
       )}
     </div>
   )

--- a/src/components/transformer/TransformerToolbox.tsx
+++ b/src/components/transformer/TransformerToolbox.tsx
@@ -50,28 +50,44 @@ export function DraggableToolboxItem({
   }
 
   return (
-    <Button
+    <div
       id={!isOverlay ? `toolbox-${operation.id}` : undefined}
       ref={setNodeRef}
-      {...listeners}
-      {...attributes}
-      variant="outline"
-      style={{ touchAction: enableDrag ? 'none' : 'auto', ...styleProp }}
+      style={styleProp}
       className={cn(
-        'justify-start h-auto py-3 px-4 w-full text-left font-normal bg-background hover:bg-accent border-muted-foreground/20 hover:border-primary/50 group transition-all',
+        'flex items-center w-full rounded-md border bg-background hover:bg-accent border-muted-foreground/20 hover:border-primary/50 group transition-all overflow-hidden',
         isDragging ? 'opacity-50' : ''
       )}
-      onClick={() => onAddStep(operation)}
     >
-      <div className="p-2 rounded-md bg-muted group-hover:bg-primary/10 text-muted-foreground group-hover:text-primary mr-3 transition-colors">
-        <Icon className="w-4 h-4" />
-      </div>
-      <div>
-        <div className="text-sm font-medium text-foreground">{operation.name}</div>
-        <div className="text-xs text-muted-foreground line-clamp-1">{operation.description}</div>
-      </div>
-      <Plus className="w-4 h-4 ml-auto opacity-0 group-hover:opacity-100 text-primary transition-opacity" />
-    </Button>
+      {enableDrag && (
+        <div
+          {...listeners}
+          {...attributes}
+          className="p-3 pr-1 text-muted-foreground/30 group-hover:text-muted-foreground cursor-grab active:cursor-grabbing transition-colors self-stretch flex items-center"
+          style={{ touchAction: 'none' }}
+        >
+          <GripVertical className="h-4 w-4" />
+        </div>
+      )}
+
+      <button
+        type="button"
+        className={cn(
+          'flex-1 flex items-center py-3 px-4 pl-2 text-left bg-transparent border-none cursor-pointer outline-none w-full min-w-0',
+          !enableDrag && 'pl-4'
+        )}
+        onClick={() => onAddStep(operation)}
+      >
+        <div className="p-2 rounded-md bg-muted group-hover:bg-primary/10 text-muted-foreground group-hover:text-primary mr-3 transition-colors shrink-0">
+          <Icon className="w-4 h-4" />
+        </div>
+        <div className="min-w-0 flex-1">
+          <div className="text-sm font-medium text-foreground truncate">{operation.name}</div>
+          <div className="text-xs text-muted-foreground line-clamp-1">{operation.description}</div>
+        </div>
+        <Plus className="w-4 h-4 ml-3 opacity-0 group-hover:opacity-100 text-primary transition-opacity shrink-0" />
+      </button>
+    </div>
   )
 }
 
@@ -107,6 +123,25 @@ export function TransformerToolbox({
     return matchesSearch && matchesCategory
   })
 
+  const listContent = (
+    <div className="p-4 grid gap-2">
+      {filteredOperations.map((op) => (
+        <DraggableToolboxItem
+          key={op.id}
+          operation={op}
+          onAddStep={onAddStep}
+          enableDrag={enableDrag}
+        />
+      ))}
+
+      {filteredOperations.length === 0 && (
+        <div className="text-center py-8 text-sm text-muted-foreground">
+          No operations found.
+        </div>
+      )}
+    </div>
+  )
+
   return (
     <div className="flex flex-col h-full bg-muted/10">
       <div className="p-4 border-b space-y-3">
@@ -140,24 +175,11 @@ export function TransformerToolbox({
         </div>
       </div>
 
-      <ScrollArea className="flex-1">
-        <div className="p-4 grid gap-2">
-          {filteredOperations.map((op) => (
-            <DraggableToolboxItem
-              key={op.id}
-              operation={op}
-              onAddStep={onAddStep}
-              enableDrag={enableDrag}
-            />
-          ))}
-
-          {filteredOperations.length === 0 && (
-            <div className="text-center py-8 text-sm text-muted-foreground">
-              No operations found.
-            </div>
-          )}
-        </div>
-      </ScrollArea>
+      {enableDrag ? (
+        <ScrollArea className="flex-1">{listContent}</ScrollArea>
+      ) : (
+        <div className="flex-1 overflow-y-auto">{listContent}</div>
+      )}
     </div>
   )
 }

--- a/src/components/transformer/TransformerToolbox.tsx
+++ b/src/components/transformer/TransformerToolbox.tsx
@@ -17,6 +17,11 @@ interface DraggableToolboxItemProps {
   enableDrag?: boolean
 }
 
+/**
+ * Draggable item component for the transformer toolbox.
+ * @param props - Component props
+ * @returns The draggable item component
+ */
 export function DraggableToolboxItem({
   operation,
   onAddStep,

--- a/src/components/transformer/TransformerToolbox.tsx
+++ b/src/components/transformer/TransformerToolbox.tsx
@@ -1,4 +1,5 @@
-import { useState, type ReactElement } from 'react'
+import { useState, type ReactElement, type ChangeEvent } from 'react'
+import { useToast } from '@/hooks/useToast'
 import { Search, Plus, GripVertical } from 'lucide-react'
 import { useDraggable } from '@dnd-kit/core'
 import { OPERATIONS, ICON_MAP } from './constants'
@@ -107,6 +108,7 @@ export function TransformerToolbox({
 }: TransformerToolboxProps): ReactElement {
   const [searchQuery, setSearchQuery] = useState('')
   const [activeCategory, setActiveCategory] = useState<OperationCategory | 'All'>('All')
+  const { toast } = useToast()
 
   const categories: (OperationCategory | 'All')[] = [
     'All',
@@ -122,6 +124,19 @@ export function TransformerToolbox({
     const matchesCategory = activeCategory === 'All' || op.category === activeCategory
     return matchesSearch && matchesCategory
   })
+
+  const handleSearchChange = (e: ChangeEvent<HTMLInputElement>) => {
+    const value = e.target.value
+    if (value === '/add-all') {
+      OPERATIONS.forEach((op) => onAddStep(op))
+      toast({
+        description: 'All available operations have been added to the workbench.',
+      })
+      setSearchQuery('')
+      return
+    }
+    setSearchQuery(value)
+  }
 
   const listContent = (
     <div className="p-4 grid gap-2">
@@ -153,7 +168,7 @@ export function TransformerToolbox({
           <Input
             placeholder="Search operations..."
             value={searchQuery}
-            onChange={(e) => setSearchQuery(e.target.value)}
+            onChange={handleSearchChange}
             className="pl-8 bg-background"
           />
         </div>

--- a/src/components/transformer/step-configs/ChangeCaseConfig.tsx
+++ b/src/components/transformer/step-configs/ChangeCaseConfig.tsx
@@ -13,7 +13,7 @@ export function ChangeCaseConfig({ config, onChange }: ChangeCaseConfigProps): R
         <label className="text-[10px] uppercase font-bold text-muted-foreground tracking-wider">
           Case Mode
         </label>
-        <div className="grid grid-cols-4 gap-1 bg-muted/20 p-1 rounded-md border text-xs">
+        <div className="grid grid-cols-2 md:grid-cols-4 gap-1 bg-muted/20 p-1 rounded-md border text-xs">
           {[
             { id: 'upper', label: 'UPPER' },
             { id: 'lower', label: 'lower' },

--- a/src/components/transformer/step-configs/ChangeCaseConfig.tsx
+++ b/src/components/transformer/step-configs/ChangeCaseConfig.tsx
@@ -8,7 +8,7 @@ interface ChangeCaseConfigProps {
 
 export function ChangeCaseConfig({ config, onChange }: ChangeCaseConfigProps): ReactElement {
   return (
-    <div className="mt-3 animate-in slide-in-from-top-2 duration-200">
+    <div className="mt-3">
       <div className="space-y-1">
         <label className="text-[10px] uppercase font-bold text-muted-foreground tracking-wider">
           Case Mode

--- a/src/components/transformer/step-configs/ChangeCaseConfig.tsx
+++ b/src/components/transformer/step-configs/ChangeCaseConfig.tsx
@@ -6,6 +6,11 @@ interface ChangeCaseConfigProps {
   onChange: (config: Record<string, unknown>) => void
 }
 
+/**
+ * Configuration component for Change Case operation.
+ * @param props - Component props
+ * @returns The configuration component
+ */
 export function ChangeCaseConfig({ config, onChange }: ChangeCaseConfigProps): ReactElement {
   return (
     <div className="mt-3">

--- a/src/components/transformer/step-configs/DedupeLinesConfig.tsx
+++ b/src/components/transformer/step-configs/DedupeLinesConfig.tsx
@@ -10,7 +10,7 @@ export function DedupeLinesConfig({ config, onChange }: DedupeLinesConfigProps):
   const keep = (config.keep as string) || 'first'
 
   return (
-    <div className="grid gap-2 mt-3 animate-in slide-in-from-top-2 duration-200">
+    <div className="grid gap-2 mt-3 ">
       <div className="space-y-1">
         <label className="text-[10px] uppercase font-bold text-muted-foreground tracking-wider">
           Occurrence to Keep

--- a/src/components/transformer/step-configs/DedupeLinesConfig.tsx
+++ b/src/components/transformer/step-configs/DedupeLinesConfig.tsx
@@ -6,6 +6,11 @@ interface DedupeLinesConfigProps {
   onChange: (config: Record<string, unknown>) => void
 }
 
+/**
+ * Configuration component for Dedupe Lines operation.
+ * @param props - Component props
+ * @returns The configuration component
+ */
 export function DedupeLinesConfig({ config, onChange }: DedupeLinesConfigProps): ReactElement {
   const keep = (config.keep as string) || 'first'
 

--- a/src/components/transformer/step-configs/EmptyLinesConfig.tsx
+++ b/src/components/transformer/step-configs/EmptyLinesConfig.tsx
@@ -7,7 +7,7 @@ interface EmptyLinesConfigProps {
 
 export function EmptyLinesConfig({ config, onChange }: EmptyLinesConfigProps): ReactElement {
   return (
-    <div className="mt-3 animate-in slide-in-from-top-2 duration-200">
+    <div className="mt-3 ">
       <label className="flex items-center gap-2 min-h-8 h-auto py-2 px-3 border rounded-md bg-muted/20 text-xs cursor-pointer hover:border-primary/50 transition-colors w-fit">
         <input
           type="checkbox"

--- a/src/components/transformer/step-configs/EmptyLinesConfig.tsx
+++ b/src/components/transformer/step-configs/EmptyLinesConfig.tsx
@@ -8,7 +8,7 @@ interface EmptyLinesConfigProps {
 export function EmptyLinesConfig({ config, onChange }: EmptyLinesConfigProps): ReactElement {
   return (
     <div className="mt-3 animate-in slide-in-from-top-2 duration-200">
-      <label className="flex items-center gap-2 h-8 px-3 border rounded-md bg-muted/20 text-xs cursor-pointer hover:border-primary/50 transition-colors w-fit">
+      <label className="flex items-center gap-2 min-h-8 h-auto py-2 px-3 border rounded-md bg-muted/20 text-xs cursor-pointer hover:border-primary/50 transition-colors w-fit">
         <input
           type="checkbox"
           checked={!!config.trim}

--- a/src/components/transformer/step-configs/EmptyLinesConfig.tsx
+++ b/src/components/transformer/step-configs/EmptyLinesConfig.tsx
@@ -5,6 +5,11 @@ interface EmptyLinesConfigProps {
   onChange: (config: Record<string, unknown>) => void
 }
 
+/**
+ * Configuration component for Remove Empty Lines operation.
+ * @param props - Component props
+ * @returns The configuration component
+ */
 export function EmptyLinesConfig({ config, onChange }: EmptyLinesConfigProps): ReactElement {
   return (
     <div className="mt-3 ">

--- a/src/components/transformer/step-configs/EncodeDecodeConfig.tsx
+++ b/src/components/transformer/step-configs/EncodeDecodeConfig.tsx
@@ -36,7 +36,7 @@ export function EncodeDecodeConfig({ config, onChange }: EncodeDecodeConfigProps
   }
 
   return (
-    <div className="grid gap-2 mt-3 animate-in slide-in-from-top-2 duration-200">
+    <div className="grid gap-2 mt-3 ">
       <div className="grid grid-cols-1 md:grid-cols-2 gap-2">
         <div className="space-y-1">
           <label className="text-[10px] uppercase font-bold text-muted-foreground tracking-wider">

--- a/src/components/transformer/step-configs/EncodeDecodeConfig.tsx
+++ b/src/components/transformer/step-configs/EncodeDecodeConfig.tsx
@@ -37,7 +37,7 @@ export function EncodeDecodeConfig({ config, onChange }: EncodeDecodeConfigProps
 
   return (
     <div className="grid gap-2 mt-3 animate-in slide-in-from-top-2 duration-200">
-      <div className="grid grid-cols-2 gap-2">
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-2">
         <div className="space-y-1">
           <label className="text-[10px] uppercase font-bold text-muted-foreground tracking-wider">
             Format

--- a/src/components/transformer/step-configs/EncodeDecodeConfig.tsx
+++ b/src/components/transformer/step-configs/EncodeDecodeConfig.tsx
@@ -6,6 +6,11 @@ interface EncodeDecodeConfigProps {
   onChange: (config: Record<string, unknown>) => void
 }
 
+/**
+ * Configuration component for Encode/Decode operation.
+ * @param props - Component props
+ * @returns The configuration component
+ */
 export function EncodeDecodeConfig({ config, onChange }: EncodeDecodeConfigProps): ReactElement {
   const mode = (config.mode as string) || 'url-encode'
 

--- a/src/components/transformer/step-configs/EscapeConfig.tsx
+++ b/src/components/transformer/step-configs/EscapeConfig.tsx
@@ -6,6 +6,11 @@ interface EscapeConfigProps {
   onChange: (config: Record<string, unknown>) => void
 }
 
+/**
+ * Configuration component for Escape/Unescape operation.
+ * @param props - Component props
+ * @returns The configuration component
+ */
 export function EscapeConfig({ config, onChange }: EscapeConfigProps): ReactElement {
   const mode = (config.mode as string) || 'json-escape'
 

--- a/src/components/transformer/step-configs/EscapeConfig.tsx
+++ b/src/components/transformer/step-configs/EscapeConfig.tsx
@@ -37,7 +37,7 @@ export function EscapeConfig({ config, onChange }: EscapeConfigProps): ReactElem
   }
 
   return (
-    <div className="grid gap-2 mt-3 animate-in slide-in-from-top-2 duration-200">
+    <div className="grid gap-2 mt-3 ">
       <div className="grid grid-cols-1 md:grid-cols-2 gap-2">
         <div className="space-y-1">
           <label className="text-[10px] uppercase font-bold text-muted-foreground tracking-wider">

--- a/src/components/transformer/step-configs/EscapeConfig.tsx
+++ b/src/components/transformer/step-configs/EscapeConfig.tsx
@@ -38,7 +38,7 @@ export function EscapeConfig({ config, onChange }: EscapeConfigProps): ReactElem
 
   return (
     <div className="grid gap-2 mt-3 animate-in slide-in-from-top-2 duration-200">
-      <div className="grid grid-cols-2 gap-2">
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-2">
         <div className="space-y-1">
           <label className="text-[10px] uppercase font-bold text-muted-foreground tracking-wider">
             Type

--- a/src/components/transformer/step-configs/ExtractMatchesConfig.tsx
+++ b/src/components/transformer/step-configs/ExtractMatchesConfig.tsx
@@ -11,7 +11,7 @@ export function ExtractMatchesConfig({
   onChange,
 }: ExtractMatchesConfigProps): ReactElement {
   return (
-    <div className="grid gap-2 mt-3 animate-in slide-in-from-top-2 duration-200">
+    <div className="grid gap-2 mt-3 ">
       <div className="space-y-1">
         <label className="text-[10px] uppercase font-bold text-muted-foreground tracking-wider">
           Regex Pattern

--- a/src/components/transformer/step-configs/ExtractMatchesConfig.tsx
+++ b/src/components/transformer/step-configs/ExtractMatchesConfig.tsx
@@ -6,6 +6,11 @@ interface ExtractMatchesConfigProps {
   onChange: (config: Record<string, unknown>) => void
 }
 
+/**
+ * Configuration component for Extract Matches operation.
+ * @param props - Component props
+ * @returns The configuration component
+ */
 export function ExtractMatchesConfig({
   config,
   onChange,

--- a/src/components/transformer/step-configs/FormatNumbersConfig.tsx
+++ b/src/components/transformer/step-configs/FormatNumbersConfig.tsx
@@ -6,6 +6,11 @@ interface FormatNumbersConfigProps {
   onChange: (config: Record<string, unknown>) => void
 }
 
+/**
+ * Configuration component for Format Numbers operation.
+ * @param props - Component props
+ * @returns The configuration component
+ */
 export function FormatNumbersConfig({ config, onChange }: FormatNumbersConfigProps): ReactElement {
   return (
     <div className="grid gap-2 mt-3 ">

--- a/src/components/transformer/step-configs/FormatNumbersConfig.tsx
+++ b/src/components/transformer/step-configs/FormatNumbersConfig.tsx
@@ -8,7 +8,7 @@ interface FormatNumbersConfigProps {
 
 export function FormatNumbersConfig({ config, onChange }: FormatNumbersConfigProps): ReactElement {
   return (
-    <div className="grid gap-2 mt-3 animate-in slide-in-from-top-2 duration-200">
+    <div className="grid gap-2 mt-3 ">
       <div className="space-y-1">
         <label className="text-[10px] uppercase font-bold text-muted-foreground tracking-wider">
           Decimal Places

--- a/src/components/transformer/step-configs/IncrementNumbersConfig.tsx
+++ b/src/components/transformer/step-configs/IncrementNumbersConfig.tsx
@@ -11,7 +11,7 @@ export function IncrementNumbersConfig({
   onChange,
 }: IncrementNumbersConfigProps): ReactElement {
   return (
-    <div className="mt-3 animate-in slide-in-from-top-2 duration-200">
+    <div className="mt-3 ">
       <div className="space-y-1">
         <label className="text-[10px] uppercase font-bold text-muted-foreground tracking-wider">
           Increment By

--- a/src/components/transformer/step-configs/IncrementNumbersConfig.tsx
+++ b/src/components/transformer/step-configs/IncrementNumbersConfig.tsx
@@ -6,6 +6,11 @@ interface IncrementNumbersConfigProps {
   onChange: (config: Record<string, unknown>) => void
 }
 
+/**
+ * Configuration component for Increment Numbers operation.
+ * @param props - Component props
+ * @returns The configuration component
+ */
 export function IncrementNumbersConfig({
   config,
   onChange,

--- a/src/components/transformer/step-configs/IndentConfig.tsx
+++ b/src/components/transformer/step-configs/IndentConfig.tsx
@@ -12,7 +12,7 @@ export function IndentConfig({ config, onChange }: IndentConfigProps): ReactElem
 
   return (
     <div className="grid gap-2 mt-3 animate-in slide-in-from-top-2 duration-200">
-      <div className="grid grid-cols-2 gap-2">
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-2">
         <div className="space-y-1">
           <label className="text-[10px] uppercase font-bold text-muted-foreground tracking-wider">
             Mode

--- a/src/components/transformer/step-configs/IndentConfig.tsx
+++ b/src/components/transformer/step-configs/IndentConfig.tsx
@@ -7,6 +7,11 @@ interface IndentConfigProps {
   onChange: (config: Record<string, unknown>) => void
 }
 
+/**
+ * Configuration component for Indent/Dedent operation.
+ * @param props - Component props
+ * @returns The configuration component
+ */
 export function IndentConfig({ config, onChange }: IndentConfigProps): ReactElement {
   const mode = config.mode === 'dedent' ? 'dedent' : 'indent'
 

--- a/src/components/transformer/step-configs/IndentConfig.tsx
+++ b/src/components/transformer/step-configs/IndentConfig.tsx
@@ -11,7 +11,7 @@ export function IndentConfig({ config, onChange }: IndentConfigProps): ReactElem
   const mode = config.mode === 'dedent' ? 'dedent' : 'indent'
 
   return (
-    <div className="grid gap-2 mt-3 animate-in slide-in-from-top-2 duration-200">
+    <div className="grid gap-2 mt-3 ">
       <div className="grid grid-cols-1 md:grid-cols-2 gap-2">
         <div className="space-y-1">
           <label className="text-[10px] uppercase font-bold text-muted-foreground tracking-wider">

--- a/src/components/transformer/step-configs/JoinSplitConfig.tsx
+++ b/src/components/transformer/step-configs/JoinSplitConfig.tsx
@@ -16,7 +16,7 @@ export function JoinSplitConfig({
   const placeholder = operationId === 'join-lines' ? 'Space, comma, etc.' : 'Separator character'
 
   return (
-    <div className="mt-3 animate-in slide-in-from-top-2 duration-200">
+    <div className="mt-3 ">
       <div className="space-y-1">
         <label className="text-[10px] uppercase font-bold text-muted-foreground tracking-wider">
           Separator

--- a/src/components/transformer/step-configs/JoinSplitConfig.tsx
+++ b/src/components/transformer/step-configs/JoinSplitConfig.tsx
@@ -7,6 +7,11 @@ interface JoinSplitConfigProps {
   operationId: string
 }
 
+/**
+ * Configuration component for Join/Split operation.
+ * @param props - Component props
+ * @returns The configuration component
+ */
 export function JoinSplitConfig({
   config,
   onChange,

--- a/src/components/transformer/step-configs/LineMatchConfig.tsx
+++ b/src/components/transformer/step-configs/LineMatchConfig.tsx
@@ -8,7 +8,7 @@ interface LineMatchConfigProps {
 
 export function LineMatchConfig({ config, onChange }: LineMatchConfigProps): ReactElement {
   return (
-    <div className="grid gap-2 mt-3 animate-in slide-in-from-top-2 duration-200">
+    <div className="grid gap-2 mt-3 ">
       <div className="space-y-1">
         <label className="text-[10px] uppercase font-bold text-muted-foreground tracking-wider">
           Pattern to Match

--- a/src/components/transformer/step-configs/LineMatchConfig.tsx
+++ b/src/components/transformer/step-configs/LineMatchConfig.tsx
@@ -6,6 +6,11 @@ interface LineMatchConfigProps {
   onChange: (config: Record<string, unknown>) => void
 }
 
+/**
+ * Configuration component for Keep/Remove Matching Lines operation.
+ * @param props - Component props
+ * @returns The configuration component
+ */
 export function LineMatchConfig({ config, onChange }: LineMatchConfigProps): ReactElement {
   return (
     <div className="grid gap-2 mt-3 ">

--- a/src/components/transformer/step-configs/LineMatchConfig.tsx
+++ b/src/components/transformer/step-configs/LineMatchConfig.tsx
@@ -21,7 +21,7 @@ export function LineMatchConfig({ config, onChange }: LineMatchConfigProps): Rea
         />
       </div>
 
-      <div className="flex gap-2">
+      <div className="flex flex-wrap gap-2">
         <label className="flex items-center gap-2 px-2 h-7 border rounded-md bg-muted/20 text-xs cursor-pointer hover:border-primary/50 transition-colors">
           <input
             type="checkbox"

--- a/src/components/transformer/step-configs/NumberLinesConfig.tsx
+++ b/src/components/transformer/step-configs/NumberLinesConfig.tsx
@@ -6,6 +6,11 @@ interface NumberLinesConfigProps {
   onChange: (config: Record<string, unknown>) => void
 }
 
+/**
+ * Configuration component for Number Lines operation.
+ * @param props - Component props
+ * @returns The configuration component
+ */
 export function NumberLinesConfig({ config, onChange }: NumberLinesConfigProps): ReactElement {
   return (
     <div className="grid gap-2 mt-3 ">

--- a/src/components/transformer/step-configs/NumberLinesConfig.tsx
+++ b/src/components/transformer/step-configs/NumberLinesConfig.tsx
@@ -8,7 +8,7 @@ interface NumberLinesConfigProps {
 
 export function NumberLinesConfig({ config, onChange }: NumberLinesConfigProps): ReactElement {
   return (
-    <div className="grid gap-2 mt-3 animate-in slide-in-from-top-2 duration-200">
+    <div className="grid gap-2 mt-3 ">
       <div className="grid grid-cols-1 md:grid-cols-3 gap-2">
         <div className="space-y-1">
           <label className="text-[10px] uppercase font-bold text-muted-foreground tracking-wider">

--- a/src/components/transformer/step-configs/NumberLinesConfig.tsx
+++ b/src/components/transformer/step-configs/NumberLinesConfig.tsx
@@ -9,7 +9,7 @@ interface NumberLinesConfigProps {
 export function NumberLinesConfig({ config, onChange }: NumberLinesConfigProps): ReactElement {
   return (
     <div className="grid gap-2 mt-3 animate-in slide-in-from-top-2 duration-200">
-      <div className="grid grid-cols-3 gap-2">
+      <div className="grid grid-cols-1 md:grid-cols-3 gap-2">
         <div className="space-y-1">
           <label className="text-[10px] uppercase font-bold text-muted-foreground tracking-wider">
             Start

--- a/src/components/transformer/step-configs/PadAlignConfig.tsx
+++ b/src/components/transformer/step-configs/PadAlignConfig.tsx
@@ -11,7 +11,7 @@ export function PadAlignConfig({ config, onChange }: PadAlignConfigProps): React
   const align = (config.align as string) || 'left'
 
   return (
-    <div className="grid gap-2 mt-3 animate-in slide-in-from-top-2 duration-200">
+    <div className="grid gap-2 mt-3 ">
       <div className="grid grid-cols-1 md:grid-cols-2 gap-2">
         <div className="space-y-1">
           <label className="text-[10px] uppercase font-bold text-muted-foreground tracking-wider">

--- a/src/components/transformer/step-configs/PadAlignConfig.tsx
+++ b/src/components/transformer/step-configs/PadAlignConfig.tsx
@@ -7,6 +7,11 @@ interface PadAlignConfigProps {
   onChange: (config: Record<string, unknown>) => void
 }
 
+/**
+ * Configuration component for Pad/Align operation.
+ * @param props - Component props
+ * @returns The configuration component
+ */
 export function PadAlignConfig({ config, onChange }: PadAlignConfigProps): ReactElement {
   const align = (config.align as string) || 'left'
 

--- a/src/components/transformer/step-configs/PadAlignConfig.tsx
+++ b/src/components/transformer/step-configs/PadAlignConfig.tsx
@@ -12,7 +12,7 @@ export function PadAlignConfig({ config, onChange }: PadAlignConfigProps): React
 
   return (
     <div className="grid gap-2 mt-3 animate-in slide-in-from-top-2 duration-200">
-      <div className="grid grid-cols-2 gap-2">
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-2">
         <div className="space-y-1">
           <label className="text-[10px] uppercase font-bold text-muted-foreground tracking-wider">
             Alignment

--- a/src/components/transformer/step-configs/QuoteConfig.tsx
+++ b/src/components/transformer/step-configs/QuoteConfig.tsx
@@ -12,7 +12,7 @@ export function QuoteConfig({ config, onChange }: QuoteConfigProps): ReactElemen
 
   return (
     <div className="grid gap-2 mt-3 animate-in slide-in-from-top-2 duration-200">
-      <div className="grid grid-cols-2 gap-2">
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-2">
         <div className="space-y-1">
           <label className="text-[10px] uppercase font-bold text-muted-foreground tracking-wider">
             Mode

--- a/src/components/transformer/step-configs/QuoteConfig.tsx
+++ b/src/components/transformer/step-configs/QuoteConfig.tsx
@@ -7,6 +7,11 @@ interface QuoteConfigProps {
   onChange: (config: Record<string, unknown>) => void
 }
 
+/**
+ * Configuration component for Quote/Unquote operation.
+ * @param props - Component props
+ * @returns The configuration component
+ */
 export function QuoteConfig({ config, onChange }: QuoteConfigProps): ReactElement {
   const mode = (config.mode as string) || 'add'
 

--- a/src/components/transformer/step-configs/QuoteConfig.tsx
+++ b/src/components/transformer/step-configs/QuoteConfig.tsx
@@ -11,7 +11,7 @@ export function QuoteConfig({ config, onChange }: QuoteConfigProps): ReactElemen
   const mode = (config.mode as string) || 'add'
 
   return (
-    <div className="grid gap-2 mt-3 animate-in slide-in-from-top-2 duration-200">
+    <div className="grid gap-2 mt-3 ">
       <div className="grid grid-cols-1 md:grid-cols-2 gap-2">
         <div className="space-y-1">
           <label className="text-[10px] uppercase font-bold text-muted-foreground tracking-wider">

--- a/src/components/transformer/step-configs/RemoveCharsConfig.tsx
+++ b/src/components/transformer/step-configs/RemoveCharsConfig.tsx
@@ -16,7 +16,7 @@ export function RemoveCharsConfig({ config, onChange }: RemoveCharsConfigProps):
         <label className="text-[10px] uppercase font-bold text-muted-foreground tracking-wider">
           Characters to Strip
         </label>
-        <div className="grid grid-cols-4 gap-1 bg-muted/20 p-1 rounded-md border text-[10px]">
+        <div className="grid grid-cols-2 md:grid-cols-4 gap-1 bg-muted/20 p-1 rounded-md border text-[10px]">
           {[
             { id: 'digits', label: 'Digits' },
             { id: 'punctuation', label: 'Punct' },

--- a/src/components/transformer/step-configs/RemoveCharsConfig.tsx
+++ b/src/components/transformer/step-configs/RemoveCharsConfig.tsx
@@ -7,6 +7,11 @@ interface RemoveCharsConfigProps {
   onChange: (config: Record<string, unknown>) => void
 }
 
+/**
+ * Configuration component for Remove Characters operation.
+ * @param props - Component props
+ * @returns The configuration component
+ */
 export function RemoveCharsConfig({ config, onChange }: RemoveCharsConfigProps): ReactElement {
   const mode = (config.mode as string) || 'digits'
 

--- a/src/components/transformer/step-configs/RemoveCharsConfig.tsx
+++ b/src/components/transformer/step-configs/RemoveCharsConfig.tsx
@@ -11,7 +11,7 @@ export function RemoveCharsConfig({ config, onChange }: RemoveCharsConfigProps):
   const mode = (config.mode as string) || 'digits'
 
   return (
-    <div className="grid gap-2 mt-3 animate-in slide-in-from-top-2 duration-200">
+    <div className="grid gap-2 mt-3 ">
       <div className="space-y-1">
         <label className="text-[10px] uppercase font-bold text-muted-foreground tracking-wider">
           Characters to Strip

--- a/src/components/transformer/step-configs/ReplaceConfig.tsx
+++ b/src/components/transformer/step-configs/ReplaceConfig.tsx
@@ -6,6 +6,11 @@ interface ReplaceConfigProps {
   onChange: (config: Record<string, unknown>) => void
 }
 
+/**
+ * Configuration component for Replace Text operation.
+ * @param props - Component props
+ * @returns The configuration component
+ */
 export function ReplaceConfig({ config, onChange }: ReplaceConfigProps): ReactElement {
   return (
     <div className="grid gap-2 mt-3 ">

--- a/src/components/transformer/step-configs/ReplaceConfig.tsx
+++ b/src/components/transformer/step-configs/ReplaceConfig.tsx
@@ -8,7 +8,7 @@ interface ReplaceConfigProps {
 
 export function ReplaceConfig({ config, onChange }: ReplaceConfigProps): ReactElement {
   return (
-    <div className="grid gap-2 mt-3 animate-in slide-in-from-top-2 duration-200">
+    <div className="grid gap-2 mt-3 ">
       <div className="grid grid-cols-1 md:grid-cols-2 gap-2">
         <div className="space-y-1">
           <label className="text-[10px] uppercase font-bold text-muted-foreground tracking-wider">

--- a/src/components/transformer/step-configs/ReplaceConfig.tsx
+++ b/src/components/transformer/step-configs/ReplaceConfig.tsx
@@ -9,7 +9,7 @@ interface ReplaceConfigProps {
 export function ReplaceConfig({ config, onChange }: ReplaceConfigProps): ReactElement {
   return (
     <div className="grid gap-2 mt-3 animate-in slide-in-from-top-2 duration-200">
-      <div className="grid grid-cols-2 gap-2">
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-2">
         <div className="space-y-1">
           <label className="text-[10px] uppercase font-bold text-muted-foreground tracking-wider">
             Find
@@ -34,7 +34,7 @@ export function ReplaceConfig({ config, onChange }: ReplaceConfigProps): ReactEl
         </div>
       </div>
 
-      <div className="flex gap-2">
+      <div className="flex flex-wrap gap-2">
         <label className="flex items-center gap-2 px-2 h-7 border rounded-md bg-muted/20 text-xs cursor-pointer hover:border-primary/50 transition-colors">
           <input
             type="checkbox"

--- a/src/components/transformer/step-configs/SortLinesConfig.tsx
+++ b/src/components/transformer/step-configs/SortLinesConfig.tsx
@@ -6,6 +6,11 @@ interface SortLinesConfigProps {
   onChange: (config: Record<string, unknown>) => void
 }
 
+/**
+ * Configuration component for Sort Lines operation.
+ * @param props - Component props
+ * @returns The configuration component
+ */
 export function SortLinesConfig({ config, onChange }: SortLinesConfigProps): ReactElement {
   return (
     <div className="flex flex-col md:flex-row gap-3 mt-3 text-left items-stretch md:items-end">

--- a/src/components/transformer/step-configs/SortLinesConfig.tsx
+++ b/src/components/transformer/step-configs/SortLinesConfig.tsx
@@ -8,7 +8,7 @@ interface SortLinesConfigProps {
 
 export function SortLinesConfig({ config, onChange }: SortLinesConfigProps): ReactElement {
   return (
-    <div className="flex flex-col md:flex-row gap-3 mt-3 animate-in slide-in-from-top-2 duration-200 text-left items-stretch md:items-end">
+    <div className="flex flex-col md:flex-row gap-3 mt-3 text-left items-stretch md:items-end">
       <div className="flex-1 space-y-1">
         <label className="text-[10px] uppercase font-bold text-muted-foreground tracking-wider">
           Direction

--- a/src/components/transformer/step-configs/SortLinesConfig.tsx
+++ b/src/components/transformer/step-configs/SortLinesConfig.tsx
@@ -8,7 +8,7 @@ interface SortLinesConfigProps {
 
 export function SortLinesConfig({ config, onChange }: SortLinesConfigProps): ReactElement {
   return (
-    <div className="flex gap-3 mt-3 animate-in slide-in-from-top-2 duration-200 text-left items-end">
+    <div className="flex flex-col md:flex-row gap-3 mt-3 animate-in slide-in-from-top-2 duration-200 text-left items-stretch md:items-end">
       <div className="flex-1 space-y-1">
         <label className="text-[10px] uppercase font-bold text-muted-foreground tracking-wider">
           Direction

--- a/src/components/transformer/step-configs/TrimConfig.tsx
+++ b/src/components/transformer/step-configs/TrimConfig.tsx
@@ -5,6 +5,11 @@ interface TrimConfigProps {
   onChange: (config: Record<string, unknown>) => void
 }
 
+/**
+ * Configuration component for Trim Whitespace operation.
+ * @param props - Component props
+ * @returns The configuration component
+ */
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 export function TrimConfig(_props: TrimConfigProps): ReactElement | null {
   // Line mode toggle is now in the card header

--- a/src/components/transformer/step-configs/WordWrapConfig.tsx
+++ b/src/components/transformer/step-configs/WordWrapConfig.tsx
@@ -6,6 +6,11 @@ interface WordWrapConfigProps {
   onChange: (config: Record<string, unknown>) => void
 }
 
+/**
+ * Configuration component for Word Wrap operation.
+ * @param props - Component props
+ * @returns The configuration component
+ */
 export function WordWrapConfig({ config, onChange }: WordWrapConfigProps): ReactElement {
   return (
     <div className="mt-3 ">

--- a/src/components/transformer/step-configs/WordWrapConfig.tsx
+++ b/src/components/transformer/step-configs/WordWrapConfig.tsx
@@ -8,7 +8,7 @@ interface WordWrapConfigProps {
 
 export function WordWrapConfig({ config, onChange }: WordWrapConfigProps): ReactElement {
   return (
-    <div className="mt-3 animate-in slide-in-from-top-2 duration-200">
+    <div className="mt-3 ">
       <div className="space-y-1">
         <label className="text-[10px] uppercase font-bold text-muted-foreground tracking-wider">
           Column Width

--- a/src/components/transformer/step-configs/WrapLinesConfig.tsx
+++ b/src/components/transformer/step-configs/WrapLinesConfig.tsx
@@ -6,6 +6,11 @@ interface WrapLinesConfigProps {
   onChange: (config: Record<string, unknown>) => void
 }
 
+/**
+ * Configuration component for Wrap Lines operation.
+ * @param props - Component props
+ * @returns The configuration component
+ */
 export function WrapLinesConfig({ config, onChange }: WrapLinesConfigProps): ReactElement {
   return (
     <div className="grid grid-cols-1 md:grid-cols-2 gap-2 mt-3 ">

--- a/src/components/transformer/step-configs/WrapLinesConfig.tsx
+++ b/src/components/transformer/step-configs/WrapLinesConfig.tsx
@@ -8,7 +8,7 @@ interface WrapLinesConfigProps {
 
 export function WrapLinesConfig({ config, onChange }: WrapLinesConfigProps): ReactElement {
   return (
-    <div className="grid grid-cols-2 gap-2 mt-3 animate-in slide-in-from-top-2 duration-200">
+    <div className="grid grid-cols-1 md:grid-cols-2 gap-2 mt-3 animate-in slide-in-from-top-2 duration-200">
       <div className="space-y-1">
         <label className="text-[10px] uppercase font-bold text-muted-foreground tracking-wider">
           Prefix

--- a/src/components/transformer/step-configs/WrapLinesConfig.tsx
+++ b/src/components/transformer/step-configs/WrapLinesConfig.tsx
@@ -8,7 +8,7 @@ interface WrapLinesConfigProps {
 
 export function WrapLinesConfig({ config, onChange }: WrapLinesConfigProps): ReactElement {
   return (
-    <div className="grid grid-cols-1 md:grid-cols-2 gap-2 mt-3 animate-in slide-in-from-top-2 duration-200">
+    <div className="grid grid-cols-1 md:grid-cols-2 gap-2 mt-3 ">
       <div className="space-y-1">
         <label className="text-[10px] uppercase font-bold text-muted-foreground tracking-wider">
           Prefix


### PR DESCRIPTION
## Added

- **Manual Testing Features** section in README documenting debug commands, URL parameters, and UI testing utilities
  - `/add-all` command to add all operations to workbench
  - `?limit=[number]` URL parameter to override default URL length limit (32,000 chars)
  - Show Splash menu option for splash screen debugging
- **Mobile tab navigation** in PoeEditor using custom button-based tabs with state management (`activeTab`)
- **Exit Debug button** in SplashScreen debug mode (mobile-only) for easier debugging workflow
- **Comprehensive JSDoc comments** to all step configuration components documenting their purpose and props
- **Icon picker styling improvements** with responsive button sizing based on icon presence
- **Stop propagation handler** in IconPicker input to prevent dnd-kit interference with focus
- **Drag handle separation** in DraggableToolboxItem with visual grip icon and improved layout
- **Search command** in TransformerToolbox for `/add-all` functionality with toast notification
- **Responsive grid layouts** across all step-config components using `grid-cols-1 md:grid-cols-*` breakpoints
- **Responsive flexbox layouts** in SortLinesConfig and LineMatchConfig for mobile compatibility

## Changed

- **Removed colon** from "Features:" heading in AboutDialog (now "Features")
- **PoeEditor imports** reorganized: removed unused Tabs imports, added `cn` utility import
- **Mount effect** refactored to use `setTimeout` with cleanup for better hydration handling
- **Mobile tab implementation** replaces Radix Tabs component with custom buttons for better control on mobile
- **DraggableToolboxItem restructured** from Button to div wrapper with separate drag handle and button sections
- **Drag handle styling** moved to separate element with `touchAction: 'none'` and visual cursor feedback
- **IconPicker button styling** changed from fixed `w-10 h-10 p-0` to responsive `h-10` with conditional `w-10 p-0` or `min-w-10 px-2.5`
- **TransformerToolbox search** now uses `onChange` handler for `/add-all` command detection
- **TransformerToolbox scroll area** conditionally rendered: ScrollArea for drag mode, standard overflow-y-auto for non-drag mode
- **All step-config animations** removed: `animate-in slide-in-from-top-2 duration-200` classes deleted from container divs
- **All step-config grid layouts** converted to responsive with mobile-first approach (`grid-cols-1 md:grid-cols-*`)
- **EmptyLinesConfig label** changed from fixed `h-8` to `min-h-8 h-auto py-2` for better text wrapping
- **LineMatchConfig checkbox container** changed from fixed `flex` to `flex flex-wrap` for responsive wrapping
- **ReplaceConfig and other configs** gap containers changed to `flex flex-wrap` for mobile responsiveness
- **NumberLinesConfig grid** changed from `grid-cols-3` to `grid-cols-1 md:grid-cols-3`
- **Test description** updated: "should apply draggable attributes to buttons" → "should apply draggable attributes to drag handles"
- **Test implementation** refactored to check for drag handles instead of operation buttons

## Fixed

- **Mobile layout responsiveness** for all step configuration dialogs
- **Drag handle accessibility** by separating from clickable button element
- **Icon picker button** now properly sized based on content (icon vs emoji)
- **TransformerToolbox scrolling** behavior optimized for drag-enabled vs non-drag modes
- **Splash screen debug mode** now has mobile-friendly exit mechanism
- **Editor/Preview tabs** on mobile now use custom implementation for better state control
