### PR TITLE
feat(editor): Add comprehensive table manipulation features

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -83,7 +83,7 @@
 
 - **Install:** `npm install`
 - **Dev:** `npm run dev`
-- **Test:** `npm test` (Unit), `npm test:e2e` (E2E)
+- **Test:** `npm test` (Unit), `npm test:e2e` (E2E) - Both must pass before completing.
 - **Type Check:** `npm run tsc` (Must pass with zero errors).
 - **Lint:** `npm run lint` (Zero warnings tolerance).
 - **Build:** `npm run build` (Must complete successfully).
@@ -105,7 +105,7 @@
 2. **DO NOT** use `console.log` in final code.
 3. **DO NOT** import React namespace (e.g., `import React from 'react'` or `import * as React from 'react'`). JSX Transform is enabled; import only what you need.
 4. **DO NOT** force "Strict TDD" (write test first) unless helpful; allow pragmatic development but ensure tests exist before completion.
-5. **DO NOT** leave the codebase in a broken state. Ensure all linting errors and unit tests pass before considering a task complete.
+5. **DO NOT** leave the codebase in a broken state. Ensure all linting errors, unit tests, build, and E2E tests pass before considering a task complete.
 6. **DO NOT** ignore warnings. All warnings must be addressed before completing a task. This includes:
    - ESLint warnings
    - TypeScript warnings

--- a/packages/app/src/components/AboutDialog.tsx
+++ b/packages/app/src/components/AboutDialog.tsx
@@ -37,6 +37,7 @@ export function AboutDialog({ open, onOpenChange }: AboutDialogProps): ReactElem
               <li>URL-based document persistence</li>
               <li>Custom text transformers</li>
               <li>Transformers import/export</li>
+              <li>Markdown table tools</li>
             </ul>
           </div>
           <div className="text-xs text-muted-foreground border-t border-border pt-4">

