### PR TITLE
feat(prefs): Ability to start editor with empty doc

### DIFF
--- a/packages/app/src/components/EditorToolbar.tsx
+++ b/packages/app/src/components/EditorToolbar.tsx
@@ -59,6 +59,7 @@ import {
   Moon,
   MoreHorizontal,
   FileText,
+  File,
   FilePlus,
   Pencil,
   Download,
@@ -268,6 +269,8 @@ interface EditorToolbarProps {
   toggleWordCount?: () => void
   showLineNumbers?: boolean
   toggleLineNumbers?: () => void
+  startEmpty?: boolean
+  toggleStartEmpty?: () => void
 }
 
 /**
@@ -313,6 +316,8 @@ export function EditorToolbar({
   toggleWordCount,
   showLineNumbers,
   toggleLineNumbers,
+  startEmpty,
+  toggleStartEmpty,
 }: EditorToolbarProps): ReactElement {
   const [isConfirmingClear, setIsConfirmingClear] = useState(false)
   const [pipelineToDelete, setPipelineToDelete] = useState<TransformationPipeline | null>(null)
@@ -641,6 +646,10 @@ export function EditorToolbar({
             <DropdownMenuItem onClick={toggleLineNumbers}>
               <Hash className="size-4" />
               {showLineNumbers ? 'Hide Line Numbers' : 'Show Line Numbers'}
+            </DropdownMenuItem>
+            <DropdownMenuItem onClick={toggleStartEmpty}>
+              <File className="size-4" />
+              {startEmpty ? 'Start with Default Content' : 'Start with Empty Editor'}
             </DropdownMenuItem>
             <DropdownMenuItem onClick={onOpenImportExport}>
               <ArrowRightLeft className="size-4" />

--- a/packages/app/src/components/PoeEditor.tsx
+++ b/packages/app/src/components/PoeEditor.tsx
@@ -9,6 +9,7 @@ import { useLineNumbers } from '@/hooks/useLineNumbers'
 import { useKeyboardShortcuts } from '@/hooks/useKeyboardShortcuts'
 import { useSyncScroll } from '@/hooks/useSyncScroll'
 import { useTransformers } from '@/hooks/useTransformers'
+import { useEditorPreferences } from '@/hooks/useEditorPreferences'
 import { renderMarkdown } from '@/utils/markdown'
 import { downloadFile } from '@/utils/download'
 import { applyPipeline } from '@/utils/transformer-engine'
@@ -133,9 +134,12 @@ export function PoeEditor({ onReady }: PoeEditorProps): ReactElement {
     [toast]
   )
 
+  // Editor preferences
+  const { startEmpty, toggleStartEmpty } = useEditorPreferences()
+
   // URL state management
   const { content, setContent, documentName, setDocumentName, isOverLimit } = useUrlState({
-    defaultContent: DEFAULT_CONTENT,
+    defaultContent: startEmpty ? '' : DEFAULT_CONTENT,
     defaultName: 'untitled.md',
     onError: handleError,
     onLengthWarning: handleLengthWarning,
@@ -509,6 +513,8 @@ ${htmlContent}
           toggleWordCount={toggleWordCount}
           showLineNumbers={showLineNumbers}
           toggleLineNumbers={toggleLineNumbers}
+          startEmpty={startEmpty}
+          toggleStartEmpty={toggleStartEmpty}
         />
 
         <AlertDialog open={showResetConfirm} onOpenChange={setShowResetConfirm}>

--- a/packages/app/src/hooks/useEditorPreferences.ts
+++ b/packages/app/src/hooks/useEditorPreferences.ts
@@ -1,0 +1,59 @@
+import { useEffect, useState } from 'react'
+
+const STORAGE_KEY = 'poe-editor-preferences'
+
+interface EditorPreferences {
+  startEmpty: boolean
+}
+
+const DEFAULT_PREFERENCES: EditorPreferences = {
+  startEmpty: false,
+}
+
+interface UseEditorPreferencesReturn extends EditorPreferences {
+  toggleStartEmpty: () => void
+}
+
+/**
+ * Gets the initial preferences from localStorage or defaults.
+ */
+function getInitialPreferences(): EditorPreferences {
+  try {
+    const stored = localStorage.getItem(STORAGE_KEY)
+    if (stored) {
+      return { ...DEFAULT_PREFERENCES, ...JSON.parse(stored) }
+    }
+  } catch {
+    // localStorage not available or invalid JSON
+  }
+  return DEFAULT_PREFERENCES
+}
+
+/**
+ * Manages editor preferences with browser persistence.
+ * @returns Current preferences and toggle functions
+ */
+export function useEditorPreferences(): UseEditorPreferencesReturn {
+  const [preferences, setPreferences] = useState<EditorPreferences>(getInitialPreferences)
+
+  const toggleStartEmpty = (): void => {
+    setPreferences((current) => ({
+      ...current,
+      startEmpty: !current.startEmpty,
+    }))
+  }
+
+  // Persist preferences to localStorage whenever they change
+  useEffect(() => {
+    try {
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(preferences))
+    } catch {
+      // Silently fail if localStorage is not available
+    }
+  }, [preferences])
+
+  return {
+    ...preferences,
+    toggleStartEmpty,
+  }
+}

--- a/packages/app/tests/e2e/preferences.spec.ts
+++ b/packages/app/tests/e2e/preferences.spec.ts
@@ -1,0 +1,39 @@
+import { test, expect } from '@playwright/test'
+
+test.describe('Editor Preferences', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/')
+    // Wait for editor to be ready
+    await expect(page.locator('.monaco-editor')).toBeVisible()
+  })
+
+  test('should persist "Start with Empty Editor" preference', async ({ page }) => {
+    // 1. Verify default state (Welcome text present)
+    await expect(page.locator('.markdown-body')).toContainText('Poe Markdown Editor')
+
+    // 2. Enable "Start with Empty Editor"
+    await page.getByRole('button', { name: 'Menu' }).click()
+    await page.getByRole('menuitem', { name: 'Start with Empty Editor' }).click()
+
+    // 3. Reload page with empty hash to simulate new session/document
+    await page.goto('/#')
+    await page.reload()
+    await expect(page.locator('.monaco-editor')).toBeVisible()
+
+    // 4. Verify editor is empty (no Welcome text)
+    await expect(page.locator('.markdown-body')).not.toContainText('Poe Markdown Editor')
+
+    // 5. Disable "Start with Empty Editor" (Toggle back)
+    await page.getByRole('button', { name: 'Menu' }).click()
+    // Text should have changed to indicate current state or action
+    await page.getByRole('menuitem', { name: 'Start with Default Content' }).click()
+
+    // 6. Reload page with empty hash
+    await page.goto('/#')
+    await page.reload()
+    await expect(page.locator('.monaco-editor')).toBeVisible()
+
+    // 7. Verify Welcome text returns
+    await expect(page.locator('.markdown-body')).toContainText('Poe Markdown Editor')
+  })
+})


### PR DESCRIPTION
Adds a new editor preference that allows users to choose whether the editor starts with default welcome content or an empty canvas. This preference is persisted across sessions using browser storage.

- Users can toggle between starting with default welcome content or an empty editor via the menu.
- The preference is automatically saved and restored when the user returns to the editor.
- New sessions respect the user's previous preference without requiring manual configuration.

The feature introduces a new `useEditorPreferences` hook for managing editor settings with localStorage persistence, and includes end-to-end tests to verify the preference persists correctly across page reloads.