### PR TITLE
feat(editor): Add markdown table formatting capability

### DIFF
--- a/packages/app/src/components/EditorPane.test.tsx
+++ b/packages/app/src/components/EditorPane.test.tsx
@@ -2,19 +2,16 @@ import { render, screen, fireEvent, waitFor } from '@testing-library/react'
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { EditorPane } from './EditorPane'
 import { copyToClipboard } from '@/utils/clipboard'
-import { toast } from 'sonner'
+import { toast } from '@/hooks/useToast'
 import { initVimMode } from 'monaco-vim'
 
-// Mock the utilities and sonner
+// Mock the utilities and toast hook
 vi.mock('@/utils/clipboard', () => ({
   copyToClipboard: vi.fn(),
 }))
 
-vi.mock('sonner', () => ({
-  toast: {
-    success: vi.fn(),
-    error: vi.fn(),
-  },
+vi.mock('@/hooks/useToast', () => ({
+  toast: vi.fn(),
 }))
 
 // Mock Monaco Editor
@@ -71,7 +68,7 @@ describe('EditorPane', () => {
 
     await waitFor(() => {
       expect(copyToClipboard).toHaveBeenCalledWith(value)
-      expect(toast.success).toHaveBeenCalledWith('Markdown copied to clipboard!')
+      expect(toast).toHaveBeenCalledWith({ description: 'Markdown copied to clipboard!' })
     })
   })
 
@@ -83,7 +80,10 @@ describe('EditorPane', () => {
     fireEvent.click(copyButton)
 
     await waitFor(() => {
-      expect(toast.error).toHaveBeenCalledWith('Failed to copy to clipboard')
+      expect(toast).toHaveBeenCalledWith({
+        description: 'Failed to copy to clipboard',
+        variant: 'destructive',
+      })
     })
   })
 

--- a/packages/app/src/components/EditorToolbar.tsx
+++ b/packages/app/src/components/EditorToolbar.tsx
@@ -80,6 +80,7 @@ import {
   RotateCcw,
   WholeWord,
   Hash,
+  Table,
 } from 'lucide-react'
 import { ICON_MAP } from '@/components/transformer/constants'
 import { cn } from '@/utils/classnames'
@@ -251,6 +252,7 @@ interface EditorToolbarProps {
   onFormatBulletList: () => void
   onFormatNumberedList: () => void
   onFormatCodeBlock: () => void
+  onFormatTable: () => void
   toggleVimMode: () => void
   toggleTheme: () => void
   setShowShortcuts: (show: boolean) => void
@@ -299,6 +301,7 @@ export function EditorToolbar({
   onFormatBulletList,
   onFormatNumberedList,
   onFormatCodeBlock,
+  onFormatTable,
   toggleVimMode,
   toggleTheme,
   setShowShortcuts,
@@ -501,6 +504,7 @@ export function EditorToolbar({
         <ToolbarButton icon={List} label="Bullet List" onClick={onFormatBulletList} />
         <ToolbarButton icon={ListOrdered} label="Numbered List" onClick={onFormatNumberedList} />
         <ToolbarButton icon={CodeSquare} label="Code Block" onClick={onFormatCodeBlock} />
+        <ToolbarButton icon={Table} label="Format Table" onClick={onFormatTable} />
 
         <div className="w-px h-5 bg-border mx-1" />
 

--- a/packages/app/src/components/PoeEditor.tsx
+++ b/packages/app/src/components/PoeEditor.tsx
@@ -206,6 +206,10 @@ export function PoeEditor({ onReady }: PoeEditorProps): ReactElement {
     formatNumberedList(sourceRef.current)
   }, [sourceRef])
 
+  const handleFormatTable = useCallback((): void => {
+    sourceRef.current?.formatTable()
+  }, [sourceRef])
+
   const handleApplyPipeline = useCallback(
     (pipeline: TransformationPipeline) => {
       const editor = sourceRef.current
@@ -492,6 +496,7 @@ ${htmlContent}
           onFormatBulletList={handleFormatBulletList}
           onFormatNumberedList={handleFormatNumberedList}
           onFormatCodeBlock={handleFormatCodeBlock}
+          onFormatTable={handleFormatTable}
           toggleVimMode={toggleVimMode}
           toggleTheme={toggleTheme}
           setShowShortcuts={setShowShortcuts}

--- a/packages/app/src/components/PreviewPane.test.tsx
+++ b/packages/app/src/components/PreviewPane.test.tsx
@@ -2,19 +2,16 @@ import { render, screen, fireEvent, waitFor } from '@testing-library/react'
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { PreviewPane } from './PreviewPane'
 import { copyToClipboard } from '@/utils/clipboard'
-import { toast } from 'sonner'
+import { toast } from '@/hooks/useToast'
 
-// Mock the utilities and sonner
+// Mock the utilities and toast hook
 vi.mock('@/utils/clipboard', () => ({
   copyToClipboard: vi.fn(),
   stripHtml: vi.fn((html) => html.replace(/<[^>]*>?/gm, '')),
 }))
 
-vi.mock('sonner', () => ({
-  toast: {
-    success: vi.fn(),
-    error: vi.fn(),
-  },
+vi.mock('@/hooks/useToast', () => ({
+  toast: vi.fn(),
 }))
 
 describe('PreviewPane', () => {
@@ -37,7 +34,7 @@ describe('PreviewPane', () => {
 
     await waitFor(() => {
       expect(copyToClipboard).toHaveBeenCalledWith('Test content', htmlContent)
-      expect(toast.success).toHaveBeenCalledWith('Rich text copied to clipboard!')
+      expect(toast).toHaveBeenCalledWith({ description: 'Rich text copied to clipboard!' })
     })
   })
 
@@ -49,7 +46,10 @@ describe('PreviewPane', () => {
     fireEvent.click(copyButton)
 
     await waitFor(() => {
-      expect(toast.error).toHaveBeenCalledWith('Failed to copy to clipboard')
+      expect(toast).toHaveBeenCalledWith({
+        description: 'Failed to copy to clipboard',
+        variant: 'destructive',
+      })
     })
   })
 })

--- a/packages/app/src/components/PreviewPane.tsx
+++ b/packages/app/src/components/PreviewPane.tsx
@@ -3,7 +3,7 @@ import { useState, type ReactElement, forwardRef } from 'react'
 import { Copy, Check, Maximize2, Minimize2 } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
-import { toast } from 'sonner'
+import { toast } from '@/hooks/useToast'
 import { copyToClipboard, stripHtml } from '@/utils/clipboard'
 
 interface PreviewPaneProps {
@@ -26,10 +26,13 @@ export const PreviewPane = forwardRef<HTMLDivElement, PreviewPaneProps>(
         await copyToClipboard(plainText, htmlContent)
 
         setCopied(true)
-        toast.success('Rich text copied to clipboard!')
+        toast({ description: 'Rich text copied to clipboard!' })
         setTimeout(() => setCopied(false), 2000)
       } catch {
-        toast.error('Failed to copy to clipboard')
+        toast({
+          description: 'Failed to copy to clipboard',
+          variant: 'destructive',
+        })
       }
     }
 

--- a/packages/app/src/components/transformer/TransformerWorkbench.tsx
+++ b/packages/app/src/components/transformer/TransformerWorkbench.tsx
@@ -13,7 +13,7 @@ import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip
 import type { PipelineStep, TransformerOperation } from './types'
 import { PipelineStepsArraySchema } from './toolbarSchema'
 import { cn } from '@/utils/classnames'
-import { toast } from 'sonner'
+import { toast } from '@/hooks/useToast'
 import { z } from 'zod'
 
 interface TransformerWorkbenchProps {
@@ -296,7 +296,10 @@ export function TransformerWorkbench({
     } else {
       // Switching to GUI
       if (!isValidJson) {
-        toast.error('Cannot switch to GUI mode with invalid JSON')
+        toast({
+          description: 'Cannot switch to GUI mode with invalid JSON',
+          variant: 'destructive',
+        })
         return
       }
 
@@ -312,10 +315,16 @@ export function TransformerWorkbench({
         if (error instanceof z.ZodError) {
           const message = `Validation error: ${error.issues.map((i) => i.message).join(', ')}`
           setValidationError(message)
-          toast.error(message)
+          toast({
+            description: message,
+            variant: 'destructive',
+          })
         } else {
           setValidationError('Invalid JSON format')
-          toast.error('Invalid JSON format')
+          toast({
+            description: 'Invalid JSON format',
+            variant: 'destructive',
+          })
         }
         setIsValidJson(false)
       }

--- a/packages/app/src/utils/markdownTable.test.ts
+++ b/packages/app/src/utils/markdownTable.test.ts
@@ -1,6 +1,5 @@
-
 import { describe, it, expect } from 'vitest'
-import { formatMarkdownTable } from '../src/utils/markdownTable'
+import { formatMarkdownTable, isMarkdownTable } from './markdownTable'
 
 describe('formatMarkdownTable', () => {
   it('formats a simple table', () => {
@@ -40,7 +39,7 @@ describe('formatMarkdownTable', () => {
     // 张三 (4 width) | 25 (2 width) -> pad to 4 -> 25__
     // Li (2 width)   | 30 (2 width) -> pad to 4 -> 30__
     // Max cols: 4, 4
-    
+
     const expected = `| 名字 | 年龄 |
 | ---- | ---- |
 | 张三 | 25   |
@@ -54,18 +53,18 @@ describe('formatMarkdownTable', () => {
 | :--- | :---: | ---: |
 | 1 | 2 | 3 |
 `.trim()
-    
+
     // Left (4) | Center (6) | Right (5)
     // 1 (1) -> 1___ | 2 (1) -> 2_____ | 3 (1) -> 3____
-    
+
     const expected = `| Left | Center | Right |
 | :--- | :----: | ----: |
 | 1    | 2      | 3     |`
     expect(formatMarkdownTable(input)).toBe(expected)
   })
-  
+
   it('handles empty cells', () => {
-      const input = `
+    const input = `
 | A | B |
 |---|---|
 | 1 | |
@@ -76,5 +75,26 @@ describe('formatMarkdownTable', () => {
 | 1   |     |
 |     | 2   |`
     expect(formatMarkdownTable(input)).toBe(expected)
+  })
+})
+
+describe('isMarkdownTable', () => {
+  it('returns true for a valid markdown table', () => {
+    const input = `
+| A | B |
+|---|---|
+| 1 | 2 |
+`.trim()
+
+    expect(isMarkdownTable(input)).toBe(true)
+  })
+
+  it('returns false for pipe-delimited text without a separator row', () => {
+    const input = `
+| A | B |
+| 1 | 2 |
+`.trim()
+
+    expect(isMarkdownTable(input)).toBe(false)
   })
 })

--- a/packages/app/src/utils/markdownTable.ts
+++ b/packages/app/src/utils/markdownTable.ts
@@ -1,4 +1,3 @@
-
 /**
  * Calculates the display width of a string, accounting for wide characters (CJK, emojis, etc.)
  * This is a simplified implementation.
@@ -35,29 +34,49 @@ function padToWidth(str: string, width: number, paddingChar = ' '): string {
  * @param text The markdown table text.
  * @returns The formatted markdown table.
  */
+function parseTableRows(text: string): string[][] {
+  const lines = text.trim().split('\n')
+  return lines.map((line) => {
+    const cells = line.split('|').map((c) => c.trim())
+
+    // Remove empty leading/trailing cells if the row starts/ends with a pipe.
+    if (line.trim().startsWith('|') && cells[0] === '') cells.shift()
+    if (line.trim().endsWith('|') && cells[cells.length - 1] === '') cells.pop()
+
+    return cells
+  })
+}
+
+function getSeparatorIndex(rows: string[][]): number {
+  return rows.findIndex((row) => row.every((cell) => /^[:\-\s]+$/.test(cell) && cell.includes('-')))
+}
+
+/**
+ * Checks whether the provided text contains a valid markdown table structure.
+ * @param text The text to validate.
+ * @returns True if the text has at least one markdown table separator row.
+ */
+export function isMarkdownTable(text: string): boolean {
+  const lines = text.trim().split('\n')
+  if (lines.length < 2) return false
+
+  const rows = parseTableRows(text)
+  return getSeparatorIndex(rows) !== -1
+}
+
+/**
+ * Formats a markdown table to have aligned columns.
+ * @param text The markdown table text.
+ * @returns The formatted markdown table.
+ */
 export function formatMarkdownTable(text: string): string {
   const lines = text.trim().split('\n')
   if (lines.length < 2) return text // Not a valid table
 
-  // 1. Parse rows and cells
-  const rows = lines.map((line) => {
-    // Split by pipe, but we need to handle escaped pipes if we want to be robust.
-    // For now, simple split is usually sufficient for simple tables.
-    // A more robust regex: /\|(?![^`]*`)/ would require tracking code blocks.
-    // Let's stick to simple split for this task unless complex requirements arise.
-    const cells = line.split('|').map((c) => c.trim())
-    
-    // Remove empty leading/trailing cells if the row starts/ends with a pipe
-    if (line.trim().startsWith('|') && cells[0] === '') cells.shift()
-    if (line.trim().endsWith('|') && cells[cells.length - 1] === '') cells.pop()
-    
-    return cells
-  })
+  const rows = parseTableRows(text)
 
   // 2. Identify separator row (usually 2nd row, contains ---)
-  const separatorIndex = rows.findIndex((row) =>
-    row.every((cell) => /^[:\-\s]+$/.test(cell) && cell.includes('-'))
-  )
+  const separatorIndex = getSeparatorIndex(rows)
 
   if (separatorIndex === -1) return text // No separator found, not a table
 
@@ -67,20 +86,20 @@ export function formatMarkdownTable(text: string): string {
 
   // 4. Calculate max width per column
   const columnWidths = new Array(columnCount).fill(0)
-  
+
   rows.forEach((row, rowIndex) => {
     // Skip separator row for width calculation (we regenerate it)
     if (rowIndex === separatorIndex) return
 
     for (let i = 0; i < columnCount; i++) {
-        const cell = row[i] || ''
-        columnWidths[i] = Math.max(columnWidths[i], getDisplayWidth(cell))
+      const cell = row[i] || ''
+      columnWidths[i] = Math.max(columnWidths[i], getDisplayWidth(cell))
     }
   })
-  
+
   // Ensure minimum width of 3 for separator (e.g. `---`)
   for (let i = 0; i < columnCount; i++) {
-      columnWidths[i] = Math.max(columnWidths[i], 3)
+    columnWidths[i] = Math.max(columnWidths[i], 3)
   }
 
   // 5. Reconstruct table
@@ -95,14 +114,14 @@ export function formatMarkdownTable(text: string): string {
             // Detect alignment
             const firstChar = original.startsWith(':')
             const lastChar = original.endsWith(':')
-            
+
             let content = '-'.repeat(width)
             if (firstChar && lastChar) {
-                content = ':' + '-'.repeat(width - 2) + ':'
+              content = ':' + '-'.repeat(width - 2) + ':'
             } else if (firstChar) {
-                 content = ':' + '-'.repeat(width - 1)
+              content = ':' + '-'.repeat(width - 1)
             } else if (lastChar) {
-                 content = '-'.repeat(width - 1) + ':'
+              content = '-'.repeat(width - 1) + ':'
             }
             return content
           })

--- a/packages/app/src/utils/markdownTable.ts
+++ b/packages/app/src/utils/markdownTable.ts
@@ -1,0 +1,127 @@
+
+/**
+ * Calculates the display width of a string, accounting for wide characters (CJK, emojis, etc.)
+ * This is a simplified implementation.
+ */
+function getDisplayWidth(str: string): number {
+  let width = 0
+  for (const char of str) {
+    // ASCII characters
+    if (char.codePointAt(0)! <= 127) {
+      width += 1
+    } else {
+      // Crude check for wide characters:
+      // - CJK Unified Ideographs: 4E00-9FFF
+      // - Fullwidth forms: FF00-FFEF
+      // - CJK punctuation, Hiragana, Katakana, etc.
+      // Emojis are often wide (2) but some are valid as 1. 2 is safer for alignment.
+      width += 2
+    }
+  }
+  return width
+}
+
+/**
+ * Pads a string to a specific width, accounting for wide characters.
+ */
+function padToWidth(str: string, width: number, paddingChar = ' '): string {
+  const currentWidth = getDisplayWidth(str)
+  if (currentWidth >= width) return str
+  return str + paddingChar.repeat(width - currentWidth)
+}
+
+/**
+ * Formats a markdown table to have aligned columns.
+ * @param text The markdown table text.
+ * @returns The formatted markdown table.
+ */
+export function formatMarkdownTable(text: string): string {
+  const lines = text.trim().split('\n')
+  if (lines.length < 2) return text // Not a valid table
+
+  // 1. Parse rows and cells
+  const rows = lines.map((line) => {
+    // Split by pipe, but we need to handle escaped pipes if we want to be robust.
+    // For now, simple split is usually sufficient for simple tables.
+    // A more robust regex: /\|(?![^`]*`)/ would require tracking code blocks.
+    // Let's stick to simple split for this task unless complex requirements arise.
+    const cells = line.split('|').map((c) => c.trim())
+    
+    // Remove empty leading/trailing cells if the row starts/ends with a pipe
+    if (line.trim().startsWith('|') && cells[0] === '') cells.shift()
+    if (line.trim().endsWith('|') && cells[cells.length - 1] === '') cells.pop()
+    
+    return cells
+  })
+
+  // 2. Identify separator row (usually 2nd row, contains ---)
+  const separatorIndex = rows.findIndex((row) =>
+    row.every((cell) => /^[:\-\s]+$/.test(cell) && cell.includes('-'))
+  )
+
+  if (separatorIndex === -1) return text // No separator found, not a table
+
+  // 3. Normalize columns
+  // Calculate max columns
+  const columnCount = rows.reduce((max, row) => Math.max(max, row.length), 0)
+
+  // 4. Calculate max width per column
+  const columnWidths = new Array(columnCount).fill(0)
+  
+  rows.forEach((row, rowIndex) => {
+    // Skip separator row for width calculation (we regenerate it)
+    if (rowIndex === separatorIndex) return
+
+    for (let i = 0; i < columnCount; i++) {
+        const cell = row[i] || ''
+        columnWidths[i] = Math.max(columnWidths[i], getDisplayWidth(cell))
+    }
+  })
+  
+  // Ensure minimum width of 3 for separator (e.g. `---`)
+  for (let i = 0; i < columnCount; i++) {
+      columnWidths[i] = Math.max(columnWidths[i], 3)
+  }
+
+  // 5. Reconstruct table
+  const formattedLines = rows.map((row, rowIndex) => {
+    if (rowIndex === separatorIndex) {
+      // Reconstruct separator row based on alignment of original if present, or default to ---
+      return (
+        '| ' +
+        columnWidths
+          .map((width, colIndex) => {
+            const original = row[colIndex] || ''
+            // Detect alignment
+            const firstChar = original.startsWith(':')
+            const lastChar = original.endsWith(':')
+            
+            let content = '-'.repeat(width)
+            if (firstChar && lastChar) {
+                content = ':' + '-'.repeat(width - 2) + ':'
+            } else if (firstChar) {
+                 content = ':' + '-'.repeat(width - 1)
+            } else if (lastChar) {
+                 content = '-'.repeat(width - 1) + ':'
+            }
+            return content
+          })
+          .join(' | ') +
+        ' |'
+      )
+    } else {
+      return (
+        '| ' +
+        columnWidths
+          .map((width, colIndex) => {
+            const cell = row[colIndex] || ''
+            return padToWidth(cell, width)
+          })
+          .join(' | ') +
+        ' |'
+      )
+    }
+  })
+
+  return formattedLines.join('\n')
+}

--- a/packages/app/tests/markdownTable.test.ts
+++ b/packages/app/tests/markdownTable.test.ts
@@ -1,0 +1,80 @@
+
+import { describe, it, expect } from 'vitest'
+import { formatMarkdownTable } from '../src/utils/markdownTable'
+
+describe('formatMarkdownTable', () => {
+  it('formats a simple table', () => {
+    const input = `
+| h1 | h2 |
+|---|---|
+| v1 | v2 |
+`.trim()
+    const expected = `| h1  | h2  |
+| --- | --- |
+| v1  | v2  |`
+    expect(formatMarkdownTable(input)).toBe(expected)
+  })
+
+  it('aligns columns with padding', () => {
+    const input = `
+| Name | Age |
+|---|---|
+| Alice | 25 |
+| Bob | 30 |
+`.trim()
+    const expected = `| Name  | Age |
+| ----- | --- |
+| Alice | 25  |
+| Bob   | 30  |`
+    expect(formatMarkdownTable(input)).toBe(expected)
+  })
+
+  it('handles wide CJK characters', () => {
+    const input = `
+| 名字 | 年龄 |
+|---|---|
+| 张三 | 25 |
+| Li | 30 |
+`.trim()
+    // 名字 (4 width) | 年龄 (4 width)
+    // 张三 (4 width) | 25 (2 width) -> pad to 4 -> 25__
+    // Li (2 width)   | 30 (2 width) -> pad to 4 -> 30__
+    // Max cols: 4, 4
+    
+    const expected = `| 名字 | 年龄 |
+| ---- | ---- |
+| 张三 | 25   |
+| Li   | 30   |`
+    expect(formatMarkdownTable(input)).toBe(expected)
+  })
+
+  it('preserves alignment markers', () => {
+    const input = `
+| Left | Center | Right |
+| :--- | :---: | ---: |
+| 1 | 2 | 3 |
+`.trim()
+    
+    // Left (4) | Center (6) | Right (5)
+    // 1 (1) -> 1___ | 2 (1) -> 2_____ | 3 (1) -> 3____
+    
+    const expected = `| Left | Center | Right |
+| :--- | :----: | ----: |
+| 1    | 2      | 3     |`
+    expect(formatMarkdownTable(input)).toBe(expected)
+  })
+  
+  it('handles empty cells', () => {
+      const input = `
+| A | B |
+|---|---|
+| 1 | |
+| | 2 |
+`.trim()
+    const expected = `| A   | B   |
+| --- | --- |
+| 1   |     |
+|     | 2   |`
+    expect(formatMarkdownTable(input)).toBe(expected)
+  })
+})


### PR DESCRIPTION
Users can now format markdown tables directly from the editor toolbar, with automatic column alignment and support for wide characters (CJK, emojis).

- A new "Format Table" button in the toolbar detects and reformats tables at the cursor position.
- Tables are aligned with consistent spacing across all columns, accounting for multi-byte characters.
- Alignment markers (`:---`, `:---:`, `---:`) are preserved during formatting.
- Empty cells and mixed character widths (ASCII and CJK) are handled correctly.
- Toast notifications inform users when no valid table is found at the cursor.

The toast notification system has also been migrated from the `sonner` library to a custom `@/hooks/useToast` hook for consistency. Existing non-table formatting features (bullet lists, numbered lists, code blocks) remain unchanged.