--- a/packages/app/src/components/EditorToolbar.test.tsx
+++ b/packages/app/src/components/EditorToolbar.test.tsx
@@ -30,7 +30,9 @@ describe('EditorToolbar', () => {
     onFormatBulletList: vi.fn(),
     onFormatNumberedList: vi.fn(),
     onFormatCodeBlock: vi.fn(),
-    onFormatTable: vi.fn(),
+
+    onTableAction: vi.fn(),
+    isInTable: false,
     toggleVimMode: vi.fn(),
     toggleTheme: vi.fn(),
     setShowShortcuts: vi.fn(),

--- a/packages/app/src/components/EditorToolbar.tsx
+++ b/packages/app/src/components/EditorToolbar.tsx
@@ -88,11 +88,16 @@ import {
   WholeWord,
   Hash,
   Table,
+  Plus,
+  AlignLeft,
+  Columns,
+  Rows,
 } from 'lucide-react'
 import { ICON_MAP } from '@/components/transformer/constants'
 import { cn } from '@/utils/classnames'
 import type { ReactElement } from 'react'
 import type { TransformationPipeline } from '@/components/transformer/types'
+import type { TableAction } from '@/components/editor'
 
 /**
  * Props for the ToolbarButton component
@@ -266,7 +271,8 @@ interface EditorToolbarProps {
   onFormatBulletList: () => void
   onFormatNumberedList: () => void
   onFormatCodeBlock: () => void
-  onFormatTable: () => void
+  onTableAction: (action: TableAction) => void
+  isInTable: boolean
   toggleVimMode: () => void
   toggleTheme: () => void
   setShowShortcuts: (show: boolean) => void
@@ -316,7 +322,8 @@ export function EditorToolbar({
   onFormatBulletList,
   onFormatNumberedList,
   onFormatCodeBlock,
-  onFormatTable,
+  onTableAction,
+  isInTable,
   toggleVimMode,
   toggleTheme,
   setShowShortcuts,
@@ -521,7 +528,76 @@ export function EditorToolbar({
         <ToolbarButton icon={List} label="Bullet List" onClick={onFormatBulletList} />
         <ToolbarButton icon={ListOrdered} label="Numbered List" onClick={onFormatNumberedList} />
         <ToolbarButton icon={CodeSquare} label="Code Block" onClick={onFormatCodeBlock} />
-        <ToolbarButton icon={Table} label="Format Table" onClick={onFormatTable} />
+
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <Button
+              variant="ghost"
+              size="icon-sm"
+              className={cn(
+                'text-muted-foreground hover:text-foreground',
+                isInTable && 'bg-accent text-foreground'
+              )}
+            >
+              <Table className="size-4" />
+              <span className="sr-only">Table Operations</span>
+            </Button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent>
+            {!isInTable ? (
+              <DropdownMenuItem onClick={() => onTableAction('insert-table')}>
+                <Plus className="size-4" />
+                Insert Table
+              </DropdownMenuItem>
+            ) : (
+              <>
+                <DropdownMenuSub>
+                  <DropdownMenuSubTrigger>
+                    <Rows className="size-4" /> Rows
+                  </DropdownMenuSubTrigger>
+                  <DropdownMenuSubContent>
+                    <DropdownMenuItem onClick={() => onTableAction('insert-row-above')}>
+                      <Plus className="size-4" /> Add Row Above
+                    </DropdownMenuItem>
+                    <DropdownMenuItem onClick={() => onTableAction('insert-row-below')}>
+                      <Plus className="size-4" /> Add Row Below
+                    </DropdownMenuItem>
+                    <DropdownMenuItem
+                      onClick={() => onTableAction('delete-row')}
+                      className="text-destructive"
+                    >
+                      <Trash2 className="size-4" /> Delete Row
+                    </DropdownMenuItem>
+                  </DropdownMenuSubContent>
+                </DropdownMenuSub>
+
+                <DropdownMenuSub>
+                  <DropdownMenuSubTrigger>
+                    <Columns className="size-4" /> Columns
+                  </DropdownMenuSubTrigger>
+                  <DropdownMenuSubContent>
+                    <DropdownMenuItem onClick={() => onTableAction('insert-col-left')}>
+                      <Plus className="size-4" /> Add Column Left
+                    </DropdownMenuItem>
+                    <DropdownMenuItem onClick={() => onTableAction('insert-col-right')}>
+                      <Plus className="size-4" /> Add Column Right
+                    </DropdownMenuItem>
+                    <DropdownMenuItem
+                      onClick={() => onTableAction('delete-col')}
+                      className="text-destructive"
+                    >
+                      <Trash2 className="size-4" /> Delete Column
+                    </DropdownMenuItem>
+                  </DropdownMenuSubContent>
+                </DropdownMenuSub>
+                <DropdownMenuSeparator />
+                <DropdownMenuItem onClick={() => onTableAction('format-table')}>
+                  <AlignLeft className="size-4" /> Format Table
+                </DropdownMenuItem>
+              </>
+            )}
+          </DropdownMenuContent>
+        </DropdownMenu>
 
         <div className="w-px h-5 bg-border mx-1" />
 

--- a/packages/app/src/components/editor/EditorPane.test.tsx
+++ b/packages/app/src/components/editor/EditorPane.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen, fireEvent, waitFor } from '@testing-library/react'
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { EditorPane } from './EditorPane'
+import { EditorPane } from './index'
 import { copyToClipboard } from '@/utils/clipboard'
 import { toast } from '@/hooks/useToast'
 import { initVimMode } from 'monaco-vim'
@@ -32,6 +32,11 @@ vi.mock('@monaco-editor/react', () => ({
         executeEdits: vi.fn(),
         setPosition: vi.fn(),
         focus: vi.fn(),
+        createContextKey: vi.fn().mockReturnValue({
+          set: vi.fn(),
+          get: vi.fn(),
+          reset: vi.fn(),
+        }),
       },
       {
         KeyMod: { CtrlCmd: 2048, Shift: 1024 },

--- a/packages/app/src/components/editor/index.ts
+++ b/packages/app/src/components/editor/index.ts
@@ -1,0 +1,1 @@
+export * from './EditorPane'

--- a/packages/app/src/components/editor/table.ts
+++ b/packages/app/src/components/editor/table.ts
@@ -1,0 +1,255 @@
+import type { editor } from 'monaco-editor'
+import { isMarkdownTable, parseTableRows } from '@/utils/markdownTable'
+
+// Helper to check if a line is part of a table
+export const isTableLine = (lineContent: string) => lineContent.includes('|')
+
+export interface TableScope {
+  range: {
+    startLineNumber: number
+    startColumn: number
+    endLineNumber: number
+    endColumn: number
+  }
+  text: string
+  rowIndex: number
+  colIndex: number
+  rows: string[][]
+  startLine: number
+}
+
+/**
+ * Identifies the markdown table at the current cursor position.
+ * @param model - The Monaco editor text model
+ * @param position - The current cursor position
+ * @returns TableScope object if inside a table, null otherwise
+ */
+export function getTableAtCursor(
+  model: editor.ITextModel,
+  position: { lineNumber: number; column: number }
+): TableScope | null {
+  const currentLine = position.lineNumber
+  if (!isTableLine(model.getLineContent(currentLine))) return null
+
+  let startLine = currentLine
+  while (startLine > 1 && isTableLine(model.getLineContent(startLine - 1))) {
+    startLine--
+  }
+
+  let endLine = currentLine
+  while (endLine < model.getLineCount() && isTableLine(model.getLineContent(endLine + 1))) {
+    endLine++
+  }
+
+  const range = {
+    startLineNumber: startLine,
+    startColumn: 1,
+    endLineNumber: endLine,
+    endColumn: model.getLineMaxColumn(endLine),
+  }
+
+  const tableText = model.getValueInRange(range)
+  if (!isMarkdownTable(tableText)) return null
+
+  const rows = parseTableRows(tableText)
+  const columnCount = rows[0]?.length || 0
+
+  // Row index relative to table start
+  const rowIndex = currentLine - startLine
+
+  // Calculate column index based on pipes before cursor
+  const lineContent = model.getLineContent(currentLine)
+  // Ensure we don't look past the cursor
+  const contentBeforeCursor = lineContent.substring(0, position.column - 1)
+
+  const pipesBefore = (contentBeforeCursor.match(/\|/g) || []).length
+  // If line starts with pipe, col index is pipesBefore - 1.
+  let colIndex = pipesBefore - 1
+  if (!lineContent.trim().startsWith('|')) colIndex = pipesBefore
+
+  // Clamp colIndex to valid range [0, columnCount - 1]
+  if (colIndex < 0) colIndex = 0
+  if (colIndex >= columnCount) colIndex = Math.max(0, columnCount - 1)
+
+  return {
+    range,
+    text: tableText,
+    rowIndex,
+    colIndex,
+    rows,
+    startLine,
+  }
+}
+
+/**
+ * Handles Tab navigation within a markdown table.
+ * @param editor - The Monaco editor instance
+ * @param direction - 1 for next cell, -1 for previous cell
+ */
+export function handleTableNavigation(editor: editor.IStandaloneCodeEditor, direction: 1 | -1) {
+  const position = editor.getPosition()
+  if (!position) return
+
+  const model = editor.getModel()
+  if (!model) return
+
+  const tableData = getTableAtCursor(model, position)
+  if (!tableData) return
+
+  const { rows, rowIndex, colIndex, startLine } = tableData
+
+  const rowCount = rows.length
+  const colCount = rows[0]?.length || 0
+
+  if (rowCount === 0 || colCount === 0) return
+
+  let nextRow = rowIndex
+  let nextCol = colIndex + direction
+
+  // Navigate
+  // If moving forward
+  if (direction === 1) {
+    if (nextCol >= colCount) {
+      nextCol = 0
+      nextRow++
+    }
+    // Skip separator (index 1 usually)
+    if (nextRow === 1) {
+      nextRow++
+    }
+    // Wrap to start
+    if (nextRow >= rowCount) {
+      nextRow = 0
+      nextCol = 0
+    }
+  }
+  // If moving backward
+  else {
+    if (nextCol < 0) {
+      nextCol = colCount - 1
+      nextRow--
+    }
+    if (nextRow === 1) {
+      nextRow--
+    }
+    // Wrap to end
+    if (nextRow < 0) {
+      nextRow = rowCount - 1
+      nextCol = colCount - 1
+    }
+  }
+
+  // Calculate new position
+  const targetLineIndex = startLine + nextRow
+  const targetLineContent = model.getLineContent(targetLineIndex)
+
+  // Find pipe indices to locate the cell
+  const pipeIndices: number[] = []
+  for (let i = 0; i < targetLineContent.length; i++) {
+    if (targetLineContent[i] === '|') pipeIndices.push(i)
+  }
+
+  // Safety check
+  if (nextCol < pipeIndices.length - 1) {
+    const startColPos = pipeIndices[nextCol] + 1 // +1 to skip pipe
+    const endColPos = pipeIndices[nextCol + 1]
+
+    const cellContent = targetLineContent.substring(startColPos, endColPos)
+    const firstNonSpace = cellContent.search(/\S/)
+
+    const newColumn = startColPos + (firstNonSpace !== -1 ? firstNonSpace : 1)
+
+    editor.setPosition({
+      lineNumber: targetLineIndex,
+      column: newColumn + 1, // Monaco is 1-indexed
+    })
+    editor.revealPosition({
+      lineNumber: targetLineIndex,
+      column: newColumn + 1,
+    })
+  }
+}
+
+export interface TableSelection {
+  tableScope: TableScope
+  selectedRowIndices: number[]
+  selectedColIndices: number[]
+}
+
+/**
+ * Gets the table scope and selected rows/columns based on the current selection.
+ */
+export function getTableSelection(
+  model: editor.ITextModel,
+  selection: {
+    startLineNumber: number
+    startColumn: number
+    endLineNumber: number
+    endColumn: number
+  }
+): TableSelection | null {
+  // Check if the selection start is inside a table
+  const startPos = { lineNumber: selection.startLineNumber, column: selection.startColumn }
+  const tableScope = getTableAtCursor(model, startPos)
+
+  if (!tableScope) return null
+
+  // Check if the selection end is also inside the SAME table
+  // Optimization: check if endLineNumber is within table range
+  if (selection.endLineNumber > tableScope.range.endLineNumber) {
+    // Selection extends beyond table, treat as non-table selection?
+    // Or just clamp? Let's treat as valid if start is in table.
+    // But for table operations, usually we want to contain it.
+    // Let's proceed with the scope found at start.
+  }
+
+  const { startLine, rows } = tableScope
+
+  // Calculate row indices
+  const selectedRowIndices: number[] = []
+  for (let i = selection.startLineNumber; i <= selection.endLineNumber; i++) {
+    const rowIndex = i - startLine
+    if (rowIndex >= 0 && rowIndex < rows.length) {
+      // Exclude separator row (index 1) from deletion context usually?
+      // But if user selects it, we might include it.
+      selectedRowIndices.push(rowIndex)
+    }
+  }
+
+  // Calculate column indices
+  // This is trickier because of variable cell widths.
+  // We need to map selection start/end columns to table columns.
+  // If usage is "highlight text across columns", we interpret that as selecting those columns.
+
+  // Simple heuristic:
+  // 1. Identify start col index from selection.startColumn
+  // 2. Identify end col index from selection.endColumn
+
+  const startLineContent = model.getLineContent(selection.startLineNumber)
+  const endLineContent = model.getLineContent(selection.endLineNumber)
+
+  const getColIndex = (line: string, col: number) => {
+    const prefix = line.substring(0, col - 1)
+    const pipes = (prefix.match(/\|/g) || []).length
+    return Math.max(0, pipes - 1)
+  }
+
+  const startColIdx = getColIndex(startLineContent, selection.startColumn)
+  const endColIdx = getColIndex(endLineContent, selection.endColumn)
+
+  const selectedColIndices: number[] = []
+  const minCol = Math.min(startColIdx, endColIdx)
+  const maxCol = Math.max(startColIdx, endColIdx)
+
+  for (let i = minCol; i <= maxCol; i++) {
+    if (i < rows[0].length) {
+      selectedColIndices.push(i)
+    }
+  }
+
+  return {
+    tableScope,
+    selectedRowIndices,
+    selectedColIndices,
+  }
+}

--- a/packages/app/src/components/editor/vim.ts
+++ b/packages/app/src/components/editor/vim.ts
@@ -1,0 +1,165 @@
+import { VimMode } from 'monaco-vim'
+import type { editor } from 'monaco-editor'
+import { toast } from '@/hooks/useToast'
+
+// Setup clipboard integration for monaco-vim
+// This needs to run only once to register the operators and actions globally
+let vimClipboardSetup = false
+
+interface VimRegisterController {
+  pushText: (
+    register: string,
+    type: string,
+    text: string,
+    linewise: boolean,
+    blockwise: boolean
+  ) => void
+}
+
+interface VimState {
+  vim: {
+    visualBlock: boolean
+  }
+}
+
+interface CodeMirrorAdapter {
+  getSelection: () => string
+  state: VimState
+  readonly editor: editor.IStandaloneCodeEditor
+}
+
+interface VimOperatorArgs {
+  registerName: string
+  linewise: boolean
+  after?: boolean
+}
+
+interface VimAPI {
+  defineOperator: (
+    name: string,
+    fn: (
+      cm: CodeMirrorAdapter,
+      args: VimOperatorArgs,
+      ranges: unknown,
+      oldAnchor: unknown
+    ) => unknown
+  ) => void
+  defineAction: (
+    name: string,
+    fn: (cm: CodeMirrorAdapter, args: VimOperatorArgs) => Promise<void> | void
+  ) => void
+  getRegisterController: () => VimRegisterController
+  handleKey: (cm: CodeMirrorAdapter, key: string) => void
+  mapCommand: (
+    command: string,
+    type: 'action' | 'operator',
+    name: string,
+    args?: Record<string, unknown>,
+    extra?: Record<string, unknown>
+  ) => void
+}
+
+interface VimModeModule {
+  Vim: VimAPI
+}
+
+/**
+ * Initializes Vim mode for Monaco editor including custom operators and actions
+ */
+export function setupVim() {
+  if (vimClipboardSetup || !VimMode) {
+    return
+  }
+  vimClipboardSetup = true
+
+  // VimMode is the CMAdapter class, and 'Vim' API is attached to it at runtime
+  const { Vim } = VimMode as unknown as VimModeModule
+
+  if (!Vim) {
+    return
+  }
+
+  // Define yank to system clipboard operator
+  Vim.defineOperator(
+    'yankSystem',
+    (cm: CodeMirrorAdapter, args: VimOperatorArgs, _ranges: unknown, oldAnchor: unknown) => {
+      const text = cm.getSelection()
+      if (text) {
+        navigator.clipboard.writeText(text).catch(() => {
+          toast({
+            description: 'Failed to write to system clipboard',
+            variant: 'destructive',
+          })
+        })
+
+        // Update internal register for consistency so 'p' works internally
+        Vim.getRegisterController().pushText(
+          args.registerName,
+          'yank',
+          text,
+          args.linewise,
+          cm.state.vim.visualBlock
+        )
+      }
+      return oldAnchor
+    }
+  )
+
+  // Define paste from system clipboard action
+  Vim.defineAction('pasteSystem', async (cm: CodeMirrorAdapter, args: VimOperatorArgs) => {
+    try {
+      const text = await navigator.clipboard.readText()
+      if (text) {
+        const linewise = text.indexOf('\n') !== -1 && (text.endsWith('\n') || text.endsWith('\r\n'))
+
+        // Push to " register
+        Vim.getRegisterController().pushText('"', 'yank', text, linewise, false)
+
+        // Trigger the internal paste action using a mapped key
+        if (args.after) {
+          Vim.handleKey(cm, '<PasteTrigger>')
+        } else {
+          Vim.handleKey(cm, '<PasteTriggerBefore>')
+        }
+      }
+    } catch {
+      toast({
+        description: 'Failed to read from system clipboard',
+        variant: 'destructive',
+      })
+    }
+  })
+
+  // Define visual line movement actions
+  Vim.defineAction('moveDownDisplay', (cm: CodeMirrorAdapter) => {
+    cm.editor.trigger('vim', 'cursorDown', {})
+  })
+
+  Vim.defineAction('moveUpDisplay', (cm: CodeMirrorAdapter) => {
+    cm.editor.trigger('vim', 'cursorUp', {})
+  })
+
+  // Register the internal paste command to a custom key
+  Vim.mapCommand('<PasteTrigger>', 'action', 'paste', { after: true, isEdit: true })
+  Vim.mapCommand('<PasteTriggerBefore>', 'action', 'paste', { after: false, isEdit: true })
+
+  // Remap y to yankSystem operator
+  Vim.mapCommand('y', 'operator', 'yankSystem')
+  // Remap Y to yankSystem (linewise)
+  Vim.mapCommand(
+    'Y',
+    'operator',
+    'yankSystem',
+    { linewise: true },
+    { type: 'operatorMotion', motion: 'expandToLine', motionArgs: { linewise: true } }
+  )
+
+  // Explicitly map p/P back to default 'paste' to ensure no stale 'pasteSystem' mapping remains
+  // This fixes the popup issue by avoiding navigator.clipboard.readText() on 'p'
+  Vim.mapCommand('p', 'action', 'paste', { after: true, isEdit: true })
+  Vim.mapCommand('P', 'action', 'paste', { after: false, isEdit: true })
+
+  // Map gj/gk to visual line movement
+  Vim.mapCommand('gj', 'action', 'moveDownDisplay', {})
+  Vim.mapCommand('gk', 'action', 'moveUpDisplay', {})
+}

--- a/packages/app/src/utils/formatting.test.ts
+++ b/packages/app/src/utils/formatting.test.ts
@@ -10,7 +10,7 @@ import {
   formatBulletList,
   formatNumberedList,
 } from './formatting'
-import type { EditorPaneHandle } from '@/components/EditorPane'
+import type { EditorPaneHandle } from '@/components/editor'
 
 describe('formatting utils', () => {
   let mockEditor: EditorPaneHandle

--- a/packages/app/src/utils/formatting.ts
+++ b/packages/app/src/utils/formatting.ts
@@ -1,4 +1,4 @@
-import type { EditorPaneHandle } from '@/components/EditorPane'
+import type { EditorPaneHandle } from '@/components/editor'
 
 interface LineFormattingOptions {
   editor: EditorPaneHandle


### PR DESCRIPTION
Markdown tables can now be created, modified, and formatted with dedicated toolbar controls.

- Users can insert new markdown tables into documents.
- When inside a table, the toolbar displays an expanded menu with row and column operations: add above/below or left/right, plus delete actions.
- `Tab` and `Shift+Tab` navigate between table cells within the editor.
- Multi-row and multi-column deletions are supported via text selection.
- Table formatting automatically aligns columns and respects alignment markers (`:---`, `:---:`, `---:`).
- The editor detects cursor position within tables and highlights the table button in the toolbar accordingly.
- Vim mode clipboard integration (yank/paste from system clipboard) is now isolated to a dedicated `vim.ts` module.
- Editor pane logic is reorganised into an `editor/` folder with modular exports: `EditorPane.tsx`, `vim.ts`, and `table.ts` for cleaner separation of concerns.

Breaking changes: Import paths for `EditorPane` have moved from `@/components/EditorPane` to `@/components/editor`.
