### PR TITLE
feat(EditorToolbar): Add reset app state functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,16 +73,7 @@ The editor includes several built-in utilities to assist with manual testing and
 
 ## Keyboard Shortcuts
 
-| Shortcut               | Action                  |
-| ---------------------- | ----------------------- |
-| `Cmd/Ctrl + B`         | Bold                    |
-| `Cmd/Ctrl + I`         | Italic                  |
-| `Cmd/Ctrl + K`         | Link                    |
-| `Cmd/Ctrl + E`         | Inline code             |
-| `Cmd/Ctrl + Shift + K` | Code block              |
-| `Cmd/Ctrl + S`         | Save (persists to URL)  |
-| `?`                    | Show keyboard shortcuts |
-| `Esc`                  | Close dialogs           |
+Press `?` within the application to view the full list of keyboard shortcuts.
 
 When Vim mode is enabled: Esc for normal mode, i for insert, v for visual.
 

--- a/src/components/EditorToolbar.tsx
+++ b/src/components/EditorToolbar.tsx
@@ -76,6 +76,7 @@ import {
   AlertTriangle,
   Wand2,
   ArrowRightLeft,
+  RotateCcw,
 } from 'lucide-react'
 import { ICON_MAP } from '@/components/transformer/constants'
 import { cn } from '@/utils/classnames'
