### PR TITLE
docs: Update package READMEs to reflect architecture changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,9 @@ The editor includes 25+ text operations that can be chained into reusable pipeli
 - Dark and light themes with system detection.
 - Mobile-optimised tab interface.
 - Zero (editor) backend; all processing occurs in browser.
-- Open Graph preview generation backend via Cloudflare Workers.
+- Markdown table formatting and manipulation tools.
+- Static Open Graph image generation via `@packages/og-generator`.
+- Cloudflare Workers proxy for meta tag injection.
 
 ## Use Cases
 

--- a/packages/app/README.md
+++ b/packages/app/README.md
@@ -11,6 +11,7 @@ This is the main application package containing the React frontend for the Poe M
 - Live preview with synchronised scrolling.
 - Vim mode via Monaco Editor.
 - 25+ text transformers with custom pipelines.
+- Markdown table formatting and manipulation.
 - URL-based document persistence (compressed).
 - Dark and light themes.
 - Mobile-optimised interface.

--- a/packages/proxy/README.md
+++ b/packages/proxy/README.md
@@ -1,10 +1,10 @@
 # Poe Editor Proxy
 
-A Cloudflare Worker that generates social media previews when Poe documents are shared. Handles dynamic Open Graph meta tags, preview image generation, and root-level URL routing.
+A Cloudflare Worker that handles dynamic Open Graph meta tags and root-level URL routing for shared documents.
 
 ## Overview
 
-When a Poe document is shared on social media, this worker intercepts the request and generates an Open Graph preview. It dynamically injects Open Graph meta tags and renders preview images on-the-fly using Satori and WASM-based rasterization.
+When a Poe document is shared on social media, this worker intercepts the request. It dynamically injects Open Graph meta tags pointing to pre-generated static images hosted by the app.
 
 ### URL Structure
 
@@ -16,14 +16,9 @@ https://poemd.dev/:title/:snippet#<content-hash>
 
 Example: `https://poemd.dev/The-Raven/Once-upon-a-midnight-dreary#abc123...`
 
-### Open Graph Image Endpoint
-
-`/api/og?title=XXX&snippet=YYY` generates 1200x630 PNG preview images with a minimalist dark theme.
-
 ## Features
 
 - Dynamic Open Graph meta tag injection via HTMLRewriter for SEO and social sharing.
-- On-the-fly preview image generation with a minimalist dark theme.
 - Root-level URL routing for clean, shareable links without query parameters.
 - Built-in XSS prevention through HTML escaping of all path parameters.
 


### PR DESCRIPTION
Restructures documentation to reflect that static Open Graph images are now generated by the app package (`@packages/og-generator`) rather than dynamically on-the-fly by the Cloudflare Workers proxy.

- Proxy now focuses solely on meta tag injection and URL routing, removing references to image generation responsibility.
- App package documentation highlights markdown table formatting capabilities.
- Root README clarifies the separation of concerns: static image generation in the app, proxy-based meta tag injection via Cloudflare Workers.

No functional changes; this updates documentation to match the current architecture.