### PR TITLE
refactor(proxy): migrate from satori/resvg to @cf-wasm/og

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -426,6 +426,43 @@
         "node": ">=18"
       }
     },
+    "node_modules/@cf-wasm/internals": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@cf-wasm/internals/-/internals-0.1.1.tgz",
+      "integrity": "sha512-zyl5ThQx3XJhGXbBI6DVsw9dSb7edAHB71goURMg1grGeIso9d0V9oa6HtOd7/9ggYGqTmLvBS/EYJByCrs3Yw==",
+      "license": "MIT"
+    },
+    "node_modules/@cf-wasm/og": {
+      "version": "0.3.7",
+      "resolved": "https://registry.npmjs.org/@cf-wasm/og/-/og-0.3.7.tgz",
+      "integrity": "sha512-9p18LVhop9enAlAfl/SSdYiO8vWeLAcWVgJCZoVahzGzXPgYk4W6qx4Uyex9YMs1hq1hftCfUC0zmgdIyIWCVA==",
+      "license": "MPL-2.0",
+      "dependencies": {
+        "@cf-wasm/internals": "0.1.1",
+        "@cf-wasm/resvg": "0.3.3",
+        "@cf-wasm/satori": "0.3.5",
+        "@hedgedoc/html-to-react": "^2.1.1"
+      }
+    },
+    "node_modules/@cf-wasm/resvg": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/@cf-wasm/resvg/-/resvg-0.3.3.tgz",
+      "integrity": "sha512-UN0cr048AZd0mtJ13ULWgFxlE0nAiBOETTON4r+VEHaaGpDk0oaak2Qurs6mfiBCVKKf2bQmXe8534WJ+o+B+w==",
+      "license": "MPL-2.0",
+      "dependencies": {
+        "@resvg/resvg-wasm": "2.6.2",
+        "@resvg/resvg-wasm-legacy": "npm:@resvg/resvg-wasm@2.4.1"
+      }
+    },
+    "node_modules/@cf-wasm/satori": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/@cf-wasm/satori/-/satori-0.3.5.tgz",
+      "integrity": "sha512-XpAbomHS/jujS+ZoVjXWNH2jIUyK6jK3hVdS5+UdFulgENpwzMHZ0QHRB9s3J7mM1B23Di9KL+ZCGEL53OOccg==",
+      "license": "MPL-2.0",
+      "dependencies": {
+        "satori": "^0.19.2"
+      }
+    },
     "node_modules/@cloudflare/kv-asset-handler": {
       "version": "0.4.2",
       "resolved": "https://registry.npmjs.org/@cloudflare/kv-asset-handler/-/kv-asset-handler-0.4.2.tgz",
@@ -1488,6 +1525,23 @@
       "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.10.tgz",
       "integrity": "sha512-aGTxbpbg8/b5JfU1HXSrbH3wXZuLPJcNEcZQFMxLs3oSzgtVu6nFPkbbGGUvBcUjKV2YyB9Wxxabo+HEH9tcRQ==",
       "license": "MIT"
+    },
+    "node_modules/@hedgedoc/html-to-react": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@hedgedoc/html-to-react/-/html-to-react-2.1.1.tgz",
+      "integrity": "sha512-jZQYG8XWi7CmhUo5F3YcnDjwlTIaY3PwuCSRgcP01CXEVHz8+dYKtHwaP7Fpu9qMRMoMQSWLgHXIKaGgbch/bA==",
+      "license": "AGPL-3.0",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3",
+        "htmlparser2": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "react": ">=16.0"
+      }
     },
     "node_modules/@hookform/resolvers": {
       "version": "5.2.2",
@@ -3989,6 +4043,16 @@
         "node": ">= 10"
       }
     },
