### PR TITLE
feat(editor): Add layout toggle functionality for split view management

### DIFF
--- a/src/components/EditorPane.tsx
+++ b/src/components/EditorPane.tsx
@@ -10,7 +10,7 @@ import {
 import Editor, { type OnMount } from '@monaco-editor/react'
 import type { editor } from 'monaco-editor'
 import { initVimMode, VimMode, type VimMode as VimAdapter } from 'monaco-vim'
-import { Copy, Check } from 'lucide-react'
+import { Copy, Check, Maximize2, Minimize2 } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import { toast } from 'sonner'
@@ -170,6 +170,8 @@ interface EditorPaneProps {
   vimMode?: boolean
   scrollRef?: RefObject<HTMLElement | null>
   showWordCount?: boolean
+  viewMode?: 'editor' | 'preview' | 'split'
+  onToggleLayout?: () => void
 }
 
 /**
@@ -219,6 +221,8 @@ export const EditorPane = forwardRef<EditorPaneHandle, EditorPaneProps>(
       vimMode,
       scrollRef,
       showWordCount,
+      viewMode,
+      onToggleLayout,
     },
     ref
   ) => {
@@ -494,25 +498,50 @@ export const EditorPane = forwardRef<EditorPaneHandle, EditorPaneProps>(
       <div className="relative h-full group bg-background flex flex-col overflow-hidden rounded-lg border border-border">
         <div className="flex-1 min-h-0">
           <div className="relative h-full">
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <Button
-                  variant="ghost"
-                  size="icon-sm"
-                  onClick={handleCopy}
-                  className="absolute top-4 right-4 z-10 h-8 w-8 bg-muted/80 backdrop-blur hover:bg-muted border border-border opacity-0 group-hover:opacity-100 transition-opacity text-foreground"
-                >
-                  {copied ? (
-                    <Check className="h-4 w-4 text-green-600" />
-                  ) : (
-                    <Copy className="h-4 w-4" />
-                  )}
-                </Button>
-              </TooltipTrigger>
-              <TooltipContent side="left">
-                <p className="text-xs">Copy markdown</p>
-              </TooltipContent>
-            </Tooltip>
+            <div className="absolute top-4 right-4 z-10 flex items-center gap-1 opacity-0 group-hover:opacity-100 transition-opacity">
+              {onToggleLayout && viewMode && (
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <Button
+                      variant="ghost"
+                      size="icon-sm"
+                      onClick={onToggleLayout}
+                      className="h-8 w-8 bg-muted/80 backdrop-blur hover:bg-muted border border-border text-foreground"
+                    >
+                      {viewMode === 'split' ? (
+                        <Maximize2 className="h-4 w-4" />
+                      ) : (
+                        <Minimize2 className="h-4 w-4" />
+                      )}
+                    </Button>
+                  </TooltipTrigger>
+                  <TooltipContent side="bottom">
+                    <p className="text-xs">
+                      {viewMode === 'split' ? 'Expand Editor' : 'Restore Split View'}
+                    </p>
+                  </TooltipContent>
+                </Tooltip>
+              )}
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <Button
+                    variant="ghost"
+                    size="icon-sm"
+                    onClick={handleCopy}
+                    className="h-8 w-8 bg-muted/80 backdrop-blur hover:bg-muted border border-border text-foreground"
+                  >
+                    {copied ? (
+                      <Check className="h-4 w-4 text-green-600" />
+                    ) : (
+                      <Copy className="h-4 w-4" />
+                    )}
+                  </Button>
+                </TooltipTrigger>
+                <TooltipContent side="bottom">
+                  <p className="text-xs">Copy Markdown</p>
+                </TooltipContent>
+              </Tooltip>
+            </div>
             <Editor
               height="100%"
               language="markdown"

--- a/src/components/PreviewPane.tsx
+++ b/src/components/PreviewPane.tsx
@@ -1,6 +1,6 @@
 import 'github-markdown-css/github-markdown.css'
 import { useState, type ReactElement, forwardRef } from 'react'
-import { Copy, Check } from 'lucide-react'
+import { Copy, Check, Maximize2, Minimize2 } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import { toast } from 'sonner'
@@ -8,6 +8,8 @@ import { copyToClipboard, stripHtml } from '@/utils/clipboard'
 
 interface PreviewPaneProps {
   htmlContent: string
+  viewMode?: 'editor' | 'preview' | 'split'
+  onToggleLayout?: () => void
 }
 
 /**
@@ -15,7 +17,7 @@ interface PreviewPaneProps {
  * Displays styled HTML with GitHub markdown styles and copy-to-clipboard functionality.
  */
 export const PreviewPane = forwardRef<HTMLDivElement, PreviewPaneProps>(
-  ({ htmlContent }, ref): ReactElement => {
+  ({ htmlContent, viewMode, onToggleLayout }, ref): ReactElement => {
     const [copied, setCopied] = useState(false)
 
     const handleCopy = async (): Promise<void> => {
@@ -34,25 +36,52 @@ export const PreviewPane = forwardRef<HTMLDivElement, PreviewPaneProps>(
     return (
       <div ref={ref} className="h-full overflow-auto">
         <div className="relative group markdown-body p-6 pt-0 bg-transparent h-full">
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <Button
-                variant="ghost"
-                size="icon-sm"
-                onClick={handleCopy}
-                className="absolute top-4 right-4 z-10 h-8 w-8 bg-muted/80 backdrop-blur hover:bg-muted border border-border opacity-0 group-hover:opacity-100 transition-opacity"
-              >
-                {copied ? (
-                  <Check className="h-4 w-4 text-green-600" />
-                ) : (
-                  <Copy className="h-4 w-4" />
-                )}
-              </Button>
-            </TooltipTrigger>
-            <TooltipContent side="left">
-              <p className="text-xs">Copy rich text</p>
-            </TooltipContent>
-          </Tooltip>
+          <div className="absolute top-4 right-4 z-10 flex items-center gap-1 opacity-0 group-hover:opacity-100 transition-opacity">
+            {onToggleLayout && viewMode && (
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <Button
+                    variant="ghost"
+                    size="icon-sm"
+                    onClick={onToggleLayout}
+                    className="h-8 w-8 bg-muted/80 backdrop-blur hover:bg-muted border border-border"
+                  >
+                    {viewMode === 'split' ? (
+                      <Maximize2 className="h-4 w-4" />
+                    ) : (
+                      <Minimize2 className="h-4 w-4" />
+                    )}
+                  </Button>
+                </TooltipTrigger>
+                <TooltipContent side="bottom">
+                  <p className="text-xs">
+                    {viewMode === 'split' ? 'Expand Preview' : 'Restore Split View'}
+                  </p>
+                </TooltipContent>
+              </Tooltip>
+            )}
+
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Button
+                  variant="ghost"
+                  size="icon-sm"
+                  onClick={handleCopy}
+                  className="h-8 w-8 bg-muted/80 backdrop-blur hover:bg-muted border border-border"
+                >
+                  {copied ? (
+                    <Check className="h-4 w-4 text-green-600" />
+                  ) : (
+                    <Copy className="h-4 w-4" />
+                  )}
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent side="bottom">
+                <p className="text-xs">Copy Rich Text</p>
+              </TooltipContent>
+            </Tooltip>
+          </div>
+
           <div dangerouslySetInnerHTML={{ __html: htmlContent }} />
         </div>
       </div>

--- a/src/hooks/useUrlState.test.ts
+++ b/src/hooks/useUrlState.test.ts
@@ -155,4 +155,32 @@ describe('useUrlState', () => {
     vi.useRealTimers()
     querySelectorSpy.mockRestore()
   })
+  it('should preserve query parameters when updating hash', () => {
+    vi.useFakeTimers()
+    const { result } = renderHook(() => useUrlState())
+
+    // Simulate existing query params
+    const baseUrl = 'http://localhost/?foo=bar'
+    Object.defineProperty(window, 'location', {
+      value: new URL(baseUrl),
+      writable: true,
+    })
+
+    // Mock history.replaceState to verify the URL being passed
+    const replaceStateSpy = vi.spyOn(window.history, 'replaceState')
+
+    act(() => {
+      result.current.setContent('New Content')
+    })
+
+    act(() => {
+      vi.advanceTimersByTime(500)
+    })
+
+    // Check if the URL passed to replaceState contains the query param
+    const lastCall = replaceStateSpy.mock.calls[replaceStateSpy.mock.calls.length - 1]
+    expect(lastCall[2]).toContain('?foo=bar')
+
+    vi.useRealTimers()
+  })
 })

--- a/src/hooks/useUrlState.ts
+++ b/src/hooks/useUrlState.ts
@@ -184,7 +184,17 @@ export function useUrlState(options?: UseUrlStateOptions): UseUrlStateReturn {
 
       // Update URL regardless of length (allow users to continue editing)
       const newHash = compressed ? `#${compressed}` : ''
-      window.history.replaceState(null, '', newHash)
+
+      // Preserve existing query parameters
+      const currentUrl = new URL(window.location.href)
+      currentUrl.hash = newHash
+
+      // We use replaceState to update the URL without adding a new history entry for every keystroke
+      // but we need to make sure we don't lose the query params
+      // Use relative path (search + hash) to avoid SecurityError in some environments
+      // and to ensure we stay on the same page.
+      const relativePath = currentUrl.search + currentUrl.hash
+      window.history.replaceState(null, '', relativePath)
     }, debounceMs)
   }, [debounceMs, maxLength, onLengthWarning])
 

--- a/src/hooks/useViewMode.test.ts
+++ b/src/hooks/useViewMode.test.ts
@@ -1,0 +1,109 @@
+import { renderHook, act } from '@testing-library/react'
+import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest'
+import { useViewMode } from './useViewMode'
+
+describe('useViewMode', () => {
+  let originalLocation: Location
+
+  beforeEach(() => {
+    // Mock window.location
+    originalLocation = window.location
+    const mockLocation = new URL('http://localhost/') as unknown as Location
+    // Need to allow assignment
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      writable: true,
+      value: mockLocation,
+    })
+
+    // Mock history.replaceState
+    window.history.replaceState = vi.fn()
+  })
+
+  afterEach(() => {
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      writable: true, // Make sure to restore writability if needed
+      value: originalLocation,
+    })
+    vi.restoreAllMocks()
+  })
+
+  it('should initialize with default split mode', () => {
+    const { result } = renderHook(() => useViewMode())
+    expect(result.current.viewMode).toBe('split')
+  })
+
+  it('should initialize from URL query param', () => {
+    window.location.search = '?view=editor'
+    const { result } = renderHook(() => useViewMode())
+    expect(result.current.viewMode).toBe('editor')
+  })
+
+  it('should default to split if param is invalid', () => {
+    window.location.search = '?view=invalid'
+    const { result } = renderHook(() => useViewMode())
+    expect(result.current.viewMode).toBe('split')
+  })
+
+  it('should update state and URL when setting mode', () => {
+    const { result } = renderHook(() => useViewMode())
+
+    act(() => {
+      result.current.setViewMode('preview')
+    })
+
+    expect(result.current.viewMode).toBe('preview')
+
+    // Check replaceState call
+    const replaceStateSpy = vi.spyOn(window.history, 'replaceState')
+    const calls = replaceStateSpy.mock.calls
+    const lastCall = calls[calls.length - 1]
+    // Expect 'http://localhost/?view=preview'
+    expect(lastCall[2]).toContain('view=preview')
+  })
+
+  it('should remove query param when setting to split', () => {
+    window.location.search = '?view=editor'
+    const { result } = renderHook(() => useViewMode())
+
+    act(() => {
+      result.current.setViewMode('split')
+    })
+
+    expect(result.current.viewMode).toBe('split')
+
+    const replaceStateSpy = vi.spyOn(window.history, 'replaceState')
+    const calls = replaceStateSpy.mock.calls
+    const lastCall = calls[calls.length - 1]
+    expect(lastCall[2]).not.toContain('view=')
+  })
+
+  it('should preserve other query params', () => {
+    // Setup initial URL with other params
+    // Note: setting window.location per test in beforeEach setup,
+    // effectively we need to set search on the mock object.
+    // Assuming the mock setup allows setting search.
+    // The URL object's search property is read-only in some envs but writable in JSDOM usually via setter
+
+    // Let's rely on constructing the URL in setup.
+    // Re-mock for this specific test to include other params
+    const url = new URL('http://localhost/?other=123&view=editor')
+    Object.defineProperty(window, 'location', {
+      value: url,
+      writable: true,
+    })
+
+    const { result } = renderHook(() => useViewMode())
+    expect(result.current.viewMode).toBe('editor')
+
+    act(() => {
+      result.current.setViewMode('preview')
+    })
+
+    const replaceStateSpy = vi.spyOn(window.history, 'replaceState')
+    const lastCallArgs = replaceStateSpy.mock.lastCall
+    expect(lastCallArgs?.[2]).toContain('other=123')
+    expect(lastCallArgs?.[2]).toContain('view=preview')
+  })
+})

