### PR TITLE
feat(editor): Add keyboard shortcuts for new features

### DIFF
--- a/packages/app/src/components/EditorPane.tsx
+++ b/packages/app/src/components/EditorPane.tsx
@@ -72,6 +72,9 @@ interface VimModeModule {
   Vim: VimAPI
 }
 
+/**
+ * Initializes Vim mode for Monaco editor including custom operators and actions
+ */
 function setupVim() {
   if (vimClipboardSetup || !VimMode) {
     return
@@ -225,6 +228,8 @@ export interface EditorPaneHandle {
   onScroll: (callback: () => void) => { dispose: () => void }
   /** Format the table at the current cursor position */
   formatTable: () => void
+  /** Focus the editor */
+  focus: () => void
 }
 
 /**
@@ -601,6 +606,10 @@ export const EditorPane = forwardRef<EditorPaneHandle, EditorPaneProps>(
           // Restore cursor position roughly? Or focus.
           editor.focus()
         }
+      },
+
+      focus: () => {
+        editorRef.current?.focus()
       },
     }))
 

--- a/packages/app/src/components/EditorToolbar.tsx
+++ b/packages/app/src/components/EditorToolbar.tsx
@@ -1,4 +1,11 @@
-import { type ElementType, forwardRef, useState, useRef } from 'react'
+import {
+  type ElementType,
+  forwardRef,
+  useState,
+  useRef,
+  type MouseEvent,
+  type RefObject,
+} from 'react'
 import {
   DndContext,
   DragOverlay,
@@ -87,6 +94,9 @@ import { cn } from '@/utils/classnames'
 import type { ReactElement } from 'react'
 import type { TransformationPipeline } from '@/components/transformer/types'
 
+/**
+ * Props for the ToolbarButton component
+ */
 interface ToolbarButtonProps {
   icon: ElementType
   label: string
@@ -154,7 +164,11 @@ const ToolbarButton = forwardRef<HTMLButtonElement, ToolbarButtonProps>(
 )
 ToolbarButton.displayName = 'ToolbarButton'
 
-// Sortable Button Wrapper for Pipelines
+/**
+ * Sortable wrapper for a transformation pipeline button
+ * @param props - Component props
+ * @returns Sortable pipeline button
+ */
 function SortablePipelineButton({
   pipeline,
   isActive,
@@ -273,6 +287,7 @@ interface EditorToolbarProps {
   toggleLineNumbers?: () => void
   startEmpty?: boolean
   toggleStartEmpty?: () => void
+  documentMenuRef?: RefObject<HTMLButtonElement | null>
 }
 
 /**
@@ -321,6 +336,7 @@ export function EditorToolbar({
   toggleLineNumbers,
   startEmpty,
   toggleStartEmpty,
+  documentMenuRef,
 }: EditorToolbarProps): ReactElement {
   const [isConfirmingClear, setIsConfirmingClear] = useState(false)
   const [pipelineToDelete, setPipelineToDelete] = useState<TransformationPipeline | null>(null)
@@ -328,7 +344,7 @@ export function EditorToolbar({
   const clearTimerRef = useRef<NodeJS.Timeout | null>(null)
   const headingActionRef = useRef(false)
 
-  const handleClearClick = (e: React.MouseEvent) => {
+  const handleClearClick = (e: MouseEvent) => {
     if (!isConfirmingClear) {
       e.preventDefault()
       setIsConfirmingClear(true)
@@ -386,6 +402,7 @@ export function EditorToolbar({
         <DropdownMenu>
           <DropdownMenuTrigger asChild>
             <Button
+              ref={documentMenuRef}
               variant="ghost"
               className={cn(
                 'gap-2 text-sm font-medium',
@@ -410,7 +427,7 @@ export function EditorToolbar({
             <DropdownMenuSub>
               <DropdownMenuSubTrigger>
                 <Download className="size-4" />
-                Download
+                Download (Cmd+Shift+S)
               </DropdownMenuSubTrigger>
               <DropdownMenuSubContent>
                 <DropdownMenuItem onClick={onDownloadMarkdown}>
@@ -478,7 +495,7 @@ export function EditorToolbar({
               }}
             >
               <Heading1 className="size-4" />
-              Heading 1
+              Heading 1 (Cmd+Opt+1)
             </DropdownMenuItem>
             <DropdownMenuItem
               onClick={() => {
@@ -487,7 +504,7 @@ export function EditorToolbar({
               }}
             >
               <Heading2 className="size-4" />
-              Heading 2
+              Heading 2 (Cmd+Opt+2)
             </DropdownMenuItem>
             <DropdownMenuItem
               onClick={() => {
@@ -496,19 +513,31 @@ export function EditorToolbar({
               }}
             >
               <Heading3 className="size-4" />
-              Heading 3
+              Heading 3 (Cmd+Opt+3)
             </DropdownMenuItem>
           </DropdownMenuContent>
         </DropdownMenu>
-        <ToolbarButton icon={Quote} label="Quote" onClick={onFormatQuote} />
-        <ToolbarButton icon={List} label="Bullet List" onClick={onFormatBulletList} />
-        <ToolbarButton icon={ListOrdered} label="Numbered List" onClick={onFormatNumberedList} />
-        <ToolbarButton icon={CodeSquare} label="Code Block" onClick={onFormatCodeBlock} />
-        <ToolbarButton icon={Table} label="Format Table" onClick={onFormatTable} />
+        <ToolbarButton icon={Quote} label="Quote (Cmd+Opt+B)" onClick={onFormatQuote} />
+        <ToolbarButton icon={List} label="Bullet List (Cmd+Shift+U)" onClick={onFormatBulletList} />
+        <ToolbarButton
+          icon={ListOrdered}
+          label="Numbered List (Cmd+Shift+O)"
+          onClick={onFormatNumberedList}
+        />
+        <ToolbarButton
+          icon={CodeSquare}
+          label="Code Block (Cmd+Shift+K)"
+          onClick={onFormatCodeBlock}
+        />
+        <ToolbarButton icon={Table} label="Format Table (Cmd+Shift+T)" onClick={onFormatTable} />
 
         <div className="w-px h-5 bg-border mx-1" />
 
-        <ToolbarButton icon={Wand2} label="Transform Selection" onClick={onOpenTransformer} />
+        <ToolbarButton
+          icon={Wand2}
+          label="Transform Selection (Cmd+Shift+M)"
+          onClick={onOpenTransformer}
+        />
 
         {pipelines && pipelines.length > 0 && (
           <DndContext

--- a/packages/app/src/components/KeyboardShortcutsDialog.tsx
+++ b/packages/app/src/components/KeyboardShortcutsDialog.tsx
@@ -53,6 +53,42 @@ export function KeyboardShortcutsDialog({
                   <code className="bg-muted px-2 py-1 rounded text-xs font-mono">Cmd/Ctrl + K</code>
                 </div>
                 <div className="flex justify-between items-center text-sm">
+                  <span className="text-muted-foreground">Heading 1/2/3</span>
+                  <code className="bg-muted px-2 py-1 rounded text-xs font-mono">
+                    Cmd/Ctrl + Opt + 1/2/3
+                  </code>
+                </div>
+                <div className="flex justify-between items-center text-sm">
+                  <span className="text-muted-foreground">Quote</span>
+                  <code className="bg-muted px-2 py-1 rounded text-xs font-mono">
+                    Cmd/Ctrl + Opt + B
+                  </code>
+                </div>
+                <div className="flex justify-between items-center text-sm">
+                  <span className="text-muted-foreground">Bullet List</span>
+                  <code className="bg-muted px-2 py-1 rounded text-xs font-mono">
+                    Cmd/Ctrl + Shift + U
+                  </code>
+                </div>
+                <div className="flex justify-between items-center text-sm">
+                  <span className="text-muted-foreground">Numbered List</span>
+                  <code className="bg-muted px-2 py-1 rounded text-xs font-mono">
+                    Cmd/Ctrl + Shift + O
+                  </code>
+                </div>
+                <div className="flex justify-between items-center text-sm">
+                  <span className="text-muted-foreground">Format Table</span>
+                  <code className="bg-muted px-2 py-1 rounded text-xs font-mono">
+                    Cmd/Ctrl + Shift + T
+                  </code>
+                </div>
+                <div className="flex justify-between items-center text-sm">
+                  <span className="text-muted-foreground">Transform Selection</span>
+                  <code className="bg-muted px-2 py-1 rounded text-xs font-mono">
+                    Cmd/Ctrl + Shift + M
+                  </code>
+                </div>
+                <div className="flex justify-between items-center text-sm">
                   <span className="text-muted-foreground">Code Block</span>
                   <code className="bg-muted px-2 py-1 rounded text-xs font-mono">
                     Cmd/Ctrl + Shift + K
@@ -67,7 +103,13 @@ export function KeyboardShortcutsDialog({
                 <div className="flex justify-between items-center text-sm">
                   <span className="text-muted-foreground">New Document</span>
                   <code className="bg-muted px-2 py-1 rounded text-xs font-mono">
-                    Cmd/Ctrl + Alt + N
+                    Cmd/Ctrl + Opt + N
+                  </code>
+                </div>
+                <div className="flex justify-between items-center text-sm">
+                  <span className="text-muted-foreground">Download (Markdown)</span>
+                  <code className="bg-muted px-2 py-1 rounded text-xs font-mono">
+                    Cmd/Ctrl + Shift + S
                   </code>
                 </div>
                 <div className="flex justify-between items-center text-sm">
@@ -97,6 +139,18 @@ export function KeyboardShortcutsDialog({
             <div>
               <h3 className="font-semibold text-sm mb-3">Application</h3>
               <div className="space-y-2">
+                <div className="flex justify-between items-center text-sm">
+                  <span className="text-muted-foreground">Focus Editor</span>
+                  <code className="bg-muted px-2 py-1 rounded text-xs font-mono">
+                    Cmd/Ctrl + Opt + E
+                  </code>
+                </div>
+                <div className="flex justify-between items-center text-sm">
+                  <span className="text-muted-foreground">Focus Document Menu</span>
+                  <code className="bg-muted px-2 py-1 rounded text-xs font-mono">
+                    Cmd/Ctrl + Opt + A
+                  </code>
+                </div>
                 <div className="flex justify-between items-center text-sm">
                   <span className="text-muted-foreground">Save</span>
                   <code className="bg-muted px-2 py-1 rounded text-xs font-mono">Cmd/Ctrl + S</code>

--- a/packages/app/src/components/PoeEditor.tsx
+++ b/packages/app/src/components/PoeEditor.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback, useMemo, useEffect, type ReactElement } from 'react'
+import { useState, useCallback, useMemo, useEffect, useRef, type ReactElement } from 'react'
 import { useTheme } from 'next-themes'
 import { useIsMobile } from '@/hooks/useIsMobile'
 import { useUrlState } from '@/hooks/useUrlState'
@@ -102,6 +102,7 @@ export function PoeEditor({ onReady }: PoeEditorProps): ReactElement {
     lineNumber: 1,
     column: 1,
   })
+  const documentMenuRef = useRef<HTMLButtonElement>(null)
 
   /* View mode management */
   const { viewMode, setViewMode } = useViewMode()
@@ -372,6 +373,19 @@ ${htmlContent}
     onClear: handleClear,
     onCopyLink: handleCopyLink,
     onReset: () => setShowResetConfirm(true),
+    onHeading: handleFormatHeading,
+    onQuote: handleFormatQuote,
+    onBulletList: handleFormatBulletList,
+    onNumberedList: handleFormatNumberedList,
+    onTable: handleFormatTable,
+    onTransform: () => {
+      const selection = sourceRef.current?.getSelection()
+      setSelectedText(selection || undefined)
+      setShowTransformer(true)
+    },
+    onDownload: handleDownloadMarkdown,
+    onFocusEditor: () => sourceRef.current?.focus(),
+    onFocusDocument: () => documentMenuRef.current?.focus(),
   })
 
   // Effects
@@ -520,6 +534,7 @@ ${htmlContent}
           toggleLineNumbers={toggleLineNumbers}
           startEmpty={startEmpty}
           toggleStartEmpty={toggleStartEmpty}
+          documentMenuRef={documentMenuRef}
         />
 
         <AlertDialog open={showResetConfirm} onOpenChange={setShowResetConfirm}>

--- a/packages/app/src/hooks/useKeyboardShortcuts.test.ts
+++ b/packages/app/src/hooks/useKeyboardShortcuts.test.ts
@@ -16,6 +16,15 @@ describe('useKeyboardShortcuts', () => {
     onClear: vi.fn(),
     onCopyLink: vi.fn(),
     onReset: vi.fn(),
+    onHeading: vi.fn(),
+    onQuote: vi.fn(),
+    onBulletList: vi.fn(),
+    onNumberedList: vi.fn(),
+    onTable: vi.fn(),
+    onTransform: vi.fn(),
+    onDownload: vi.fn(),
+    onFocusEditor: vi.fn(),
+    onFocusDocument: vi.fn(),
   }
 
   const triggerKeyDown = (key: string, options: KeyboardEventInit = {}) => {
@@ -102,6 +111,48 @@ describe('useKeyboardShortcuts', () => {
     renderHook(() => useKeyboardShortcuts(handlers))
     triggerKeyDown('F2')
     expect(handlers.onRename).toHaveBeenCalled()
+  })
+
+  it('should trigger onHeading with Cmd+Alt+1/2/3', () => {
+    renderHook(() => useKeyboardShortcuts(handlers))
+    triggerKeyDown('1', { metaKey: true, altKey: true, code: 'Digit1' })
+    expect(handlers.onHeading).toHaveBeenCalledWith(1)
+    triggerKeyDown('2', { metaKey: true, altKey: true, code: 'Digit2' })
+    expect(handlers.onHeading).toHaveBeenCalledWith(2)
+    triggerKeyDown('3', { metaKey: true, altKey: true, code: 'Digit3' })
+    expect(handlers.onHeading).toHaveBeenCalledWith(3)
+  })
+
+  it('should trigger onQuote with Cmd+Alt+B', () => {
+    renderHook(() => useKeyboardShortcuts(handlers))
+    triggerKeyDown('b', { metaKey: true, altKey: true, code: 'KeyB' })
+    expect(handlers.onQuote).toHaveBeenCalled()
+  })
+
+  it('should trigger onFocusEditor with Cmd+Alt+E', () => {
+    renderHook(() => useKeyboardShortcuts(handlers))
+    triggerKeyDown('e', { metaKey: true, altKey: true, code: 'KeyE' })
+    expect(handlers.onFocusEditor).toHaveBeenCalled()
+  })
+
+  it('should trigger onFocusDocument with Cmd+Alt+A', () => {
+    renderHook(() => useKeyboardShortcuts(handlers))
+    triggerKeyDown('a', { metaKey: true, altKey: true, code: 'KeyA' })
+    expect(handlers.onFocusDocument).toHaveBeenCalled()
+  })
+
+  it('should trigger formatting shortcuts with Cmd+Shift', () => {
+    renderHook(() => useKeyboardShortcuts(handlers))
+    triggerKeyDown('u', { metaKey: true, shiftKey: true })
+    expect(handlers.onBulletList).toHaveBeenCalled()
+    triggerKeyDown('o', { metaKey: true, shiftKey: true })
+    expect(handlers.onNumberedList).toHaveBeenCalled()
+    triggerKeyDown('t', { metaKey: true, shiftKey: true })
+    expect(handlers.onTable).toHaveBeenCalled()
+    triggerKeyDown('m', { metaKey: true, shiftKey: true })
+    expect(handlers.onTransform).toHaveBeenCalled()
+    triggerKeyDown('s', { metaKey: true, shiftKey: true })
+    expect(handlers.onDownload).toHaveBeenCalled()
   })
 
   it('should NOT trigger shortcuts when typing in an input', () => {

--- a/packages/app/src/hooks/useKeyboardShortcuts.ts
+++ b/packages/app/src/hooks/useKeyboardShortcuts.ts
@@ -13,6 +13,15 @@ interface ShortcutHandlers {
   onClear: () => void
   onCopyLink: () => void
   onReset: () => void
+  onHeading: (level: number) => void
+  onQuote: () => void
+  onBulletList: () => void
+  onNumberedList: () => void
+  onTable: () => void
+  onTransform: () => void
+  onDownload: () => void
+  onFocusEditor: () => void
+  onFocusDocument: () => void
 }
 
 /**
@@ -52,15 +61,39 @@ export function useKeyboardShortcuts(handlers: ShortcutHandlers): void {
       // Handle modifier-based shortcuts
       if (isMod) {
         // Shift + K for code block
-        if (event.shiftKey && event.key.toLowerCase() === 'k') {
-          event.preventDefault()
-          handlers.onCodeBlock()
-          return
+        if (event.shiftKey) {
+          switch (event.key.toLowerCase()) {
+            case 'k':
+              event.preventDefault()
+              handlers.onCodeBlock()
+              return
+            case 's':
+              event.preventDefault()
+              handlers.onDownload()
+              return
+            case 'u':
+              event.preventDefault()
+              handlers.onBulletList()
+              return
+            case 'o':
+              event.preventDefault()
+              handlers.onNumberedList()
+              return
+            case 't':
+              event.preventDefault()
+              handlers.onTable()
+              return
+            case 'm':
+              event.preventDefault()
+              handlers.onTransform()
+              return
+          }
         }
 
         // App-level shortcuts (Cmd+Alt+...)
         if (isAlt) {
           // Use event.code for reliable detection across layouts (ignoring Option key side-effects on character output)
+          // macOS: Option acts as Alt.
           switch (event.code) {
             case 'KeyN':
               event.preventDefault()
@@ -81,6 +114,34 @@ export function useKeyboardShortcuts(handlers: ShortcutHandlers): void {
             case 'Digit0':
               event.preventDefault()
               handlers.onReset()
+              break
+            // Headings
+            case 'Digit1':
+              event.preventDefault()
+              handlers.onHeading(1)
+              break
+            case 'Digit2':
+              event.preventDefault()
+              handlers.onHeading(2)
+              break
+            case 'Digit3':
+              event.preventDefault()
+              handlers.onHeading(3)
+              break
+            // Quote (Cmd+Opt+B)
+            case 'KeyB':
+              event.preventDefault()
+              handlers.onQuote()
+              break
+            // Focus Editor (Cmd+Opt+E)
+            case 'KeyE':
+              event.preventDefault()
+              handlers.onFocusEditor()
+              break
+            // Focus Document Menu (Cmd+Opt+A)
+            case 'KeyA':
+              event.preventDefault()
+              handlers.onFocusDocument()
               break
           }
           return


### PR DESCRIPTION
## Summary

This PR adds comprehensive keyboard shortcuts for common editor operations to improve workflow efficiency and accessibility.

## What's New

Users can now format and navigate using keyboard shortcuts:

- Format text with `Cmd/Ctrl + Opt + 1/2/3` for headings
- Insert quotes with `Cmd/Ctrl + Opt + B`
- Create bullet lists with `Cmd/Ctrl + Shift + U`
- Create numbered lists with `Cmd/Ctrl + Shift + O`
- Format tables with `Cmd/Ctrl + Shift + T`
- Transform selected text with `Cmd/Ctrl + Shift + M`
- Download Markdown with `Cmd/Ctrl + Shift + S`
- Focus the editor with `Cmd/Ctrl + Opt + E`
- Focus the document menu with `Cmd/Ctrl + Opt + A`

## Changes

- Added keyboard shortcuts for headings, quotes, lists, tables, transform, and download
- Added focus shortcuts for editor and document menu navigation
- Updated `KeyboardShortcutsDialog` with all new shortcuts
- Added `focus()` method to `EditorPane` for programmatic focus control
- Added `documentMenuRef` prop to `EditorToolbar` for focus management
- Added comprehensive tests for all new shortcuts
- Improved JSDoc documentation across affected components

## Notes

- All shortcuts follow the existing pattern: `Cmd/Ctrl + Shift` for formatting, `Cmd/Ctrl + Opt` for app-level actions
- Shortcuts are disabled when typing in input fields to prevent conflicts