### PR TITLE
fix(build): Add missing onFormatTable mock and document build/typecheck workflow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -84,7 +84,9 @@
 - **Install:** `npm install`
 - **Dev:** `npm run dev`
 - **Test:** `npm test` (Unit), `npm test:e2e` (E2E)
+- **Type Check:** `npm run tsc` (Must pass with zero errors).
 - **Lint:** `npm run lint` (Zero warnings tolerance).
+- **Build:** `npm run build` (Must complete successfully).
 - **Format:** `npm run format` (Apply Prettier formatting after code changes).
 
 ## 7. Git Commit Convention

--- a/packages/app/src/components/EditorToolbar.test.tsx
+++ b/packages/app/src/components/EditorToolbar.test.tsx
@@ -30,6 +30,7 @@ describe('EditorToolbar', () => {
     onFormatBulletList: vi.fn(),
     onFormatNumberedList: vi.fn(),
     onFormatCodeBlock: vi.fn(),
+    onFormatTable: vi.fn(),
     toggleVimMode: vi.fn(),
     toggleTheme: vi.fn(),
     setShowShortcuts: vi.fn(),


### PR DESCRIPTION
Ensures the `EditorToolbar` test suite stays aligned with the current component API and clarifies the build/typecheck verification steps for agent workflows.

- The `EditorToolbar` test now provides the required `onFormatTable` mock, preventing prop/type mismatches.
- Agent operation manual now explicitly documents running `npm run tsc` for type checking and `npm run build` for build verification.
- CI/workflow documentation now includes typecheck and build gates to catch broken changes before merge.

All tests pass. No breaking changes for existing code.