+    "node_modules/@resvg/resvg-wasm-legacy": {
+      "name": "@resvg/resvg-wasm",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-wasm/-/resvg-wasm-2.4.1.tgz",
+      "integrity": "sha512-yi6R0HyHtsoWTRA06Col4WoDs7SvlXU3DLMNP2bdAgs7HK18dTEVl1weXgxRzi8gwLteGUbIg29zulxIB3GSdg==",
+      "license": "MPL-2.0",
+      "engines": {
+        "node": ">= 10"
+      }
+    },
     "node_modules/@rolldown/pluginutils": {
       "version": "1.0.0-rc.3",
       "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.3.tgz",
@@ -6071,6 +6135,15 @@
         "node": ">=4"
       }
     },
+    "node_modules/css-gradient-parser": {
+      "version": "0.0.17",
+      "resolved": "https://registry.npmjs.org/css-gradient-parser/-/css-gradient-parser-0.0.17.tgz",
+      "integrity": "sha512-w2Xy9UMMwlKtou0vlRnXvWglPAceXCTtcmVSo8ZBUvqCV5aXEFP/PC6d+I464810I9FT++UACwTD5511bmGPUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      }
+    },
     "node_modules/css-to-react-native": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/css-to-react-native/-/css-to-react-native-3.2.0.tgz",