--- a/src/hooks/useViewMode.ts
+++ b/src/hooks/useViewMode.ts
@@ -1,0 +1,52 @@
+import { useState, useCallback } from 'react'
+
+export type ViewMode = 'editor' | 'preview' | 'split'
+
+interface UseViewModeReturn {
+  viewMode: ViewMode
+  setViewMode: (mode: ViewMode) => void
+}
+
+/**
+ * Manages the editor view mode state, synchronized with the URL query parameter 'view'.
+ * @returns Object containing viewMode state and setter
+ */
+export function useViewMode(): UseViewModeReturn {
+  const [viewMode, setViewModeState] = useState<ViewMode>(() => {
+    if (typeof window === 'undefined') return 'split'
+    const params = new URLSearchParams(window.location.search)
+    const view = params.get('view')
+    if (view === 'editor' || view === 'preview' || view === 'split') {
+      return view
+    }
+    return 'split'
+  })
+
+  // Sync state changes to URL
+  const setViewMode = useCallback((mode: ViewMode) => {
+    setViewModeState(mode)
+
+    const url = new URL(window.location.href)
+    if (mode === 'split') {
+      url.searchParams.delete('view')
+    } else {
+      url.searchParams.set('view', mode)
+    }
+
+    // Use replaceState to avoid cluttering history stack with view toggles if desired
+    // Or pushState if back button should revert view.
+    // Given the user request "toggle between preview and editor mode and persist in URL",
+    // replacing state feels smoother for layout changes, but pushState is better for "navigation"
+    // Let's stick with replaceState to match existing behavior of "app state" unless requested otherwise.
+    window.history.replaceState(null, '', url.toString())
+  }, [])
+
+  // Listen for external URL changes (e.g. popstate) if we want to support back button navigation for view changes
+  // converting this to pushState would require handling popstate here.
+  // For now, simple sync on mount and manual updates.
+
+  return {
+    viewMode,
+    setViewMode,
+  }
+}


### PR DESCRIPTION
Users can now toggle between split view, fullscreen editor, and fullscreen preview on desktop, with the layout preference persisted in the URL.

- Click the expand/collapse button in the editor or preview pane to toggle between split view and fullscreen modes.
- The selected view mode is saved as a `view` query parameter and restored when revisiting the page.
- Mobile tab behavior remains unchanged; the new layout controls appear only on desktop.
- Copy buttons in both panes now use consistent tooltip positioning.
- URL query parameters are preserved when toggling layout modes.

The new `useViewMode` hook manages view state synchronization with the URL, and `handleToggleEditor`/`handleTogglePreview` callbacks allow the panes to request layout changes.
