### PR TITLE
feat: Update document title from first markdown heading

### DIFF
--- a/src/components/PoeEditor.tsx
+++ b/src/components/PoeEditor.tsx
@@ -47,9 +47,9 @@ import {
   formatNumberedList,
 } from '@/utils/formatting'
 
-const DEFAULT_CONTENT = `# Welcome to Poe
+const DEFAULT_CONTENT = `# Poe Markdown Editor
 
-A Markdown editor with vim support.
+An online, no-signup, writing tool with Vim support.
 
 ## Features
 
@@ -66,7 +66,7 @@ const editor = "Poe";
 console.log(\`Welcome to \${editor}\`);
 \`\`\`
 
-> Start writing.
+> Start writing
 `
 
 interface PoeEditorProps {

--- a/src/hooks/useUrlState.test.ts
+++ b/src/hooks/useUrlState.test.ts
@@ -89,4 +89,23 @@ describe('useUrlState', () => {
     expect(result.current.content).toBe('Fallback')
     expect(onError).toHaveBeenCalled()
   })
+
+  it('should update document title from first heading', () => {
+    vi.useFakeTimers()
+    const { result } = renderHook(() => useUrlState())
+
+    // Mock compression to return something so updateUrl doesn't fail if it relies on it
+    vi.mocked(compression.compressDocumentToHash).mockReturnValue('hash')
+
+    act(() => {
+      result.current.setContent('# New Title\nContent')
+    })
+
+    act(() => {
+      vi.advanceTimersByTime(500)
+    })
+
+    expect(document.title).toBe('New Title')
+    vi.useRealTimers()
+  })
 })

--- a/src/utils/markdown.test.ts
+++ b/src/utils/markdown.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { renderMarkdown } from './markdown'
+import { renderMarkdown, getFirstHeading } from './markdown'
 
 describe('renderMarkdown', () => {
   it('should render basic markdown', () => {
@@ -26,5 +26,32 @@ describe('renderMarkdown', () => {
     const markdown = '[link](https://example.com)'
     const html = renderMarkdown(markdown)
     expect(html).toContain('<a href="https://example.com">link</a>')
+  })
+})
+
+describe('getFirstHeading', () => {
+  it('should extract h1', () => {
+    expect(getFirstHeading('# Hello World')).toBe('Hello World')
+  })
+
+  it('should extract h2', () => {
+    expect(getFirstHeading('## Subheading')).toBe('Subheading')
+  })
+
+  it('should ignore text before heading', () => {
+    expect(getFirstHeading('Some text\n# Title')).toBe('Title')
+  })
+
+  it('should ignore hashes in code blocks', () => {
+    const md = '```\n# Not a heading\n```\n# Real Heading'
+    expect(getFirstHeading(md)).toBe('Real Heading')
+  })
+
+  it('should return null if no heading', () => {
+    expect(getFirstHeading('Just some text')).toBeNull()
+  })
+
+  it('should handle empty input', () => {
+    expect(getFirstHeading('')).toBeNull()
   })
 })

--- a/src/utils/markdown.ts
+++ b/src/utils/markdown.ts
@@ -16,3 +16,29 @@ export function renderMarkdown(markdown: string): string {
   if (!markdown) return ''
   return md.render(markdown)
 }
+
+/**
+ * Extracts the first heading from markdown text
+ * @param markdown - The markdown text to parse
+ * @returns The text content of the first heading, or null if none found
+ */
+export function getFirstHeading(markdown: string): string | null {
+  if (!markdown) return null
+
+  // Use a fresh instance to avoid side effects or state issues,
+  // though parse() is generally stateless.
+  // We can reuse the exported md instance if we want to share config.
+  const tokens = md.parse(markdown, {})
+
+  for (let i = 0; i < tokens.length; i++) {
+    if (tokens[i].type === 'heading_open') {
+      // The next token should be inline content
+      const nextToken = tokens[i + 1]
+      if (nextToken && nextToken.type === 'inline') {
+        return nextToken.content
+      }
+    }
+  }
+
+  return null
+}

--- a/tests/e2e/editor.spec.ts
+++ b/tests/e2e/editor.spec.ts
@@ -13,9 +13,9 @@ test.describe('Editor Integration', () => {
   })
 
   test('should render editor and preview panes', async ({ page }) => {
-    // Check for "Welcome to Poe" default text in preview (rendered from markdown)
+    // Check for "Poe Markdown Editor" default text in preview (rendered from markdown)
     const preview = page.locator('.markdown-body')
-    await expect(preview).toContainText('Welcome to Poe')
+    await expect(preview).toContainText('Poe Markdown Editor')
   })
 
   test('should apply bold formatting via toolbar', async ({ page }) => {
@@ -35,7 +35,7 @@ test.describe('Editor Integration', () => {
 
     // Verify editor is cleared by checking preview (should be empty or minimal)
     const clearPreview = page.locator('.markdown-body')
-    await expect(clearPreview).not.toContainText('Welcome to Poe')
+    await expect(clearPreview).not.toContainText('Poe Markdown Editor')
 
     // Create new content
     // Editor should still be focused, but click again to be safe

--- a/tests/e2e/new-document-dialog.spec.ts
+++ b/tests/e2e/new-document-dialog.spec.ts
@@ -23,9 +23,9 @@ test.describe('New Document Dialog', () => {
     // Verify dialog disappears
     await expect(page.getByRole('alertdialog')).not.toBeVisible()
 
-    // Verify content is preserved (default content starts with "# Welcome to Poe")
+    // Verify content is preserved (default content starts with "# Poe Markdown Editor")
     const preview = page.locator('.markdown-body')
-    await expect(preview).toContainText('Welcome to Poe')
+    await expect(preview).toContainText('Poe Markdown Editor')
 
     // Try again and confirm
     await page.getByRole('button', { name: /untitled.md/i }).click()
@@ -39,7 +39,7 @@ test.describe('New Document Dialog', () => {
 
     // Verify content is cleared
     // We check that the preview does NOT contain the welcome text anymore
-    await expect(preview).not.toContainText('Welcome to Poe')
+    await expect(preview).not.toContainText('Poe Markdown Editor')
 
     // Check if editor is empty or cleared.
     // Since we can't easily read monaco value, we rely on preview or URL state if we tracked it,


### PR DESCRIPTION
- Add getFirstHeading utility function to extract first heading from markdown
- Update useUrlState hook to sync document title with first heading on content changes
- Initialize document title on component mount
- Update title when hash changes or content is decompressed
- Add comprehensive tests for getFirstHeading utility
- Add test for document title update in useUrlState hook