@@ -260,6 +261,7 @@ interface EditorToolbarProps {
   onEditPipeline?: (pipeline: TransformationPipeline) => void
   onDeletePipeline?: (id: string) => void
   onReorderPipelines?: (pipelines: TransformationPipeline[]) => void
+  onReset?: () => void
 }
 
 /**
@@ -300,6 +302,7 @@ export function EditorToolbar({
   onEditPipeline,
   onDeletePipeline,
   onReorderPipelines,
+  onReset,
 }: EditorToolbarProps): ReactElement {
   const [isConfirmingClear, setIsConfirmingClear] = useState(false)
   const [pipelineToDelete, setPipelineToDelete] = useState<TransformationPipeline | null>(null)
@@ -624,6 +627,10 @@ export function EditorToolbar({
             <DropdownMenuItem onClick={onOpenImportExport}>
               <ArrowRightLeft className="size-4" />
               Import/Export Transformers
+            </DropdownMenuItem>
+            <DropdownMenuItem onClick={() => onReset?.()}>
+              <RotateCcw className="size-4" />
+              Reset App State
             </DropdownMenuItem>
             <DropdownMenuItem onClick={() => setShowShortcuts(true)}>
               <Keyboard className="size-4" />

--- a/src/components/KeyboardShortcutsDialog.tsx
+++ b/src/components/KeyboardShortcutsDialog.tsx
@@ -109,6 +109,12 @@ export function KeyboardShortcutsDialog({
                   <span className="text-muted-foreground">Close Modal</span>
                   <code className="bg-muted px-2 py-1 rounded text-xs font-mono">Esc</code>
                 </div>
+                <div className="flex justify-between items-center text-sm">
+                  <span className="text-muted-foreground">Reset App State</span>
+                  <code className="bg-muted px-2 py-1 rounded text-xs font-mono">
+                    Cmd/Ctrl + Alt + 0
+                  </code>
+                </div>
               </div>
             </div>
 

--- a/src/components/PoeEditor.tsx
+++ b/src/components/PoeEditor.tsx
@@ -16,6 +16,16 @@ import { TooltipProvider } from '@/components/ui/tooltip'
 import { ResizablePanelGroup, ResizablePanel, ResizableHandle } from '@/components/ui/resizable'
 import { cn } from '@/utils/classnames'
 import { AboutDialog } from '@/components/AboutDialog'
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/ui/alert-dialog'
 import { KeyboardShortcutsDialog } from '@/components/KeyboardShortcutsDialog'
 import { EditorToolbar } from '@/components/EditorToolbar'
 import { RenameDialog } from '@/components/RenameDialog'
@@ -78,6 +88,7 @@ export function PoeEditor({ onReady }: PoeEditorProps): ReactElement {
   const [showRename, setShowRename] = useState(false)
   const [showNewDialog, setShowNewDialog] = useState(false)
   const [showSplash, setShowSplash] = useState(false)
+  const [showResetConfirm, setShowResetConfirm] = useState(false)
   const [showTransformer, setShowTransformer] = useState(false)
   const [showImportExport, setShowImportExport] = useState(false)
   const [editingPipeline, setEditingPipeline] = useState<TransformationPipeline | null>(null)
@@ -228,6 +239,11 @@ export function PoeEditor({ onReady }: PoeEditorProps): ReactElement {
     [replacePipelines]
   )
 
+  const handleReset = useCallback((): void => {
+    window.history.replaceState(null, '', window.location.pathname)
+    window.location.reload()
+  }, [])
+
   // Document management functions
   const handleNew = useCallback((): void => {
     setShowNewDialog(true)
@@ -317,6 +333,7 @@ ${htmlContent}
     onRename: handleRename,
     onClear: handleClear,
     onCopyLink: handleCopyLink,
+    onReset: () => setShowResetConfirm(true),
   })
 
   // Effects
@@ -456,7 +473,37 @@ ${htmlContent}
           onEditPipeline={handleEditPipeline}
           onDeletePipeline={handleDeletePipeline}
           onReorderPipelines={handleReorderPipelines}
+          onReset={() => setShowResetConfirm(true)}
         />
+
+        <AlertDialog open={showResetConfirm} onOpenChange={setShowResetConfirm}>
+          <AlertDialogContent>
+            <AlertDialogHeader>
+              <AlertDialogTitle>Reset App State?</AlertDialogTitle>
+              <AlertDialogDescription>
+                This will clear your current work and return to the default state. This action
+                cannot be undone.
+                <br />
+                <br />
+                <span className="font-medium text-foreground">
+                  Note: Your saved transformers will remain intact.
+                </span>
+              </AlertDialogDescription>
+            </AlertDialogHeader>
+            <AlertDialogFooter>
+              <AlertDialogCancel>Cancel</AlertDialogCancel>
+              <AlertDialogAction
+                className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+                onClick={() => {
+                  setShowResetConfirm(false)
+                  handleReset()
+                }}
+              >
+                Reset
+              </AlertDialogAction>
+            </AlertDialogFooter>
+          </AlertDialogContent>
+        </AlertDialog>
 
         <main className="flex-1 overflow-hidden">
           {!isMobile ? (

--- a/src/hooks/useKeyboardShortcuts.test.ts
+++ b/src/hooks/useKeyboardShortcuts.test.ts
@@ -15,6 +15,7 @@ describe('useKeyboardShortcuts', () => {
     onRename: vi.fn(),
     onClear: vi.fn(),
     onCopyLink: vi.fn(),
+    onReset: vi.fn(),
   }
 
   const triggerKeyDown = (key: string, options: KeyboardEventInit = {}) => {
@@ -76,6 +77,13 @@ describe('useKeyboardShortcuts', () => {
     renderHook(() => useKeyboardShortcuts(handlers))
     triggerKeyDown('l', { metaKey: true, altKey: true })
     expect(handlers.onCopyLink).toHaveBeenCalled()
+  })
+
+  it('should trigger onReset with Cmd+Alt+0', () => {
+    renderHook(() => useKeyboardShortcuts(handlers))
+    const event = triggerKeyDown('0', { metaKey: true, altKey: true, code: 'Digit0' })
+    expect(handlers.onReset).toHaveBeenCalled()
+    expect(event.defaultPrevented).toBe(true)
   })
 
   it('should trigger onClear with Cmd+Alt+K', () => {

--- a/src/hooks/useKeyboardShortcuts.ts
+++ b/src/hooks/useKeyboardShortcuts.ts
@@ -12,6 +12,7 @@ interface ShortcutHandlers {
   onRename: () => void
   onClear: () => void
   onCopyLink: () => void
+  onReset: () => void
 }
 
 /**
@@ -76,6 +77,10 @@ export function useKeyboardShortcuts(handlers: ShortcutHandlers): void {
             case 'KeyK':
               event.preventDefault()
               handlers.onClear()
+              break
+            case 'Digit0':
+              event.preventDefault()
+              handlers.onReset()
               break
           }
           return


### PR DESCRIPTION
# Changelog

## Summary
Added a reset app state feature with keyboard shortcut (Cmd/Ctrl + Alt + 0), confirmation dialog, and updated documentation. Simplified keyboard shortcuts README section to reference in-app help.

## Changed
- **README.md**: Replaced keyboard shortcuts table with instruction to press `?` in-app to view shortcuts
- **EditorToolbar.tsx**: 
  - Added `RotateCcw` icon import
  - Added `onReset?: () => void` callback to `EditorToolbarProps`
  - Added "Reset App State" menu item in dropdown with reset icon
- **KeyboardShortcutsDialog.tsx**: Added "Reset App State" shortcut help text showing `Cmd/Ctrl + Alt + 0`
- **PoeEditor.tsx**:
  - Imported `AlertDialog` components from ui library
  - Added `showResetConfirm` state
  - Implemented `handleReset` callback that clears URL state and reloads page
  - Connected reset handlers to toolbar and keyboard shortcuts
  - Added full-screen confirmation dialog with warning about clearing work and note that saved transformers persist
  - Dialog includes Cancel and destructive-styled Reset button
- **useKeyboardShortcuts.ts**:
  - Added `onReset: () => void` to `ShortcutHandlers` interface
  - Added handler for `Digit0` key with `metaKey` and `altKey` modifiers to trigger reset
- **useKeyboardShortcuts.test.ts**:
  - Added `onReset` to mock handlers
  - Added test case verifying reset triggers with Cmd+Alt+0 and prevents default

## Details
- Reset clears URL hash/query and reloads to default state
- User confirmation required before reset
- Saved transformers are preserved after reset
- Keyboard shortcut is Cmd/Ctrl + Alt + 0 (zero)
- Reset action accessible from toolbar dropdown menu and keyboard shortcut
