### PR TITLE
feat(EditorPane): Add auto-continuation for lists and block quotes

### DIFF
--- a/src/components/EditorPane.test.tsx
+++ b/src/components/EditorPane.test.tsx
@@ -30,6 +30,7 @@ vi.mock('@monaco-editor/react', () => ({
         onDidScrollChange: vi.fn(),
         onDidChangeCursorPosition: vi.fn(),
         addCommand: vi.fn(),
+        onKeyDown: vi.fn(),
         getPosition: vi.fn(),
         executeEdits: vi.fn(),
         setPosition: vi.fn(),
@@ -37,7 +38,7 @@ vi.mock('@monaco-editor/react', () => ({
       },
       {
         KeyMod: { CtrlCmd: 2048, Shift: 1024 },
-        KeyCode: { KeyB: 32, KeyI: 39, KeyK: 41, KeyE: 35 },
+        KeyCode: { KeyB: 32, KeyI: 39, KeyK: 41, KeyE: 35, Enter: 13 },
       }
     )
     return <div data-testid="monaco-editor" />

--- a/src/utils/formatting.test.ts
+++ b/src/utils/formatting.test.ts
@@ -379,3 +379,96 @@ describe('formatting utils', () => {
     // Expect no errors
   })
 })
+
+import { getAutoContinueEdit, type AutoContinueResult } from './formatting'
+
+describe('getAutoContinueEdit', () => {
+  it('should return null if no pattern matches', () => {
+    expect(getAutoContinueEdit('Just some text', 15)).toBeNull()
+  })
+
+  it('should return exit action for empty unordered list', () => {
+    const result = getAutoContinueEdit('- ', 3)
+    expect(result).toEqual<AutoContinueResult>({
+      action: 'exit',
+      range: {
+        startColumn: 1,
+        endColumn: 3,
+      },
+    })
+  })
+
+  it('should return exit action for empty ordered list', () => {
+    const result = getAutoContinueEdit('1. ', 4)
+    expect(result).toEqual<AutoContinueResult>({
+      action: 'exit',
+      range: {
+        startColumn: 1,
+        endColumn: 4,
+      },
+    })
+  })
+
+  it('should return exit action for empty quote', () => {
+    const result = getAutoContinueEdit('> ', 3)
+    expect(result).toEqual<AutoContinueResult>({
+      action: 'exit',
+      range: {
+        startColumn: 1,
+        endColumn: 3,
+      },
+    })
+  })
+
+  it('should continue unordered list', () => {
+    const result = getAutoContinueEdit('- Item 1', 9)
+    expect(result).toEqual<AutoContinueResult>({
+      action: 'continue',
+      text: '\n- ',
+      range: {
+        startColumn: 9,
+        endColumn: 9,
+      },
+    })
+  })
+
+  it('should continue unordered list with asterisk', () => {
+    const result = getAutoContinueEdit('* Item 1', 9)
+    expect(result).toEqual<AutoContinueResult>({
+      action: 'continue',
+      text: '\n* ',
+      range: {
+        startColumn: 9,
+        endColumn: 9,
+      },
+    })
+  })
+
+  it('should continue ordered list and increment number', () => {
+    const result = getAutoContinueEdit('1. Item 1', 10)
+    expect(result).toEqual<AutoContinueResult>({
+      action: 'continue',
+      text: '\n2. ',
+      range: {
+        startColumn: 10,
+        endColumn: 10,
+      },
+    })
+  })
+
+  it('should continue quote', () => {
+    const result = getAutoContinueEdit('> Quote me', 11)
+    expect(result).toEqual<AutoContinueResult>({
+      action: 'continue',
+      text: '\n> ',
+      range: {
+        startColumn: 11,
+        endColumn: 11,
+      },
+    })
+  })
+
+  it('should ignore if cursor is before the prefix', () => {
+    expect(getAutoContinueEdit('- Item 1', 2)).toBeNull()
+  })
+})


### PR DESCRIPTION
- Implement automatic list item continuation for unordered, ordered, and quoted blocks
- Add smart indentation preservation when pressing Enter within markdown lists
- Exit list/quote context when pressing Enter on empty list/quote line
- Increment ordered list numbers automatically on new lines