### PR TITLE
feat(proxy): Add configurable origin URL and improve scroll sync in editor

### DIFF
--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -13,6 +13,7 @@
     "format": "prettier --write .",
     "format:check": "prettier --check .",
     "test": "vitest",
+    "test:run": "vitest run",
     "test:coverage": "vitest run --coverage",
     "test:e2e": "playwright test",
     "deploy": "wrangler deploy"

--- a/packages/proxy/src/handlers.test.tsx
+++ b/packages/proxy/src/handlers.test.tsx
@@ -25,7 +25,7 @@ describe('Handlers', () => {
     it('should proxy index request', async () => {
       fetchMock.mockResolvedValueOnce(new Response('Index HTML', { status: 200 }))
       const request = new Request('http://localhost/Title/Snippet')
-      await handleMetadataRoute(request, { title: 'Title', snippet: 'Snippet' })
+      await handleMetadataRoute(request, { title: 'Title', snippet: 'Snippet' }, {})
       expect(fetchMock).toHaveBeenCalledWith('http://localhost/index.html')
     })
   })

--- a/packages/proxy/src/utils.test.ts
+++ b/packages/proxy/src/utils.test.ts
@@ -26,6 +26,14 @@ describe('Utils', () => {
       expect(parsePathMetadata('/OneSegment')).toBeNull()
       expect(parsePathMetadata('/Too/Many/Segments')).toBeNull()
     })
+
+    it('should return null for static asset paths', () => {
+      expect(parsePathMetadata('/assets/index-vDEImsbE.js')).toBeNull()
+      expect(parsePathMetadata('/assets/index-B4kUc-lG.css')).toBeNull()
+      expect(parsePathMetadata('/images/logo.png')).toBeNull()
+      expect(parsePathMetadata('/favicon.ico')).toBeNull()
+      expect(parsePathMetadata('/manifest.json')).toBeNull()
+    })
   })
 
   describe('escapeHtml', () => {

--- a/packages/proxy/src/utils.ts
+++ b/packages/proxy/src/utils.ts
@@ -1,4 +1,23 @@
-export type Env = Record<string, never>
+export interface Env {
+  ORIGIN_URL?: string
+}
+
+/** Static asset patterns to exclude from metadata handling */
+const STATIC_ASSET_PATTERNS = [
+  /\.\w+$/i, // Any path with a file extension
+  /^\/favicon\.ico$/i,
+  /^\/manifest\.json$/i,
+  /^\/robots\.txt$/i,
+]
+
+/**
+ * Checks if a path is a static asset that should pass through unchanged
+ * @param path - The URL pathname
+ * @returns true if it's a static asset
+ */
+function isStaticAsset(path: string): boolean {
+  return STATIC_ASSET_PATTERNS.some((pattern) => pattern.test(path))
+}
 
 /**
  * Parses metadata from URL path segments
@@ -7,6 +26,8 @@ export type Env = Record<string, never>
  * @returns Object with title and snippet, or null if invalid
  */
 export function parsePathMetadata(pathname: string): { title: string; snippet: string } | null {
+  if (isStaticAsset(pathname)) return null
+
   const segments = pathname.split('/').filter(Boolean)
 
   // Must have exactly 2 segments for metadata

--- a/packages/proxy/src/worker.tsx
+++ b/packages/proxy/src/worker.tsx
@@ -1,20 +1,34 @@
-// ... imports ...
 import { type Env, parsePathMetadata } from './utils'
 import { handleMetadataRoute } from './handlers'
 import { createHeadHandler, removeElementHandler } from './rewriter'
 
 export { createHeadHandler, removeElementHandler }
 
+/**
+ * Proxies a request to the origin, using ORIGIN_URL env var if set
+ * @param request - The original request
+ * @param env - Worker environment bindings
+ * @returns Proxied response
+ */
+function proxyToOrigin(request: Request, env: Env): Promise<Response> {
+  if (env.ORIGIN_URL) {
+    const url = new URL(request.url)
+    const originUrl = new URL(url.pathname + url.search, env.ORIGIN_URL)
+    return fetch(originUrl.toString())
+  }
+  return fetch(request)
+}
+
 export default {
-  async fetch(request: Request, _env: Env, _ctx: ExecutionContext): Promise<Response> {
+  async fetch(request: Request, env: Env, _ctx: ExecutionContext): Promise<Response> {
     const url = new URL(request.url)
     const { pathname } = url
 
     const metadata = parsePathMetadata(pathname)
     if (metadata) {
-      return handleMetadataRoute(request, metadata)
+      return handleMetadataRoute(request, metadata, env)
     }
 
-    return fetch(request)
+    return proxyToOrigin(request, env)
   },
 }

--- a/packages/proxy/wrangler.toml
+++ b/packages/proxy/wrangler.toml
@@ -13,3 +13,6 @@ fallthrough = false
 [build]
 command = ""
 
+[env.dev]
+vars = { ORIGIN_URL = "http://localhost:5173" }
+


### PR DESCRIPTION
Adds support for proxying requests through a configurable `ORIGIN_URL` environment variable, improving flexibility for development and deployment scenarios. Also enhances editor scroll synchronisation to handle Monaco's asynchronous mounting and virtual scrolling behaviour.

- Proxy requests can now route through a custom origin URL set via `ORIGIN_URL` environment variable, allowing the worker to forward requests to a local development server or alternative backend.
- Static assets (files with extensions, `/favicon.ico`, `/manifest.json`, etc.) now bypass metadata handling and pass through unchanged.
- Editor scroll callbacks are now queued during Monaco's initialisation phase and drained once the editor mounts, preventing race conditions.
- E2E scroll tests now use Monaco's API (`setScrollTop`) directly instead of simulated mouse/keyboard events, ensuring reliable scroll detection in headless environments.
- Added `test:run` npm script for running tests in non-watch mode.
- Development environment configuration (`wrangler.toml`) now includes `ORIGIN_URL` pointing to localhost for easier local testing.

No breaking changes for existing deployments. The `ORIGIN_URL` variable is optional; requests behave as before when not set.
