### PR TITLE
feat(proxy): Add WASM module support for Cloudflare Workers

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6228,15 +6228,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/css-gradient-parser": {
-      "version": "0.0.17",
-      "resolved": "https://registry.npmjs.org/css-gradient-parser/-/css-gradient-parser-0.0.17.tgz",
-      "integrity": "sha512-w2Xy9UMMwlKtou0vlRnXvWglPAceXCTtcmVSo8ZBUvqCV5aXEFP/PC6d+I464810I9FT++UACwTD5511bmGPUg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=16"
-      }
-    },
     "node_modules/css-to-react-native": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/css-to-react-native/-/css-to-react-native-3.2.0.tgz",
@@ -6700,15 +6691,6 @@
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/emoji-regex-xs": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/emoji-regex-xs/-/emoji-regex-xs-2.0.1.tgz",
-      "integrity": "sha512-1QFuh8l7LqUcKe24LsPUNzjrzJQ7pgRwp1QMcZ5MX6mFplk2zQ08NVCM84++1cveaUUYtcCYHmeFEuNg16sU4g==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10.0.0"
-      }
     },
     "node_modules/enhanced-resolve": {
       "version": "5.19.0",
@@ -10194,28 +10176,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/satori": {
-      "version": "0.19.1",
-      "resolved": "https://registry.npmjs.org/satori/-/satori-0.19.1.tgz",
-      "integrity": "sha512-/XaT/JiWLfNlgjlQdde4wXB1/6F+FEze9c3OW2QIH0ywsfOrY57YOetgESWyOFHW3JfEQ6dJAo2U9Xwb7+DDAw==",
-      "license": "MPL-2.0",
-      "dependencies": {
-        "@shuding/opentype.js": "1.4.0-beta.0",
-        "css-background-parser": "^0.1.0",
-        "css-box-shadow": "1.0.0-3",
-        "css-gradient-parser": "^0.0.17",
-        "css-to-react-native": "^3.0.0",
-        "emoji-regex-xs": "^2.0.1",
-        "escape-html": "^1.0.3",
-        "linebreak": "^1.1.0",
-        "parse-css-color": "^0.2.1",
-        "postcss-value-parser": "^4.2.0",
-        "yoga-layout": "^3.2.1"
-      },
-      "engines": {
-        "node": ">=16"
-      }
-    },
     "node_modules/saxes": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
@@ -12410,12 +12370,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/yoga-layout": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/yoga-layout/-/yoga-layout-3.2.1.tgz",
-      "integrity": "sha512-0LPOt3AxKqMdFBZA3HBAt/t/8vIKq7VaQYbuA8WxCgung+p9TVyKRYdpvCb80HcdTN2NkbIKbhNwKUfm3tQywQ==",
-      "license": "MIT"
-    },
     "node_modules/yoga-wasm-web": {
       "version": "0.3.3",
       "resolved": "https://registry.npmjs.org/yoga-wasm-web/-/yoga-wasm-web-0.3.3.tgz",
@@ -12576,7 +12530,7 @@
       "dependencies": {
         "@resvg/resvg-wasm": "^2.6.2",
         "react": "^19.2.4",
-        "satori": "^0.19.1",
+        "satori": "0.12.2",
         "yoga-wasm-web": "^0.3.3"
       },
       "devDependencies": {
@@ -12723,6 +12677,43 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "packages/proxy/node_modules/css-gradient-parser": {
+      "version": "0.0.16",
+      "resolved": "https://registry.npmjs.org/css-gradient-parser/-/css-gradient-parser-0.0.16.tgz",
+      "integrity": "sha512-3O5QdqgFRUbXvK1x5INf1YkBz1UKSWqrd63vWsum8MNHDBYD5urm3QtxZbKU259OrEXNM26lP/MPY3d1IGkBgA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "packages/proxy/node_modules/emoji-regex": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
+      "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
+      "license": "MIT"
+    },
+    "packages/proxy/node_modules/satori": {
+      "version": "0.12.2",
+      "resolved": "https://registry.npmjs.org/satori/-/satori-0.12.2.tgz",
+      "integrity": "sha512-3C/laIeE6UUe9A+iQ0A48ywPVCCMKCNSTU5Os101Vhgsjd3AAxGNjyq0uAA8kulMPK5n0csn8JlxPN9riXEjLA==",
+      "license": "MPL-2.0",
+      "dependencies": {
+        "@shuding/opentype.js": "1.4.0-beta.0",
+        "css-background-parser": "^0.1.0",
+        "css-box-shadow": "1.0.0-3",
+        "css-gradient-parser": "^0.0.16",
+        "css-to-react-native": "^3.0.0",
+        "emoji-regex": "^10.2.1",
+        "escape-html": "^1.0.3",
+        "linebreak": "^1.1.0",
+        "parse-css-color": "^0.2.1",
+        "postcss-value-parser": "^4.2.0",
+        "yoga-wasm-web": "^0.3.3"
+      },
+      "engines": {
+        "node": ">=16"
       }
     },
     "packages/proxy/node_modules/tinyexec": {

--- a/packages/proxy/README.md
+++ b/packages/proxy/README.md
@@ -146,9 +146,11 @@ npm run deploy
 
 ## Configuration
 
-The `wrangler.toml` includes a rule for WASM module handling:
+The `wrangler.toml` enables compiled WASM imports (required for Workers' no-JIT environment):
 
 ```toml
+compatibility_flags = ["nodejs_compat"]
+
 [[rules]]
 type = "CompiledWasm"
 globs = ["**/*.wasm"]

--- a/packages/proxy/package.json
+++ b/packages/proxy/package.json
@@ -6,6 +6,7 @@
   "type": "module",
   "scripts": {
     "dev": "wrangler dev --config wrangler.toml",
+    "dev:remote": "wrangler dev --remote --config wrangler.toml",
     "deploy": "wrangler deploy",
     "build": "tsc",
     "lint": "eslint .",

--- a/packages/proxy/package.json
+++ b/packages/proxy/package.json
@@ -18,7 +18,7 @@
     "format:check": "prettier --check ."
   },
   "dependencies": {
-    "satori": "^0.19.1",
+    "satori": "0.12.2",
     "yoga-wasm-web": "^0.3.3",
     "@resvg/resvg-wasm": "^2.6.2",
     "react": "^19.2.4"


### PR DESCRIPTION
Enables proper WASM module handling in the Cloudflare Workers runtime by adding environment-based WASM module resolution and improving test infrastructure.

- Workers can now access compiled WASM modules (`YOGA_WASM` and `RESVG_WASM`) through the `Env` interface, supporting both static imports and runtime injection.
- WASM module validation ensures correct module types are passed, with helpful error messages if `wrangler.toml` misconfiguration occurs.
- Tests now properly mock WASM modules as `WebAssembly.Module` instances instead of raw byte arrays, matching the actual runtime behaviour.
- A new `dev:remote` script allows testing against Cloudflare's remote infrastructure with `wrangler dev --remote`.
- `wrangler.toml` now explicitly enables `nodejs_compat` flag, required for Workers' no-JIT environment.

Refactored `OpenGraphHandler` class into reusable `createHeadHandler()` and `createTitleHandler()` functions for cleaner code organisation. No breaking changes for existing deployments.
