### PR TITLE
feat(editor): Add line numbers toggle and JSON pipeline editing mode

### DIFF
--- a/src/components/EditorPane.tsx
+++ b/src/components/EditorPane.tsx
@@ -175,6 +175,7 @@ interface EditorPaneProps {
   onCodeBlock?: () => void
   vimMode?: boolean
   showWordCount?: boolean
+  showLineNumbers?: boolean
   viewMode?: 'editor' | 'preview' | 'split'
   onToggleLayout?: () => void
 }
@@ -235,6 +236,7 @@ export const EditorPane = forwardRef<EditorPaneHandle, EditorPaneProps>(
       onCodeBlock,
       vimMode,
       showWordCount,
+      showLineNumbers,
       viewMode,
       onToggleLayout,
     },
@@ -545,7 +547,7 @@ export const EditorPane = forwardRef<EditorPaneHandle, EditorPaneProps>(
               options={{
                 wordWrap: 'on',
                 minimap: { enabled: false },
-                lineNumbers: 'on',
+                lineNumbers: showLineNumbers ?? true ? 'on' : 'off',
                 fontSize: 14,
                 lineHeight: 22,
                 fontFamily:

--- a/src/components/EditorPane.tsx
+++ b/src/components/EditorPane.tsx
@@ -563,6 +563,9 @@ export const EditorPane = forwardRef<EditorPaneHandle, EditorPaneProps>(
                 renderLineHighlight: 'line',
                 cursorBlinking: 'smooth',
                 smoothScrolling: false, // Explicitly disable smooth scrolling for sync
+                unicodeHighlight: {
+                  ambiguousCharacters: false,
+                },
               }}
             />
           </div>

--- a/src/components/EditorPane.tsx
+++ b/src/components/EditorPane.tsx
@@ -547,7 +547,7 @@ export const EditorPane = forwardRef<EditorPaneHandle, EditorPaneProps>(
               options={{
                 wordWrap: 'on',
                 minimap: { enabled: false },
-                lineNumbers: showLineNumbers ?? true ? 'on' : 'off',
+                lineNumbers: (showLineNumbers ?? true) ? 'on' : 'off',
                 fontSize: 14,
                 lineHeight: 22,
                 fontFamily:

--- a/src/components/EditorToolbar.tsx
+++ b/src/components/EditorToolbar.tsx
@@ -78,6 +78,7 @@ import {
   ArrowRightLeft,
   RotateCcw,
   WholeWord,
+  Hash,
 } from 'lucide-react'
 import { ICON_MAP } from '@/components/transformer/constants'
 import { cn } from '@/utils/classnames'
@@ -265,6 +266,8 @@ interface EditorToolbarProps {
   onReset?: () => void
   showWordCount?: boolean
   toggleWordCount?: () => void
+  showLineNumbers?: boolean
+  toggleLineNumbers?: () => void
 }
 
 /**
@@ -308,6 +311,8 @@ export function EditorToolbar({
   onReset,
   showWordCount,
   toggleWordCount,
+  showLineNumbers,
+  toggleLineNumbers,
 }: EditorToolbarProps): ReactElement {
   const [isConfirmingClear, setIsConfirmingClear] = useState(false)
   const [pipelineToDelete, setPipelineToDelete] = useState<TransformationPipeline | null>(null)
@@ -632,6 +637,10 @@ export function EditorToolbar({
             <DropdownMenuItem onClick={toggleWordCount}>
               <WholeWord className="size-4" />
               {showWordCount ? 'Hide Word Count' : 'Show Word Count'}
+            </DropdownMenuItem>
+            <DropdownMenuItem onClick={toggleLineNumbers}>
+              <Hash className="size-4" />
+              {showLineNumbers ? 'Hide Line Numbers' : 'Show Line Numbers'}
             </DropdownMenuItem>
             <DropdownMenuItem onClick={onOpenImportExport}>
               <ArrowRightLeft className="size-4" />

--- a/src/components/PoeEditor.tsx
+++ b/src/components/PoeEditor.tsx
@@ -424,6 +424,7 @@ ${htmlContent}
         onApply={handleApplyPipeline}
         editPipeline={editingPipeline}
         initialPreviewText={selectedText}
+        vimMode={vimModeEnabled}
       />
 
       <TransformerImportExportDialog

--- a/src/components/PoeEditor.tsx
+++ b/src/components/PoeEditor.tsx
@@ -5,6 +5,7 @@ import { useUrlState } from '@/hooks/useUrlState'
 import { useViewMode } from '@/hooks/useViewMode'
 import { useVimMode } from '@/hooks/useVimMode'
 import { useWordCount } from '@/hooks/useWordCount'
+import { useLineNumbers } from '@/hooks/useLineNumbers'
 import { useKeyboardShortcuts } from '@/hooks/useKeyboardShortcuts'
 import { useSyncScroll } from '@/hooks/useSyncScroll'
 import { useTransformers } from '@/hooks/useTransformers'
@@ -144,6 +145,9 @@ export function PoeEditor({ onReady }: PoeEditorProps): ReactElement {
 
   // Word count management
   const { showWordCount, toggleWordCount } = useWordCount()
+
+  // Line numbers management
+  const { showLineNumbers, toggleLineNumbers } = useLineNumbers()
 
   // Transformers management
   const { pipelines, addPipeline, updatePipeline, removePipeline, replacePipelines } =
@@ -495,6 +499,8 @@ ${htmlContent}
           onReset={() => setShowResetConfirm(true)}
           showWordCount={showWordCount}
           toggleWordCount={toggleWordCount}
+          showLineNumbers={showLineNumbers}
+          toggleLineNumbers={toggleLineNumbers}
         />
 
         <AlertDialog open={showResetConfirm} onOpenChange={setShowResetConfirm}>
@@ -544,6 +550,7 @@ ${htmlContent}
                           onCodeBlock={handleFormatCodeBlock}
                           vimMode={vimModeEnabled}
                           showWordCount={showWordCount}
+                          showLineNumbers={showLineNumbers}
                           viewMode={viewMode}
                           onToggleLayout={handleToggleEditor}
                         />
@@ -606,6 +613,7 @@ ${htmlContent}
                   onCodeBlock={handleFormatCodeBlock}
                   vimMode={vimModeEnabled}
                   showWordCount={showWordCount}
+                  showLineNumbers={showLineNumbers}
                   viewMode={activeTab === 'editor' ? 'editor' : 'preview'}
                 />
               </div>

--- a/src/components/transformer/TransformerWorkbench.tsx
+++ b/src/components/transformer/TransformerWorkbench.tsx
@@ -1,18 +1,30 @@
-import { type ReactElement } from 'react'
-import { Plus, Sparkles } from 'lucide-react'
+import { type ReactElement, useState, useRef, useEffect } from 'react'
+import { Plus, Sparkles, Code, FileJson, AlertTriangle } from 'lucide-react'
 import { useDroppable } from '@dnd-kit/core'
 import { SortableContext, verticalListSortingStrategy } from '@dnd-kit/sortable'
+import Editor, { type OnMount } from '@monaco-editor/react'
+import type { editor } from 'monaco-editor'
+import { useTheme } from 'next-themes'
+import { initVimMode, type VimMode as VimAdapter } from 'monaco-vim'
 import { TransformerStep } from './TransformerStep'
 import { ScrollArea } from '@/components/ui/scroll-area'
+import { Button } from '@/components/ui/button'
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import type { PipelineStep, TransformerOperation } from './types'
+import { PipelineStepsArraySchema } from './toolbarSchema'
+import { cn } from '@/utils/classnames'
+import { toast } from 'sonner'
+import { z } from 'zod'
 
 interface TransformerWorkbenchProps {
   steps: PipelineStep[]
+  onSetSteps?: (steps: PipelineStep[]) => void
   onUpdateStep: (id: string, config: Record<string, unknown>) => void
   onRemoveStep: (id: string) => void
   onToggleStep: (id: string) => void
-  onAddOperation: (operation: TransformerOperation) => void
+  onAddOperation?: (operation: TransformerOperation) => void
   onAddRequest?: () => void
+  vimMode?: boolean
 }
 
 /**
@@ -22,18 +34,327 @@ interface TransformerWorkbenchProps {
  */
 export function TransformerWorkbench({
   steps,
+  onSetSteps,
   onUpdateStep,
   onRemoveStep,
   onToggleStep,
   onAddRequest,
+  vimMode,
 }: TransformerWorkbenchProps): ReactElement {
+  const { resolvedTheme } = useTheme()
+  const [mode, setMode] = useState<'gui' | 'json'>('gui')
+  const [jsonValue, setJsonValue] = useState('')
+  const [isValidJson, setIsValidJson] = useState(true)
+  const [validationError, setValidationError] = useState<string | null>(null)
+
+  const editorRef = useRef<editor.IStandaloneCodeEditor | null>(null)
+  const vimInstanceRef = useRef<VimAdapter | null>(null)
+  const statusBarRef = useRef<HTMLDivElement | null>(null)
+
   const { setNodeRef, isOver } = useDroppable({
     id: 'workbench-container',
+    // Enable drop in JSON mode too so we can detect when an item is dropped
+    disabled: false,
   })
+
+  // Track previous steps to detect additions
+  const prevStepsRef = useRef<PipelineStep[]>(steps)
+  const cursorPositionRef = useRef<number>(0) // Track line number
+
+  // Sync steps to JSON when opening JSON mode or when steps change while in JSON mode (optional, but good for keeping sync)
+  useEffect(() => {
+    if (mode === 'gui') {
+      setJsonValue(JSON.stringify(steps, null, 2))
+      setIsValidJson(true)
+      setValidationError(null)
+    } else {
+      // In JSON mode, if steps changed, it might be due to an add operation from the toolbox
+      const prevSteps = prevStepsRef.current
+      if (steps.length > prevSteps.length) {
+        // Find added steps
+        const addedSteps = steps.filter((s) => !prevSteps.find((p) => p.id === s.id))
+
+        if (addedSteps.length > 0) {
+          let newJsonValue = jsonValue
+
+          try {
+            // Try to parse current JSON
+            const currentContent = jsonValue.trim()
+            let stepsArray: unknown[] = []
+
+            if (currentContent && isValidJson) {
+              stepsArray = JSON.parse(currentContent)
+              if (!Array.isArray(stepsArray)) {
+                throw new Error('Not an array')
+              }
+
+              // Determine insertion index based on cursor line
+              // We need to find which object in the array the cursor is over or after
+              // This is a bit tricky with just JSON.parse.
+              // We can estimate by looking at the JSON string structure or just use the end if not sure.
+              // A simple heuristic: find the index of the object that ends before the cursor line
+
+              const cursorLine = cursorPositionRef.current
+
+              // Re-serialize to find line numbers of items (approximate)
+              // This is expensive but accurate enough for small pipelines
+              // Or better: we can't easily map lines to array indices without AST.
+              // Let's use a simpler approach:
+              // If we are adding 1 item, find where to put it.
+
+              let insertIndex = stepsArray.length // Default to end
+
+              if (cursorLine > 0 && editorRef.current) {
+                // Get the model to find offsets
+                const model = editorRef.current.getModel()
+                if (model) {
+                  const cursorOffset = model.getOffsetAt({ lineNumber: cursorLine, column: 1 })
+
+                  // Find the array item that starts after this offset
+                  // We need to tokenize or regex find the start of objects.
+                  // Let's try to match `{` at top level.
+                  // This is getting complex for a simple JSON editor.
+
+                  // Simplified approach:
+                  // 1. Split by `},` to approximate items? No, fragile.
+                  // 2. Just count how many `{` at depth 1 are before the cursor?
+
+                  // Refined logic: itemsPassed is "number of closed items before cursor".
+                  // So if we are after item 0 (closed) and before item 1, index is 1.
+                  // insertIndex = itemsPassed
+                  // User wants to insert *after* cursor's containing block or position.
+                  // So we count how many items have *started* before cursor.
+
+                  let depth = 0
+                  let itemsStarted = 0
+                  let inString = false
+                  let escape = false
+
+                  for (let i = 0; i < cursorOffset && i < currentContent.length; i++) {
+                    const char = currentContent[i]
+
+                    if (escape) {
+                      escape = false
+                      continue
+                    }
+
+                    if (char === '\\') {
+                      escape = true
+                      continue
+                    }
+
+                    if (char === '"') {
+                      inString = !inString
+                      continue
+                    }
+
+                    if (!inString) {
+                      if (char === '{') {
+                        if (depth === 1) {
+                          // Starting a top level item
+                          itemsStarted++
+                        }
+                        depth++
+                      } else if (char === '}') {
+                        depth--
+                      } else if (char === '[') {
+                        depth++
+                      } else if (char === ']') {
+                        depth--
+                      }
+                    }
+                  }
+
+                  insertIndex = itemsStarted
+
+                  // Special check: are we inside the last item but it's not closed?
+                  // Then itemsPassed is length-1. We should insert at length (after).
+                  // Actually if we are inside, we probably shouldn't break the JSON.
+                  // But we are reconstructing the array, so we just decide the order.
+
+                  // If cursor is at start `[ | {`, itemsPassed = 0. Insert at 0. Correct.
+                  // If cursor is `[ {}, | {} ]`, itemsPassed = 1. Insert at 1. Correct.
+                  // If cursor is `[ {}, {} | ]`, itemsPassed = 2. Insert at 2. Correct.
+                }
+              }
+
+              // Ensure index is within bounds
+              if (insertIndex < 0) insertIndex = 0
+              if (insertIndex > stepsArray.length) insertIndex = stepsArray.length
+
+              // Insert
+              stepsArray.splice(insertIndex, 0, ...addedSteps)
+
+              newJsonValue = JSON.stringify(stepsArray, null, 2)
+              setIsValidJson(true)
+              setValidationError(null)
+            } else if (!currentContent) {
+              // Empty content
+              stepsArray = []
+              stepsArray.push(...addedSteps)
+              newJsonValue = JSON.stringify(stepsArray, null, 2)
+            } else {
+              throw new Error('Invalid JSON')
+            }
+          } catch {
+            // Fallback for invalid JSON: Insert at cursor position directly as string
+            const addedJson = addedSteps.map((s) => JSON.stringify(s, null, 2)).join(',\n')
+            const cursorLine = cursorPositionRef.current
+
+            if (cursorLine > 0 && editorRef.current) {
+              const model = editorRef.current.getModel()
+              if (model) {
+                const cursorOffset = model.getOffsetAt({ lineNumber: cursorLine, column: 1 })
+
+                const prefix = jsonValue.substring(0, cursorOffset)
+                const suffix = jsonValue.substring(cursorOffset)
+
+                // Best effort comma handling
+                const needsCommaBefore =
+                  prefix.trim().endsWith('}') ||
+                  prefix.trim().endsWith(']') ||
+                  prefix.trim().endsWith('"')
+                const needsCommaAfter =
+                  suffix.trim().startsWith('{') || suffix.trim().startsWith('"')
+
+                newJsonValue = `${prefix}${needsCommaBefore ? ',' : ''}\n${addedJson}${needsCommaAfter ? ',' : ''}\n${suffix}`
+                setJsonValue(newJsonValue)
+                return // Early return to avoid overwritting
+              }
+            }
+
+            // Fallback to append if no cursor info or update failed
+            // Simple heuristic to try to insert before the last closing bracket if it looks like an array
+            const trimmed = jsonValue.trim()
+            if (trimmed.endsWith(']')) {
+              const lastBracketIndex = jsonValue.lastIndexOf(']')
+              const prefix = jsonValue.substring(0, lastBracketIndex)
+              const suffix = jsonValue.substring(lastBracketIndex)
+
+              // Add comma if there seems to be content before
+              const needsComma =
+                prefix.trim().endsWith('}') ||
+                prefix.trim().endsWith(']') ||
+                prefix.trim().endsWith('"') ||
+                prefix.trim().match(/\d$/)
+
+              newJsonValue = `${prefix}${needsComma ? ',' : ''}\n${addedJson}\n${suffix}`
+            } else {
+              // Just append
+              newJsonValue = `${jsonValue}\n${addedJson}`
+            }
+          }
+
+          setJsonValue(newJsonValue)
+        }
+      }
+    }
+
+    // Update ref
+    prevStepsRef.current = steps
+  }, [steps, mode, isValidJson, jsonValue])
+
+  // Handle vim mode initialization on mode/prop change
+  useEffect(() => {
+    // Initialize Vim mode
+    const initVim = () => {
+      if (
+        mode !== 'json' ||
+        !vimMode ||
+        !editorRef.current ||
+        !statusBarRef.current ||
+        vimInstanceRef.current
+      ) {
+        return
+      }
+
+      try {
+        vimInstanceRef.current = initVimMode(editorRef.current, statusBarRef.current)
+      } catch {
+        // Silently handle vim initialization errors
+      }
+    }
+
+    if (mode === 'json' && vimMode) {
+      // Small delay to ensure status bar is rendered
+      const timer = setTimeout(initVim, 0)
+      return () => clearTimeout(timer)
+    }
+
+    // Cleanup
+    if (vimInstanceRef.current) {
+      vimInstanceRef.current.dispose()
+      vimInstanceRef.current = null
+    }
+  }, [mode, vimMode])
+
+  const handleModeToggle = () => {
+    if (mode === 'gui') {
+      // Switching to JSON
+      setJsonValue(JSON.stringify(steps, null, 2))
+      setMode('json')
+    } else {
+      // Switching to GUI
+      if (!isValidJson) {
+        toast.error('Cannot switch to GUI mode with invalid JSON')
+        return
+      }
+
+      try {
+        const parsed = JSON.parse(jsonValue)
+        const validated = PipelineStepsArraySchema.parse(parsed)
+
+        if (onSetSteps) {
+          onSetSteps(validated)
+          setMode('gui')
+        }
+      } catch (error) {
+        if (error instanceof z.ZodError) {
+          const message = `Validation error: ${error.issues.map((i) => i.message).join(', ')}`
+          setValidationError(message)
+          toast.error(message)
+        } else {
+          setValidationError('Invalid JSON format')
+          toast.error('Invalid JSON format')
+        }
+        setIsValidJson(false)
+      }
+    }
+  }
+
+  const handleEditorDidMount: OnMount = (editor) => {
+    editorRef.current = editor
+
+    // Track cursor position
+    editor.onDidChangeCursorPosition((e) => {
+      cursorPositionRef.current = e.position.lineNumber
+    })
+  }
+
+  const handleJsonChange = (value: string | undefined) => {
+    const newValue = value || ''
+    setJsonValue(newValue)
+
+    try {
+      const parsed = JSON.parse(newValue)
+      const result = PipelineStepsArraySchema.safeParse(parsed)
+
+      if (result.success) {
+        setIsValidJson(true)
+        setValidationError(null)
+      } else {
+        setIsValidJson(false)
+        setValidationError('Schema validation failed')
+      }
+    } catch {
+      setIsValidJson(false)
+      setValidationError('Invalid JSON syntax')
+    }
+  }
 
   return (
     <div className="flex flex-col h-full bg-muted/5 relative">
-      <div className="p-4 border-b bg-background flex justify-between items-center">
+      <div className="p-4 border-b bg-background flex justify-between items-center shrink-0">
         <h3 className="font-semibold text-sm text-muted-foreground uppercase tracking-wide flex items-center gap-2">
           <Sparkles className="w-4 h-4 text-primary" />
           Pipeline
@@ -41,67 +362,155 @@ export function TransformerWorkbench({
             {steps.length} steps
           </span>
         </h3>
+
+        {onSetSteps && (
+          <div className="flex items-center">
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <div className="inline-block">
+                  {' '}
+                  {/* Wrapper to allow tooltip on 'disabled' style button */}
+                  <Button
+                    variant="ghost"
+                    size="icon-sm"
+                    onClick={handleModeToggle}
+                    className={cn(
+                      'h-8 w-8',
+                      mode === 'json'
+                        ? !isValidJson
+                          ? 'bg-destructive/10 text-destructive hover:bg-destructive/20'
+                          : 'bg-primary/10 text-primary hover:bg-primary/20'
+                        : 'text-muted-foreground'
+                    )}
+                  >
+                    {mode === 'gui' ? (
+                      <FileJson className="w-4 h-4" />
+                    ) : (
+                      <Code className="w-4 h-4" />
+                    )}
+                  </Button>
+                </div>
+              </TooltipTrigger>
+              <TooltipContent>
+                {mode === 'gui'
+                  ? 'Edit as JSON'
+                  : !isValidJson
+                    ? 'Fix schema errors to switch view'
+                    : 'Switch to GUI'}
+              </TooltipContent>
+            </Tooltip>
+          </div>
+        )}
       </div>
 
-      <ScrollArea className="flex-1">
+      {mode === 'json' ? (
         <div
           ref={setNodeRef}
-          className={`p-4 flex flex-col gap-3 min-h-[500px] transition-colors ${
-            isOver ? 'bg-primary/5' : ''
-          }`}
+          className={cn(
+            'flex-1 relative min-h-0 flex flex-col transition-colors',
+            isOver && 'bg-primary/5 ring-2 ring-primary/20 ring-inset'
+          )}
         >
-          {steps.length === 0 ? (
-            <div
-              className={
-                onAddRequest
-                  ? 'flex-1 flex flex-col items-center justify-center border-2 border-dashed border-muted-foreground/20 rounded-xl m-4 text-center p-8 transition-colors hover:border-primary/40 hover:bg-primary/5 cursor-pointer'
-                  : 'flex-1 flex flex-col items-center justify-center border-2 border-dashed border-muted-foreground/20 rounded-xl m-4 text-center p-8 transition-colors hover:border-primary/40 hover:bg-primary/5'
-              }
-              onClick={onAddRequest}
-            >
-              <div className="w-12 h-12 rounded-full bg-muted flex items-center justify-center mb-4">
-                <Plus className="w-6 h-6 text-muted-foreground" />
-              </div>
-              <h4 className="font-medium text-foreground mb-1">Build your pipeline</h4>
-              <p className="text-sm text-muted-foreground max-w-[200px]">
-                {onAddRequest
-                  ? 'Tap here to add your first step.'
-                  : 'Drag items from the toolbox on the left to start building.'}
-              </p>
-            </div>
-          ) : (
-            <SortableContext items={steps} strategy={verticalListSortingStrategy}>
-              {steps.map((step, index) => (
-                <div key={step.id} className="relative">
-                  {/* Connector Line */}
-                  {index < steps.length - 1 && (
-                    <div className="absolute left-6 top-full h-3 w-0.5 bg-border -ml-px z-0" />
-                  )}
+          <div className="flex-1">
+            <Editor
+              height="100%"
+              language="json"
+              value={jsonValue}
+              onChange={handleJsonChange}
+              onMount={handleEditorDidMount}
+              theme={resolvedTheme === 'dark' ? 'vs-dark' : 'vs-light'}
+              options={{
+                minimap: { enabled: false },
+                lineNumbers: 'on',
+                fontSize: 13,
+                scrollBeyondLastLine: false,
+                automaticLayout: true,
+                padding: { top: 16, bottom: 16 },
+                formatOnPaste: true,
+                formatOnType: true,
+              }}
+            />
+          </div>
 
-                  <TransformerStep
-                    step={step}
-                    index={index}
-                    onUpdate={onUpdateStep}
-                    onRemove={onRemoveStep}
-                    onToggle={onToggleStep}
-                  />
-                </div>
-              ))}
-            </SortableContext>
-          )}
-          {steps.length > 0 && onAddRequest && (
-            <div className="pt-2 flex justify-center">
-              <button
-                onClick={onAddRequest}
-                className="flex items-center gap-2 px-4 py-2 rounded-full bg-primary/10 text-primary hover:bg-primary/20 transition-colors text-sm font-medium"
-              >
-                <Plus className="w-4 h-4" />
-                Add Step
-              </button>
-            </div>
-          )}
+          <div className="flex flex-col shrink-0">
+            {!isValidJson && (
+              <div className="bg-destructive/10 text-destructive text-xs p-2 border-t border-destructive/20 flex items-center gap-2">
+                <AlertTriangle className="w-4 h-4" />
+                <span>{validationError || 'Invalid JSON'}</span>
+              </div>
+            )}
+            {vimMode && (
+              <div
+                ref={statusBarRef}
+                className="vim-status-bar h-6 border-t border-border bg-background font-mono text-xs flex items-center overflow-hidden px-2"
+                style={{
+                  fontFamily: "'SF Mono', 'Monaco', 'Menlo', 'Consolas', 'Courier New', monospace",
+                }}
+              />
+            )}
+          </div>
         </div>
-      </ScrollArea>
+      ) : (
+        <ScrollArea className="flex-1">
+          <div
+            ref={setNodeRef}
+            className={cn(
+              'p-4 flex flex-col gap-3 min-h-[500px] transition-colors',
+              isOver && 'bg-primary/5'
+            )}
+          >
+            {steps.length === 0 ? (
+              <div
+                className={cn(
+                  'flex-1 flex flex-col items-center justify-center border-2 border-dashed border-muted-foreground/20 rounded-xl m-4 text-center p-8 transition-colors',
+                  onAddRequest ? 'hover:border-primary/40 hover:bg-primary/5 cursor-pointer' : ''
+                )}
+                onClick={onAddRequest}
+              >
+                <div className="w-12 h-12 rounded-full bg-muted flex items-center justify-center mb-4">
+                  <Plus className="w-6 h-6 text-muted-foreground" />
+                </div>
+                <h4 className="font-medium text-foreground mb-1">Build your pipeline</h4>
+                <p className="text-sm text-muted-foreground max-w-[200px]">
+                  {onAddRequest
+                    ? 'Tap here to add your first step.'
+                    : 'Drag items from the toolbox on the left to start building.'}
+                </p>
+              </div>
+            ) : (
+              <SortableContext items={steps} strategy={verticalListSortingStrategy}>
+                {steps.map((step, index) => (
+                  <div key={step.id} className="relative">
+                    {/* Connector Line */}
+                    {index < steps.length - 1 && (
+                      <div className="absolute left-6 top-full h-3 w-0.5 bg-border -ml-px z-0" />
+                    )}
+
+                    <TransformerStep
+                      step={step}
+                      index={index}
+                      onUpdate={onUpdateStep}
+                      onRemove={onRemoveStep}
+                      onToggle={onToggleStep}
+                    />
+                  </div>
+                ))}
+              </SortableContext>
+            )}
+            {steps.length > 0 && onAddRequest && (
+              <div className="pt-2 flex justify-center">
+                <button
+                  onClick={onAddRequest}
+                  className="flex items-center gap-2 px-4 py-2 rounded-full bg-primary/10 text-primary hover:bg-primary/20 transition-colors text-sm font-medium"
+                >
+                  <Plus className="w-4 h-4" />
+                  Add Step
+                </button>
+              </div>
+            )}
+          </div>
+        </ScrollArea>
+      )}
     </div>
   )
 }

--- a/src/components/transformer/toolbarSchema.ts
+++ b/src/components/transformer/toolbarSchema.ts
@@ -4,7 +4,10 @@ import type { TransformationPipeline } from './types'
 /**
  * Zod schema for a single pipeline step.
  */
-const PipelineStepSchema = z.object({
+/**
+ * Zod schema for a single pipeline step.
+ */
+export const PipelineStepSchema = z.object({
   id: z.string(),
   operationId: z.enum([
     'trim',
@@ -37,6 +40,8 @@ const PipelineStepSchema = z.object({
   enabled: z.boolean(),
 })
 
+export const PipelineStepsArraySchema = z.array(PipelineStepSchema)
+
 /**
  * Zod schema for a transformation pipeline.
  */
@@ -44,7 +49,7 @@ const TransformationPipelineSchema = z.object({
   id: z.string(),
   name: z.string(),
   icon: z.string(),
-  steps: z.array(PipelineStepSchema),
+  steps: PipelineStepsArraySchema,
 })
 
 /**

--- a/src/hooks/useLineNumbers.test.ts
+++ b/src/hooks/useLineNumbers.test.ts
@@ -1,0 +1,87 @@
+import { renderHook, act } from '@testing-library/react'
+import { useLineNumbers } from './useLineNumbers'
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+
+const localStorageMock = (() => {
+  let store: Record<string, string> = {}
+  return {
+    getItem: vi.fn((key: string) => store[key] || null),
+    setItem: vi.fn((key: string, value: string) => {
+      store[key] = value.toString()
+    }),
+    clear: vi.fn(() => {
+      store = {}
+    }),
+    removeItem: vi.fn((key: string) => {
+      delete store[key]
+    }),
+  }
+})()
+
+Object.defineProperty(window, 'localStorage', {
+  value: localStorageMock,
+})
+
+describe('useLineNumbers', () => {
+  const STORAGE_KEY = 'poe-editor-line-numbers'
+
+  beforeEach(() => {
+    localStorageMock.clear()
+    vi.clearAllMocks()
+  })
+
+  afterEach(() => {
+    localStorageMock.clear()
+  })
+
+  it('should default to true when no localStorage value exists', () => {
+    const { result } = renderHook(() => useLineNumbers())
+    expect(result.current.showLineNumbers).toBe(true)
+  })
+
+  it('should initialize with true from localStorage', () => {
+    localStorage.setItem(STORAGE_KEY, 'true')
+    const { result } = renderHook(() => useLineNumbers())
+    expect(result.current.showLineNumbers).toBe(true)
+  })
+
+  it('should initialize with false from localStorage', () => {
+    localStorage.setItem(STORAGE_KEY, 'false')
+    const { result } = renderHook(() => useLineNumbers())
+    expect(result.current.showLineNumbers).toBe(false)
+  })
+
+  it('should toggle state', () => {
+    const { result } = renderHook(() => useLineNumbers())
+
+    expect(result.current.showLineNumbers).toBe(true)
+
+    act(() => {
+      result.current.toggleLineNumbers()
+    })
+
+    expect(result.current.showLineNumbers).toBe(false)
+
+    act(() => {
+      result.current.toggleLineNumbers()
+    })
+
+    expect(result.current.showLineNumbers).toBe(true)
+  })
+
+  it('should persist changes to localStorage', () => {
+    const { result } = renderHook(() => useLineNumbers())
+
+    act(() => {
+      result.current.toggleLineNumbers()
+    })
+
+    expect(localStorage.getItem(STORAGE_KEY)).toBe('false')
+
+    act(() => {
+      result.current.toggleLineNumbers()
+    })
+
+    expect(localStorage.getItem(STORAGE_KEY)).toBe('true')
+  })
+})

--- a/src/hooks/useLineNumbers.ts
+++ b/src/hooks/useLineNumbers.ts
@@ -1,0 +1,50 @@
+import { useEffect, useState } from 'react'
+
+const STORAGE_KEY = 'poe-editor-line-numbers'
+
+interface UseLineNumbersReturn {
+  showLineNumbers: boolean
+  toggleLineNumbers: () => void
+}
+
+/**
+ * Gets the initial line numbers state from localStorage or defaults to true.
+ */
+function getInitialLineNumbers(): boolean {
+  try {
+    const stored = localStorage.getItem(STORAGE_KEY)
+    if (stored === 'true' || stored === 'false') {
+      return stored === 'true'
+    }
+  } catch {
+    // localStorage not available
+  }
+  return true
+}
+
+/**
+ * Manages Line Numbers visibility state with browser persistence.
+ * Line Numbers preference is saved to localStorage and restored on page reload.
+ * @returns Current Line Numbers visibility state and toggle function
+ */
+export function useLineNumbers(): UseLineNumbersReturn {
+  const [showLineNumbers, setShowLineNumbersState] = useState<boolean>(getInitialLineNumbers)
+
+  const toggleLineNumbers = (): void => {
+    setShowLineNumbersState((current) => !current)
+  }
+
+  // Persist line numbers state to localStorage whenever it changes
+  useEffect(() => {
+    try {
+      localStorage.setItem(STORAGE_KEY, String(showLineNumbers))
+    } catch {
+      // Silently fail if localStorage is not available
+    }
+  }, [showLineNumbers])
+
+  return {
+    showLineNumbers,
+    toggleLineNumbers,
+  }
+}


### PR DESCRIPTION
Users can now toggle line number visibility in the editor and edit transformation pipelines directly as JSON for advanced use cases.

- Line numbers can be shown or hidden via a new menu option, with preference saved to browser storage.
- Transformation pipelines can be edited in JSON mode alongside the existing GUI builder, with live schema validation.
- JSON mode supports Vim keybindings (when Vim mode is enabled) and intelligently inserts new steps at the cursor position.
- Switching between GUI and JSON modes validates the pipeline structure before allowing the transition.
- The escape key is now trapped inside the JSON editor to prevent accidental dialog closure, with a helpful toast message on first encounter.
- Editor respects user's theme preference (light/dark) when displaying JSON.

Requires no configuration changes. Existing users continue using the GUI builder by default; JSON editing is opt-in.