@@ -6460,6 +6533,47 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/dom-serializer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
+      "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.2",
+        "entities": "^4.2.0"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
+      }
+    },
+    "node_modules/domelementtype": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
+      "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/domhandler": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+      "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "domelementtype": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 4"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domhandler?sponsor=1"
+      }
+    },
     "node_modules/dompurify": {
       "version": "3.2.7",
       "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.2.7.tgz",
@@ -6467,6 +6581,20 @@
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"
+      }
+    },
+    "node_modules/domutils": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.2.2.tgz",
+      "integrity": "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "dom-serializer": "^2.0.0",
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domutils?sponsor=1"
       }
     },
     "node_modules/dunder-proto": {
@@ -6524,6 +6652,15 @@
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/emoji-regex-xs": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/emoji-regex-xs/-/emoji-regex-xs-2.0.1.tgz",
+      "integrity": "sha512-1QFuh8l7LqUcKe24LsPUNzjrzJQ7pgRwp1QMcZ5MX6mFplk2zQ08NVCM84++1cveaUUYtcCYHmeFEuNg16sU4g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      }
     },
     "node_modules/enhanced-resolve": {
       "version": "5.19.0",
@@ -7680,6 +7817,25 @@
       "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/htmlparser2": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-9.1.0.tgz",
+      "integrity": "sha512-5zfg6mHUoaer/97TxnGpxmbR7zJtPwIYFMZ/H5ucTlPZhKvtum05yiPK3Mgai3a0DyVxv7qYqoweaEd2nrYQzQ==",
+      "funding": [
+        "https://github.com/fb55/htmlparser2?sponsor=1",
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.1.0",
+        "entities": "^4.5.0"
+      }
     },
     "node_modules/http-proxy-agent": {
       "version": "7.0.2",
@@ -9992,6 +10148,28 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/satori": {
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/satori/-/satori-0.19.2.tgz",
+      "integrity": "sha512-71plFHWcq6WJBM5sf/n0eHOmTBiKLUB/G8du7SmLTTLHKEKrV3TPHGKcEVIoyjnbhnjvu9HhLyF9MATB/zzL7g==",
+      "license": "MPL-2.0",
+      "dependencies": {
+        "@shuding/opentype.js": "1.4.0-beta.0",
+        "css-background-parser": "^0.1.0",
+        "css-box-shadow": "1.0.0-3",
+        "css-gradient-parser": "^0.0.17",
+        "css-to-react-native": "^3.0.0",
+        "emoji-regex-xs": "^2.0.1",
+        "escape-html": "^1.0.3",
+        "linebreak": "^1.1.0",
+        "parse-css-color": "^0.2.1",
+        "postcss-value-parser": "^4.2.0",
+        "yoga-layout": "^3.2.1"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
     "node_modules/saxes": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
@@ -11502,10 +11680,10 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/yoga-wasm-web": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/yoga-wasm-web/-/yoga-wasm-web-0.3.3.tgz",
-      "integrity": "sha512-N+d4UJSJbt/R3wqY7Coqs5pcV0aUj2j9IaQ3rNj9bVCLld8tTGKRa2USARjnvZJWVx1NDmQev8EknoczaOQDOA==",
+    "node_modules/yoga-layout": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/yoga-layout/-/yoga-layout-3.2.1.tgz",
+      "integrity": "sha512-0LPOt3AxKqMdFBZA3HBAt/t/8vIKq7VaQYbuA8WxCgung+p9TVyKRYdpvCb80HcdTN2NkbIKbhNwKUfm3tQywQ==",
       "license": "MIT"
     },
     "node_modules/youch": {
@@ -11660,10 +11838,8 @@
       "name": "poe-editor-proxy",
       "version": "1.0.0",
       "dependencies": {
-        "@resvg/resvg-wasm": "^2.6.2",
-        "react": "^19.2.4",
-        "satori": "0.12.2",
-        "yoga-wasm-web": "^0.3.3"
+        "@cf-wasm/og": "^0.3.7",
+        "react": "^19.2.4"
       },
       "devDependencies": {
         "@cloudflare/workers-types": "^4.20260210.0",
@@ -11677,43 +11853,6 @@
         "typescript-eslint": "^8.54.0",
         "vitest": "^4.0.18",
         "wrangler": "^4.63.0"
-      }
-    },
-    "packages/proxy/node_modules/css-gradient-parser": {
-      "version": "0.0.16",
-      "resolved": "https://registry.npmjs.org/css-gradient-parser/-/css-gradient-parser-0.0.16.tgz",
-      "integrity": "sha512-3O5QdqgFRUbXvK1x5INf1YkBz1UKSWqrd63vWsum8MNHDBYD5urm3QtxZbKU259OrEXNM26lP/MPY3d1IGkBgA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=16"
-      }
-    },
-    "packages/proxy/node_modules/emoji-regex": {
-      "version": "10.6.0",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
-      "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
-      "license": "MIT"
-    },
-    "packages/proxy/node_modules/satori": {
-      "version": "0.12.2",
-      "resolved": "https://registry.npmjs.org/satori/-/satori-0.12.2.tgz",
-      "integrity": "sha512-3C/laIeE6UUe9A+iQ0A48ywPVCCMKCNSTU5Os101Vhgsjd3AAxGNjyq0uAA8kulMPK5n0csn8JlxPN9riXEjLA==",
-      "license": "MPL-2.0",
-      "dependencies": {
-        "@shuding/opentype.js": "1.4.0-beta.0",
-        "css-background-parser": "^0.1.0",
-        "css-box-shadow": "1.0.0-3",
-        "css-gradient-parser": "^0.0.16",
-        "css-to-react-native": "^3.0.0",
-        "emoji-regex": "^10.2.1",
-        "escape-html": "^1.0.3",
-        "linebreak": "^1.1.0",
-        "parse-css-color": "^0.2.1",
-        "postcss-value-parser": "^4.2.0",
-        "yoga-wasm-web": "^0.3.3"
-      },
-      "engines": {
-        "node": ">=16"
       }
     }
   }

--- a/packages/proxy/package.json
+++ b/packages/proxy/package.json
@@ -18,9 +18,7 @@
     "format:check": "prettier --check ."
   },
   "dependencies": {
-    "satori": "0.12.2",
-    "yoga-wasm-web": "^0.3.3",
-    "@resvg/resvg-wasm": "^2.6.2",
+    "@cf-wasm/og": "^0.3.7",
     "react": "^19.2.4"
   },
   "devDependencies": {


### PR DESCRIPTION
Simplifies OG image generation by switching from manually managing Satori, Resvg, and Yoga WASM modules to using Cloudflare's `@cf-wasm/og` package, which bundles and optimises all dependencies.

- OG images now generate with less boilerplate code and fewer moving parts.
- WASM module initialisation is handled automatically by the library.
- Removes manual font loading coordination and WASM module resolution logic.
- Cache headers are now set directly in the `ImageResponse` constructor.
- Font caching still works to avoid redundant network requests.
- Significantly reduces test complexity by eliminating mock WASM setup.

No breaking changes for end-users. The `/api/og` endpoint behaviour remains unchanged, producing identical PNG images.
