### PR TITLE
feat(transformer): Refactor dialog into modular components with custom hooks

### DIFF
--- a/packages/app/src/components/PoeEditor.tsx
+++ b/packages/app/src/components/PoeEditor.tsx
@@ -253,12 +253,15 @@ export function PoeEditor({ onReady }: PoeEditorProps): ReactElement {
     [addPipeline, updatePipeline, editingPipeline, toast]
   )
 
-  const handleEditPipeline = useCallback((pipeline: TransformationPipeline) => {
-    const selection = sourceRef.current?.getSelection()
-    setSelectedText(selection || undefined)
-    setEditingPipeline(pipeline)
-    setShowTransformer(true)
-  }, [sourceRef])
+  const handleEditPipeline = useCallback(
+    (pipeline: TransformationPipeline) => {
+      const selection = sourceRef.current?.getSelection()
+      setSelectedText(selection || undefined)
+      setEditingPipeline(pipeline)
+      setShowTransformer(true)
+    },
+    [sourceRef]
+  )
 
   const handleDeletePipeline = useCallback(
     (id: string) => {

--- a/packages/app/src/components/PoeEditor.tsx
+++ b/packages/app/src/components/PoeEditor.tsx
@@ -254,9 +254,11 @@ export function PoeEditor({ onReady }: PoeEditorProps): ReactElement {
   )
 
   const handleEditPipeline = useCallback((pipeline: TransformationPipeline) => {
+    const selection = sourceRef.current?.getSelection()
+    setSelectedText(selection || undefined)
     setEditingPipeline(pipeline)
     setShowTransformer(true)
-  }, [])
+  }, [sourceRef])
 
   const handleDeletePipeline = useCallback(
     (id: string) => {

--- a/packages/app/src/components/transformer/TransformerDesktopView.tsx
+++ b/packages/app/src/components/transformer/TransformerDesktopView.tsx
@@ -1,0 +1,71 @@
+import type { ReactElement } from 'react'
+import { ResizablePanelGroup, ResizablePanel, ResizableHandle } from '@/components/ui/resizable'
+import { TransformerToolbox } from './TransformerToolbox'
+import { TransformerWorkbench } from './TransformerWorkbench'
+import { TransformerPreview } from './TransformerPreview'
+import type { PipelineStep, TransformationPipeline, TransformerOperation } from './types'
+
+interface TransformerDesktopViewProps {
+  steps: PipelineStep[]
+  onSetSteps: React.Dispatch<React.SetStateAction<PipelineStep[]>>
+  onUpdateStep: (id: string, config: Record<string, unknown>) => void
+  onRemoveStep: (id: string) => void
+  onToggleStep: (id: string) => void
+  onAddOperation: (operation: TransformerOperation) => void
+  currentPipeline: TransformationPipeline
+  initialPreviewText?: string
+  vimMode?: boolean
+}
+
+/**
+ * Desktop layout for the transformer dialog with resizable three-panel view.
+ * @param props - Component props
+ * @returns Desktop view component
+ */
+export function TransformerDesktopView({
+  steps,
+  onSetSteps,
+  onUpdateStep,
+  onRemoveStep,
+  onToggleStep,
+  onAddOperation,
+  currentPipeline,
+  initialPreviewText,
+  vimMode,
+}: TransformerDesktopViewProps): ReactElement {
+  return (
+    <div className="flex-1 overflow-hidden h-full">
+      <ResizablePanelGroup orientation="horizontal" className="h-full w-full">
+        <ResizablePanel defaultSize={30} minSize={20}>
+          <div className="h-full overflow-y-auto bg-muted/5">
+            <TransformerToolbox onAddStep={onAddOperation} />
+          </div>
+        </ResizablePanel>
+
+        <ResizableHandle withHandle />
+
+        <ResizablePanel defaultSize={40} minSize={30}>
+          <div className="h-full overflow-y-auto bg-background/50">
+            <TransformerWorkbench
+              steps={steps}
+              onSetSteps={onSetSteps}
+              onUpdateStep={onUpdateStep}
+              onRemoveStep={onRemoveStep}
+              onToggleStep={onToggleStep}
+              onAddOperation={onAddOperation}
+              vimMode={vimMode}
+            />
+          </div>
+        </ResizablePanel>
+
+        <ResizableHandle withHandle />
+
+        <ResizablePanel defaultSize={30} minSize={20}>
+          <div className="h-full overflow-y-auto">
+            <TransformerPreview pipeline={currentPipeline} initialText={initialPreviewText} />
+          </div>
+        </ResizablePanel>
+      </ResizablePanelGroup>
+    </div>
+  )
+}

--- a/packages/app/src/components/transformer/TransformerDialog.tsx
+++ b/packages/app/src/components/transformer/TransformerDialog.tsx
@@ -324,32 +324,63 @@ export function TransformerDialog({
 
             <div className="flex items-center gap-2 ml-auto sm:ml-0 order-2 sm:order-3">
               {initialPreviewText ? (
-                <div className="flex items-center -space-x-px">
-                  <Button
-                    variant="ghost"
-                    onClick={handleApply}
-                    className="h-10 rounded-r-none border-r"
-                  >
-                    Apply
-                  </Button>
-                  <DropdownMenu>
-                    <DropdownMenuTrigger asChild>
-                      <Button variant="ghost" className="h-10 px-2 rounded-l-none">
-                        <ChevronDown className="w-4 h-4" />
-                      </Button>
-                    </DropdownMenuTrigger>
-                    <DropdownMenuContent align="end">
-                      <DropdownMenuItem onClick={handleSave}>
-                        <Save className="w-4 h-4 mr-2" />
-                        Save
-                      </DropdownMenuItem>
-                      <DropdownMenuItem onClick={handleSaveAndApply}>
-                        <Save className="w-4 h-4 mr-2" />
-                        Save &amp; Apply
-                      </DropdownMenuItem>
-                    </DropdownMenuContent>
-                  </DropdownMenu>
-                </div>
+                editPipeline ? (
+                  // Editing with selection: Default to Save & Apply
+                  <div className="flex items-center -space-x-px">
+                    <Button
+                      variant="ghost"
+                      onClick={handleSaveAndApply}
+                      className="h-10 rounded-r-none border-r"
+                    >
+                      Save & Apply
+                    </Button>
+                    <DropdownMenu>
+                      <DropdownMenuTrigger asChild>
+                        <Button variant="ghost" className="h-10 px-2 rounded-l-none">
+                          <ChevronDown className="w-4 h-4" />
+                        </Button>
+                      </DropdownMenuTrigger>
+                      <DropdownMenuContent align="end">
+                        <DropdownMenuItem onClick={handleSave}>
+                          <Save className="w-4 h-4 mr-2" />
+                          Save
+                        </DropdownMenuItem>
+                        <DropdownMenuItem onClick={handleApply}>
+                          <Wand2 className="w-4 h-4 mr-2" />
+                          Apply
+                        </DropdownMenuItem>
+                      </DropdownMenuContent>
+                    </DropdownMenu>
+                  </div>
+                ) : (
+                  // transforming selection: Default to Apply
+                  <div className="flex items-center -space-x-px">
+                    <Button
+                      variant="ghost"
+                      onClick={handleApply}
+                      className="h-10 rounded-r-none border-r"
+                    >
+                      Apply
+                    </Button>
+                    <DropdownMenu>
+                      <DropdownMenuTrigger asChild>
+                        <Button variant="ghost" className="h-10 px-2 rounded-l-none">
+                          <ChevronDown className="w-4 h-4" />
+                        </Button>
+                      </DropdownMenuTrigger>
+                      <DropdownMenuContent align="end">
+                        <DropdownMenuItem onClick={handleSave}>
+                          <Save className="w-4 h-4 mr-2" />
+                          Save
+                        </DropdownMenuItem>
+                        <DropdownMenuItem onClick={handleSaveAndApply}>
+                          <Save className="w-4 h-4 mr-2" />
+                          Save &amp; Apply
+                        </DropdownMenuItem>
+                      </DropdownMenuContent>
+                    </DropdownMenu>
+                  </div>
+                )
               ) : (
                 <Button variant="ghost" onClick={handleSave} className="h-10">
                   <Save className="w-4 h-4 mr-2" />

--- a/packages/app/src/components/transformer/TransformerDialog.tsx
+++ b/packages/app/src/components/transformer/TransformerDialog.tsx
@@ -1,42 +1,16 @@
-import { useState, useCallback, useEffect, useRef, type ReactElement } from 'react'
-import { createPortal } from 'react-dom'
-import {
-  DndContext,
-  DragOverlay,
-  useSensor,
-  useSensors,
-  PointerSensor,
-  type DragStartEvent,
-  type DragEndEvent,
-  closestCenter,
-} from '@dnd-kit/core'
-import { arrayMove } from '@dnd-kit/sortable'
+import { useRef, useEffect, type ReactElement } from 'react'
+import { DndContext, closestCenter } from '@dnd-kit/core'
+import { Save, Wand2 } from 'lucide-react'
 import { useToast } from '@/hooks/useToast'
 import { useMediaQuery } from '@/hooks/useMediaQuery'
-import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogHeader,
-  DialogTitle,
-} from '@/components/ui/dialog'
-import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
-import { ResizablePanelGroup, ResizablePanel, ResizableHandle } from '@/components/ui/resizable'
-import { Button } from '@/components/ui/button'
-import { Input } from '@/components/ui/input'
-import { Wand2, Save, ChevronDown, X } from 'lucide-react'
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuTrigger,
-} from '@/components/ui/dropdown-menu'
-import { IconPicker } from './IconPicker'
-import { TransformerToolbox, DraggableToolboxItem } from './TransformerToolbox'
-import { TransformerWorkbench } from './TransformerWorkbench'
-import { TransformerPreview } from './TransformerPreview'
-import { TransformerStep } from './TransformerStep'
-import type { TransformationPipeline, PipelineStep, TransformerOperation } from './types'
+import { useTransformerPipeline } from '@/hooks/useTransformerPipeline'
+import { useTransformerDragDrop } from '@/hooks/useTransformerDragDrop'
+import { Dialog, DialogContent } from '@/components/ui/dialog'
+import { TransformerDialogHeader } from './TransformerDialogHeader'
+import { TransformerMobileView } from './TransformerMobileView'
+import { TransformerDesktopView } from './TransformerDesktopView'
+import { TransformerDragOverlay } from './TransformerDragOverlay'
+import type { TransformationPipeline } from './types'
 
 interface TransformerDialogProps {
   open: boolean
@@ -47,13 +21,6 @@ interface TransformerDialogProps {
   initialPreviewText?: string
   vimMode?: boolean
 }
-
-interface DragData {
-  sortable?: { index: number }
-  operation?: TransformerOperation
-}
-
-const generateId = (): string => Math.random().toString(36).substring(2, 9)
 
 /**
  * Dialog for creating and editing custom text transformation pipelines.
@@ -70,253 +37,49 @@ export function TransformerDialog({
   vimMode,
 }: TransformerDialogProps): ReactElement {
   const { toast } = useToast()
-  const [activeTab, setActiveTab] = useState('pipeline')
-  const [pipelineName, setPipelineName] = useState('')
-  const [pipelineIcon, setPipelineIcon] = useState('🪄')
-  const [steps, setSteps] = useState<PipelineStep[]>([])
-  const [isToolboxOpen, setIsToolboxOpen] = useState(false)
-  const [activeDragItem, setActiveDragItem] = useState<PipelineStep | TransformerOperation | null>(
-    null
-  )
-  const [activeDragWidth, setActiveDragWidth] = useState<number | undefined>(undefined)
-
   const isDesktop = useMediaQuery('(min-width: 1024px)')
 
   // Track if escape toast has been shown in this session
   const hasShownEscapeToastRef = useRef(false)
 
-  // Track previous open state to detect dialog open transition
+  const pipeline = useTransformerPipeline({
+    open,
+    editPipeline,
+    onSave,
+    onApply,
+    onOpenChange,
+  })
+
+  const dnd = useTransformerDragDrop({
+    steps: pipeline.steps,
+    setSteps: pipeline.setSteps,
+    onAddOperation: pipeline.handleAddOperation,
+  })
+
+  // Reset escape toast tracking when dialog opens
   const wasOpenRef = useRef(open)
-
-  // Configure sensors for drag and drop
-  // Using PointerSensor exclusively provides the best compatibility for both mouse and touch
-  // when touch-action: none is applied to draggable elements.
-  const sensors = useSensors(
-    useSensor(PointerSensor, {
-      activationConstraint: {
-        distance: 8,
-      },
-    })
-  )
-
-  // Load edit state only when dialog transitions from closed to open
   useEffect(() => {
     const wasOpen = wasOpenRef.current
     wasOpenRef.current = open
-
-    // Only run when dialog opens (was closed, now open)
     if (open && !wasOpen) {
       hasShownEscapeToastRef.current = false
-
-      // Defer state updates to avoid synchronous setState in effect
-      queueMicrotask(() => {
-        const name = editPipeline?.name ?? ''
-        const icon = editPipeline?.icon ?? '🪄'
-        const newSteps = editPipeline?.steps ?? []
-
-        setPipelineName(name)
-        setPipelineIcon(icon)
-        setSteps(newSteps)
-        setActiveTab('pipeline')
-        setIsToolboxOpen(false)
-      })
     }
-  }, [open, editPipeline])
-
-  const handleAddOperation = useCallback((operation: TransformerOperation) => {
-    const newStep: PipelineStep = {
-      id: generateId(),
-      operationId: operation.id,
-      config: { ...operation.defaultConfig },
-      enabled: true,
-    }
-    setSteps((prev) => [...prev, newStep])
-    setIsToolboxOpen(false)
-  }, [])
-
-  const handleUpdateStep = useCallback((id: string, config: Record<string, unknown>) => {
-    setSteps((prev) => prev.map((s) => (s.id === id ? { ...s, config } : s)))
-  }, [])
-
-  const handleRemoveStep = useCallback((id: string) => {
-    setSteps((prev) => prev.filter((s) => s.id !== id))
-  }, [])
-
-  const handleToggleStep = useCallback((id: string) => {
-    setSteps((prev) => prev.map((s) => (s.id === id ? { ...s, enabled: !s.enabled } : s)))
-  }, [])
-
-  // DnD Handlers
-  const handleDragStart = (event: DragStartEvent) => {
-    const { active } = event
-    const activeData = active.data.current as DragData | undefined
-
-    if (activeData?.sortable?.index !== undefined) {
-      // It's a step being reordered
-      // Find the step object
-      const step = steps.find((s) => s.id === active.id)
-      if (step) setActiveDragItem(step)
-    } else if (activeData?.operation) {
-      // It's a new operation from toolbox
-      setActiveDragItem(activeData.operation)
-    }
-
-    // Capture width of the dragged element to prevent squashing in overlay
-    if (active.id) {
-      const element = document.getElementById(active.id as string)
-      if (element) {
-        setActiveDragWidth(element.offsetWidth)
-      }
-    }
-  }
-
-  const handleDragEnd = (event: DragEndEvent) => {
-    const { active, over } = event
-    setActiveDragItem(null)
-    setActiveDragWidth(undefined)
-
-    if (!over) return
-
-    // Case 1: Reordering steps
-    if (
-      active.data.current?.sortable?.index !== undefined &&
-      over.data.current?.sortable?.index !== undefined &&
-      active.id !== over.id
-    ) {
-      setSteps((items) => {
-        const oldIndex = items.findIndex((item) => item.id === active.id)
-        const newIndex = items.findIndex((item) => item.id === over.id)
-        return arrayMove(items, oldIndex, newIndex)
-      })
-      return
-    }
-
-    // Case 2: Dropping new operation from toolbox
-    if (active.data.current?.operation && over.id === 'workbench-container') {
-      const operation = active.data.current.operation as TransformerOperation
-      handleAddOperation(operation)
-    }
-  }
-
-  const handleSave = () => {
-    if (!pipelineName.trim()) {
-      toast({
-        description: 'Please enter a name for your pipeline',
-      })
-      return
-    }
-
-    if (steps.length === 0) {
-      toast({
-        description: 'Add at least one step to the pipeline before saving',
-      })
-      return
-    }
-
-    const newPipeline: TransformationPipeline = {
-      id: editPipeline?.id || generateId(),
-      name: pipelineName,
-      icon: pipelineIcon || '🪄',
-      steps,
-    }
-
-    onSave(newPipeline)
-    onOpenChange(false)
-
-    // Reset state
-    setSteps([])
-    setPipelineName('')
-    setPipelineIcon('🪄')
-  }
-
-  const handleApply = () => {
-    if (steps.length === 0) {
-      toast({
-        description: 'Add at least one step to the pipeline before applying',
-      })
-      return
-    }
-
-    if (onApply) {
-      onApply(currentPipeline)
-      onOpenChange(false)
-    }
-  }
-
-  const handleSaveAndApply = () => {
-    if (!pipelineName.trim()) {
-      toast({
-        description: 'Please enter a name for your pipeline',
-      })
-      return
-    }
-
-    if (steps.length === 0) {
-      toast({
-        description: 'Add at least one step to the pipeline before saving and applying',
-      })
-      return
-    }
-
-    const newPipeline: TransformationPipeline = {
-      id: editPipeline?.id || generateId(),
-      name: pipelineName,
-      icon: pipelineIcon || '🪄',
-      steps,
-    }
-
-    onSave(newPipeline)
-    if (onApply) {
-      onApply(newPipeline)
-    }
-    onOpenChange(false)
-
-    // Reset state
-    setSteps([])
-    setPipelineName('')
-    setPipelineIcon('🪄')
-  }
+  }, [open])
 
   // Configure split button actions
   const splitButtonActions = [
-    {
-      id: 'save',
-      label: 'Save',
-      icon: Save,
-      handler: handleSave,
-    },
-    {
-      id: 'apply',
-      label: 'Apply',
-      icon: Wand2,
-      handler: handleApply,
-    },
-    {
-      id: 'saveAndApply',
-      label: 'Save & Apply',
-      icon: Save,
-      handler: handleSaveAndApply,
-    },
+    { id: 'save', label: 'Save', icon: Save, handler: pipeline.handleSave },
+    { id: 'apply', label: 'Apply', icon: Wand2, handler: pipeline.handleApply },
+    { id: 'saveAndApply', label: 'Save & Apply', icon: Save, handler: pipeline.handleSaveAndApply },
   ]
-
   const primaryActionId = editPipeline ? 'saveAndApply' : 'apply'
-  const primaryAction = splitButtonActions.find((a) => a.id === primaryActionId)!
-  const dropdownActions = splitButtonActions.filter((a) => a.id !== primaryActionId)
-
-  // Construct temporary pipeline for preview
-  const currentPipeline: TransformationPipeline = {
-    id: 'preview',
-    name: 'Preview',
-    icon: 'presview',
-    steps,
-  }
 
   return (
     <DndContext
-      sensors={sensors}
+      sensors={dnd.sensors}
       collisionDetection={closestCenter}
-      onDragStart={handleDragStart}
-      onDragEnd={handleDragEnd}
+      onDragStart={dnd.handleDragStart}
+      onDragEnd={dnd.handleDragEnd}
     >
       <Dialog open={open} onOpenChange={onOpenChange}>
         <DialogContent
@@ -326,7 +89,6 @@ export function TransformerDialog({
             const target = e.target as HTMLElement
             const isMonaco = target?.closest?.('.monaco-editor')
 
-            // If focus is inside monaco editor (JSON mode), prevent closing
             if (isMonaco) {
               e.preventDefault()
 
@@ -339,190 +101,55 @@ export function TransformerDialog({
             }
           }}
         >
-          <DialogHeader className="px-4 py-3 border-b shrink-0 flex flex-row flex-wrap sm:flex-nowrap items-center justify-between gap-y-3 sm:gap-y-0 space-y-0 pr-12">
-            <div className="flex items-center gap-2">
-              <Wand2 className="w-5 h-5 text-primary" />
-              <DialogTitle>{editPipeline ? 'Edit Transformer' : 'Transform Selection'}</DialogTitle>
-            </div>
-            <DialogDescription className="sr-only">
-              Create and edit custom text transformation pipelines
-            </DialogDescription>
+          <TransformerDialogHeader
+            editPipeline={editPipeline}
+            initialPreviewText={initialPreviewText}
+            pipelineName={pipeline.pipelineName}
+            onPipelineNameChange={pipeline.setPipelineName}
+            pipelineIcon={pipeline.pipelineIcon}
+            onPipelineIconChange={pipeline.setPipelineIcon}
+            onSave={pipeline.handleSave}
+            splitButtonActions={splitButtonActions}
+            primaryActionId={primaryActionId}
+          />
 
-            <div className="flex items-center gap-2 ml-auto sm:ml-0 order-2 sm:order-3">
-              {initialPreviewText ? (
-                <div className="flex items-center -space-x-px">
-                  <Button
-                    variant="ghost"
-                    onClick={primaryAction.handler}
-                    className="h-10 rounded-r-none border-r"
-                  >
-                    {primaryAction.label}
-                  </Button>
-                  <DropdownMenu>
-                    <DropdownMenuTrigger asChild>
-                      <Button variant="ghost" className="h-10 px-2 rounded-l-none">
-                        <ChevronDown className="w-4 h-4" />
-                      </Button>
-                    </DropdownMenuTrigger>
-                    <DropdownMenuContent align="end">
-                      {dropdownActions.map((action) => (
-                        <DropdownMenuItem key={action.id} onClick={action.handler}>
-                          <action.icon className="w-4 h-4 mr-2" />
-                          {action.label}
-                        </DropdownMenuItem>
-                      ))}
-                    </DropdownMenuContent>
-                  </DropdownMenu>
-                </div>
-              ) : (
-                <Button variant="ghost" onClick={handleSave} className="h-10">
-                  <Save className="w-4 h-4 mr-2" />
-                  Save
-                </Button>
-              )}
-            </div>
-
-            <div className="flex items-center gap-2 w-full sm:w-auto order-3 sm:order-2 sm:mr-4">
-              <IconPicker value={pipelineIcon} onChange={setPipelineIcon} />
-              <Input
-                value={pipelineName}
-                onChange={(e) => setPipelineName(e.target.value)}
-                className="flex-1 sm:w-40 md:w-64 h-10"
-                placeholder="Pipeline Name (e.g. Clean & Sort)"
-              />
-            </div>
-          </DialogHeader>
-
-          {/* Mobile View */}
           {!isDesktop && (
-            <div className="flex-1 overflow-hidden flex flex-col relative">
-              <Tabs value={activeTab} onValueChange={setActiveTab} className="h-full flex flex-col">
-                <TabsList className="w-full justify-start rounded-none border-b bg-background p-0 h-10">
-                  <TabsTrigger
-                    value="pipeline"
-                    className="flex-1 h-10 rounded-none border-b-2 border-transparent data-[state=active]:border-primary data-[state=active]:shadow-none"
-                  >
-                    Edit ({steps.length})
-                  </TabsTrigger>
-                  <TabsTrigger
-                    value="preview"
-                    className="flex-1 h-10 rounded-none border-b-2 border-transparent data-[state=active]:border-primary data-[state=active]:shadow-none"
-                  >
-                    Preview
-                  </TabsTrigger>
-                </TabsList>
-                <TabsContent
-                  value="pipeline"
-                  className="flex-1 m-0 overflow-hidden h-full overflow-y-auto"
-                >
-                  <TransformerWorkbench
-                    steps={steps}
-                    onSetSteps={setSteps}
-                    onUpdateStep={handleUpdateStep}
-                    onRemoveStep={handleRemoveStep}
-                    onToggleStep={handleToggleStep}
-                    onAddOperation={handleAddOperation}
-                    onAddRequest={() => setIsToolboxOpen(true)}
-                    vimMode={vimMode}
-                  />
-                </TabsContent>
-                <TabsContent
-                  value="preview"
-                  className="flex-1 m-0 overflow-hidden h-full overflow-y-auto"
-                >
-                  <TransformerPreview pipeline={currentPipeline} initialText={initialPreviewText} />
-                </TabsContent>
-              </Tabs>
-
-              {/* Toolbox Overlay */}
-              {isToolboxOpen && (
-                <div className="absolute inset-0 z-50 bg-background flex flex-col animate-in slide-in-from-bottom duration-200">
-                  <div className="flex items-center justify-between p-3 border-b bg-background">
-                    <h3 className="font-semibold text-lg">Add Operation</h3>
-                    <Button variant="ghost" size="icon" onClick={() => setIsToolboxOpen(false)}>
-                      <X className="w-5 h-5" />
-                    </Button>
-                  </div>
-                  <div className="flex-1 overflow-hidden">
-                    <TransformerToolbox onAddStep={handleAddOperation} enableDrag={false} />
-                  </div>
-                </div>
-              )}
-            </div>
+            <TransformerMobileView
+              activeTab={pipeline.activeTab}
+              onActiveTabChange={pipeline.setActiveTab}
+              steps={pipeline.steps}
+              onSetSteps={pipeline.setSteps}
+              onUpdateStep={pipeline.handleUpdateStep}
+              onRemoveStep={pipeline.handleRemoveStep}
+              onToggleStep={pipeline.handleToggleStep}
+              onAddOperation={pipeline.handleAddOperation}
+              isToolboxOpen={pipeline.isToolboxOpen}
+              onToolboxOpenChange={pipeline.setIsToolboxOpen}
+              currentPipeline={pipeline.currentPipeline}
+              initialPreviewText={initialPreviewText}
+              vimMode={vimMode}
+            />
           )}
 
-          {/* Desktop View */}
           {isDesktop && (
-            <div className="flex-1 overflow-hidden h-full">
-              <ResizablePanelGroup orientation="horizontal" className="h-full w-full">
-                <ResizablePanel defaultSize={30} minSize={20}>
-                  <div className="h-full overflow-y-auto bg-muted/5">
-                    <TransformerToolbox onAddStep={handleAddOperation} />
-                  </div>
-                </ResizablePanel>
-
-                <ResizableHandle withHandle />
-
-                <ResizablePanel defaultSize={40} minSize={30}>
-                  <div className="h-full overflow-y-auto bg-background/50">
-                    <TransformerWorkbench
-                      steps={steps}
-                      onSetSteps={setSteps}
-                      onUpdateStep={handleUpdateStep}
-                      onRemoveStep={handleRemoveStep}
-                      onToggleStep={handleToggleStep}
-                      onAddOperation={handleAddOperation}
-                      vimMode={vimMode}
-                    />
-                  </div>
-                </ResizablePanel>
-
-                <ResizableHandle withHandle />
-
-                <ResizablePanel defaultSize={30} minSize={20}>
-                  <div className="h-full overflow-y-auto">
-                    <TransformerPreview
-                      pipeline={currentPipeline}
-                      initialText={initialPreviewText}
-                    />
-                  </div>
-                </ResizablePanel>
-              </ResizablePanelGroup>
-            </div>
+            <TransformerDesktopView
+              steps={pipeline.steps}
+              onSetSteps={pipeline.setSteps}
+              onUpdateStep={pipeline.handleUpdateStep}
+              onRemoveStep={pipeline.handleRemoveStep}
+              onToggleStep={pipeline.handleToggleStep}
+              onAddOperation={pipeline.handleAddOperation}
+              currentPipeline={pipeline.currentPipeline}
+              initialPreviewText={initialPreviewText}
+              vimMode={vimMode}
+            />
           )}
         </DialogContent>
       </Dialog>
-      {createPortal(
-        <DragOverlay className="z-[100] pointer-events-none" modifiers={[]} dropAnimation={null}>
-          {activeDragItem ? (
-            'operationId' in activeDragItem ? (
-              // It's a Step
-              <div className="opacity-80">
-                <TransformerStep
-                  step={activeDragItem as PipelineStep}
-                  index={-1}
-                  onUpdate={() => {}}
-                  onRemove={() => {}}
-                  onToggle={() => {}}
-                  isOverlay
-                  style={{ width: activeDragWidth, margin: 0 }}
-                />
-              </div>
-            ) : (
-              // It's a new Operation
-              <div className="opacity-80">
-                <DraggableToolboxItem
-                  operation={activeDragItem as TransformerOperation}
-                  onAddStep={() => {}}
-                  isOverlay
-                  style={{ width: activeDragWidth, margin: 0 }}
-                />
-              </div>
-            )
-          ) : null}
-        </DragOverlay>,
-        document.body
-      )}
+      <TransformerDragOverlay
+        activeDragItem={dnd.activeDragItem}
+        activeDragWidth={dnd.activeDragWidth}
+      />
     </DndContext>
   )
 }

--- a/packages/app/src/components/transformer/TransformerDialog.tsx
+++ b/packages/app/src/components/transformer/TransformerDialog.tsx
@@ -277,6 +277,32 @@ export function TransformerDialog({
     setPipelineIcon('🪄')
   }
 
+  // Configure split button actions
+  const splitButtonActions = [
+    {
+      id: 'save',
+      label: 'Save',
+      icon: Save,
+      handler: handleSave,
+    },
+    {
+      id: 'apply',
+      label: 'Apply',
+      icon: Wand2,
+      handler: handleApply,
+    },
+    {
+      id: 'saveAndApply',
+      label: 'Save & Apply',
+      icon: Save,
+      handler: handleSaveAndApply,
+    },
+  ]
+
+  const primaryActionId = editPipeline ? 'saveAndApply' : 'apply'
+  const primaryAction = splitButtonActions.find((a) => a.id === primaryActionId)!
+  const dropdownActions = splitButtonActions.filter((a) => a.id !== primaryActionId)
+
   // Construct temporary pipeline for preview
   const currentPipeline: TransformationPipeline = {
     id: 'preview',
@@ -324,63 +350,30 @@ export function TransformerDialog({
 
             <div className="flex items-center gap-2 ml-auto sm:ml-0 order-2 sm:order-3">
               {initialPreviewText ? (
-                editPipeline ? (
-                  // Editing with selection: Default to Save & Apply
-                  <div className="flex items-center -space-x-px">
-                    <Button
-                      variant="ghost"
-                      onClick={handleSaveAndApply}
-                      className="h-10 rounded-r-none border-r"
-                    >
-                      Save & Apply
-                    </Button>
-                    <DropdownMenu>
-                      <DropdownMenuTrigger asChild>
-                        <Button variant="ghost" className="h-10 px-2 rounded-l-none">
-                          <ChevronDown className="w-4 h-4" />
-                        </Button>
-                      </DropdownMenuTrigger>
-                      <DropdownMenuContent align="end">
-                        <DropdownMenuItem onClick={handleSave}>
-                          <Save className="w-4 h-4 mr-2" />
-                          Save
+                <div className="flex items-center -space-x-px">
+                  <Button
+                    variant="ghost"
+                    onClick={primaryAction.handler}
+                    className="h-10 rounded-r-none border-r"
+                  >
+                    {primaryAction.label}
+                  </Button>
+                  <DropdownMenu>
+                    <DropdownMenuTrigger asChild>
+                      <Button variant="ghost" className="h-10 px-2 rounded-l-none">
+                        <ChevronDown className="w-4 h-4" />
+                      </Button>
+                    </DropdownMenuTrigger>
+                    <DropdownMenuContent align="end">
+                      {dropdownActions.map((action) => (
+                        <DropdownMenuItem key={action.id} onClick={action.handler}>
+                          <action.icon className="w-4 h-4 mr-2" />
+                          {action.label}
                         </DropdownMenuItem>
-                        <DropdownMenuItem onClick={handleApply}>
-                          <Wand2 className="w-4 h-4 mr-2" />
-                          Apply
-                        </DropdownMenuItem>
-                      </DropdownMenuContent>
-                    </DropdownMenu>
-                  </div>
-                ) : (
-                  // transforming selection: Default to Apply
-                  <div className="flex items-center -space-x-px">
-                    <Button
-                      variant="ghost"
-                      onClick={handleApply}
-                      className="h-10 rounded-r-none border-r"
-                    >
-                      Apply
-                    </Button>
-                    <DropdownMenu>
-                      <DropdownMenuTrigger asChild>
-                        <Button variant="ghost" className="h-10 px-2 rounded-l-none">
-                          <ChevronDown className="w-4 h-4" />
-                        </Button>
-                      </DropdownMenuTrigger>
-                      <DropdownMenuContent align="end">
-                        <DropdownMenuItem onClick={handleSave}>
-                          <Save className="w-4 h-4 mr-2" />
-                          Save
-                        </DropdownMenuItem>
-                        <DropdownMenuItem onClick={handleSaveAndApply}>
-                          <Save className="w-4 h-4 mr-2" />
-                          Save &amp; Apply
-                        </DropdownMenuItem>
-                      </DropdownMenuContent>
-                    </DropdownMenu>
-                  </div>
-                )
+                      ))}
+                    </DropdownMenuContent>
+                  </DropdownMenu>
+                </div>
               ) : (
                 <Button variant="ghost" onClick={handleSave} className="h-10">
                   <Save className="w-4 h-4 mr-2" />

--- a/packages/app/src/components/transformer/TransformerDialogHeader.tsx
+++ b/packages/app/src/components/transformer/TransformerDialogHeader.tsx
@@ -1,0 +1,108 @@
+import type { ReactElement } from 'react'
+import { Wand2, Save, ChevronDown } from 'lucide-react'
+import { DialogDescription, DialogHeader, DialogTitle } from '@/components/ui/dialog'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu'
+import { IconPicker } from './IconPicker'
+import type { TransformationPipeline } from './types'
+
+interface SplitButtonAction {
+  id: string
+  label: string
+  icon: typeof Save
+  handler: () => void
+}
+
+interface TransformerDialogHeaderProps {
+  editPipeline?: TransformationPipeline | null
+  initialPreviewText?: string
+  pipelineName: string
+  onPipelineNameChange: (name: string) => void
+  pipelineIcon: string
+  onPipelineIconChange: (icon: string) => void
+  onSave: () => void
+  splitButtonActions: SplitButtonAction[]
+  primaryActionId: string
+}
+
+/**
+ * Header component for the transformer dialog with title, name input, icon picker, and actions.
+ * @param props - Component props
+ * @returns Transformer dialog header component
+ */
+export function TransformerDialogHeader({
+  editPipeline,
+  initialPreviewText,
+  pipelineName,
+  onPipelineNameChange,
+  pipelineIcon,
+  onPipelineIconChange,
+  onSave,
+  splitButtonActions,
+  primaryActionId,
+}: TransformerDialogHeaderProps): ReactElement {
+  const primaryAction = splitButtonActions.find((a) => a.id === primaryActionId)!
+  const dropdownActions = splitButtonActions.filter((a) => a.id !== primaryActionId)
+
+  return (
+    <DialogHeader className="px-4 py-3 border-b shrink-0 flex flex-row flex-wrap sm:flex-nowrap items-center justify-between gap-y-3 sm:gap-y-0 space-y-0 pr-12">
+      <div className="flex items-center gap-2">
+        <Wand2 className="w-5 h-5 text-primary" />
+        <DialogTitle>{editPipeline ? 'Edit Transformer' : 'Transform Selection'}</DialogTitle>
+      </div>
+      <DialogDescription className="sr-only">
+        Create and edit custom text transformation pipelines
+      </DialogDescription>
+
+      <div className="flex items-center gap-2 ml-auto sm:ml-0 order-2 sm:order-3">
+        {initialPreviewText ? (
+          <div className="flex items-center -space-x-px">
+            <Button
+              variant="ghost"
+              onClick={primaryAction.handler}
+              className="h-10 rounded-r-none border-r"
+            >
+              {primaryAction.label}
+            </Button>
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <Button variant="ghost" className="h-10 px-2 rounded-l-none">
+                  <ChevronDown className="w-4 h-4" />
+                </Button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent align="end">
+                {dropdownActions.map((action) => (
+                  <DropdownMenuItem key={action.id} onClick={action.handler}>
+                    <action.icon className="w-4 h-4 mr-2" />
+                    {action.label}
+                  </DropdownMenuItem>
+                ))}
+              </DropdownMenuContent>
+            </DropdownMenu>
+          </div>
+        ) : (
+          <Button variant="ghost" onClick={onSave} className="h-10">
+            <Save className="w-4 h-4 mr-2" />
+            Save
+          </Button>
+        )}
+      </div>
+
+      <div className="flex items-center gap-2 w-full sm:w-auto order-3 sm:order-2 sm:mr-4">
+        <IconPicker value={pipelineIcon} onChange={onPipelineIconChange} />
+        <Input
+          value={pipelineName}
+          onChange={(e) => onPipelineNameChange(e.target.value)}
+          className="flex-1 sm:w-40 md:w-64 h-10"
+          placeholder="Pipeline Name (e.g. Clean & Sort)"
+        />
+      </div>
+    </DialogHeader>
+  )
+}

--- a/packages/app/src/components/transformer/TransformerDragOverlay.tsx
+++ b/packages/app/src/components/transformer/TransformerDragOverlay.tsx
@@ -1,0 +1,53 @@
+import type { ReactElement } from 'react'
+import { createPortal } from 'react-dom'
+import { DragOverlay } from '@dnd-kit/core'
+import { TransformerStep } from './TransformerStep'
+import { DraggableToolboxItem } from './TransformerToolbox'
+import type { PipelineStep, TransformerOperation } from './types'
+
+interface TransformerDragOverlayProps {
+  activeDragItem: PipelineStep | TransformerOperation | null
+  activeDragWidth?: number
+}
+
+/**
+ * Drag overlay portal for the transformer dialog, rendering dragged steps or operations.
+ * @param props - Component props
+ * @returns Drag overlay rendered via portal
+ */
+export function TransformerDragOverlay({
+  activeDragItem,
+  activeDragWidth,
+}: TransformerDragOverlayProps): ReactElement {
+  return createPortal(
+    <DragOverlay className="z-[100] pointer-events-none" modifiers={[]} dropAnimation={null}>
+      {activeDragItem ? (
+        'operationId' in activeDragItem ? (
+          // It's a Step
+          <div className="opacity-80">
+            <TransformerStep
+              step={activeDragItem as PipelineStep}
+              index={-1}
+              onUpdate={() => {}}
+              onRemove={() => {}}
+              onToggle={() => {}}
+              isOverlay
+              style={{ width: activeDragWidth, margin: 0 }}
+            />
+          </div>
+        ) : (
+          // It's a new Operation
+          <div className="opacity-80">
+            <DraggableToolboxItem
+              operation={activeDragItem as TransformerOperation}
+              onAddStep={() => {}}
+              isOverlay
+              style={{ width: activeDragWidth, margin: 0 }}
+            />
+          </div>
+        )
+      ) : null}
+    </DragOverlay>,
+    document.body
+  ) as ReactElement
+}

--- a/packages/app/src/components/transformer/TransformerMobileView.tsx
+++ b/packages/app/src/components/transformer/TransformerMobileView.tsx
@@ -1,0 +1,96 @@
+import type { ReactElement } from 'react'
+import { X } from 'lucide-react'
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
+import { Button } from '@/components/ui/button'
+import { TransformerToolbox } from './TransformerToolbox'
+import { TransformerWorkbench } from './TransformerWorkbench'
+import { TransformerPreview } from './TransformerPreview'
+import type { PipelineStep, TransformationPipeline, TransformerOperation } from './types'
+
+interface TransformerMobileViewProps {
+  activeTab: string
+  onActiveTabChange: (tab: string) => void
+  steps: PipelineStep[]
+  onSetSteps: React.Dispatch<React.SetStateAction<PipelineStep[]>>
+  onUpdateStep: (id: string, config: Record<string, unknown>) => void
+  onRemoveStep: (id: string) => void
+  onToggleStep: (id: string) => void
+  onAddOperation: (operation: TransformerOperation) => void
+  isToolboxOpen: boolean
+  onToolboxOpenChange: (open: boolean) => void
+  currentPipeline: TransformationPipeline
+  initialPreviewText?: string
+  vimMode?: boolean
+}
+
+/**
+ * Mobile layout for the transformer dialog with tabbed navigation and toolbox overlay.
+ * @param props - Component props
+ * @returns Mobile view component
+ */
+export function TransformerMobileView({
+  activeTab,
+  onActiveTabChange,
+  steps,
+  onSetSteps,
+  onUpdateStep,
+  onRemoveStep,
+  onToggleStep,
+  onAddOperation,
+  isToolboxOpen,
+  onToolboxOpenChange,
+  currentPipeline,
+  initialPreviewText,
+  vimMode,
+}: TransformerMobileViewProps): ReactElement {
+  return (
+    <div className="flex-1 overflow-hidden flex flex-col relative">
+      <Tabs value={activeTab} onValueChange={onActiveTabChange} className="h-full flex flex-col">
+        <TabsList className="w-full justify-start rounded-none border-b bg-background p-0 h-10">
+          <TabsTrigger
+            value="pipeline"
+            className="flex-1 h-10 rounded-none border-b-2 border-transparent data-[state=active]:border-primary data-[state=active]:shadow-none"
+          >
+            Edit ({steps.length})
+          </TabsTrigger>
+          <TabsTrigger
+            value="preview"
+            className="flex-1 h-10 rounded-none border-b-2 border-transparent data-[state=active]:border-primary data-[state=active]:shadow-none"
+          >
+            Preview
+          </TabsTrigger>
+        </TabsList>
+        <TabsContent value="pipeline" className="flex-1 m-0 overflow-hidden h-full overflow-y-auto">
+          <TransformerWorkbench
+            steps={steps}
+            onSetSteps={onSetSteps}
+            onUpdateStep={onUpdateStep}
+            onRemoveStep={onRemoveStep}
+            onToggleStep={onToggleStep}
+            onAddOperation={onAddOperation}
+            onAddRequest={() => onToolboxOpenChange(true)}
+            vimMode={vimMode}
+          />
+        </TabsContent>
+        <TabsContent value="preview" className="flex-1 m-0 overflow-hidden h-full overflow-y-auto">
+          <TransformerPreview pipeline={currentPipeline} initialText={initialPreviewText} />
+        </TabsContent>
+      </Tabs>
+
+      {/* Toolbox Overlay */}
+      {isToolboxOpen && (
+        <div className="absolute inset-0 z-50 bg-background flex flex-col animate-in slide-in-from-bottom duration-200">
+          <div className="flex items-center justify-between p-3 border-b bg-background">
+            <h3 className="font-semibold text-lg">Add Operation</h3>
+            <Button variant="ghost" size="icon" onClick={() => onToolboxOpenChange(false)}>
+              <X className="w-5 h-5" />
+            </Button>
+          </div>
+          <div className="flex-1 overflow-hidden">
+            <TransformerToolbox onAddStep={onAddOperation} enableDrag={false} />
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/packages/app/src/components/transformer/pipelineUtils.test.ts
+++ b/packages/app/src/components/transformer/pipelineUtils.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect } from 'vitest'
+import {
+  generateId,
+  validatePipelineName,
+  validatePipelineSteps,
+  buildPipeline,
+} from './pipelineUtils'
+import type { PipelineStep } from './types'
+
+describe('pipelineUtils', () => {
+  describe('generateId', () => {
+    it('returns a 7-character string', () => {
+      const id = generateId()
+      expect(id).toHaveLength(7)
+    })
+
+    it('returns alphanumeric characters', () => {
+      const id = generateId()
+      expect(id).toMatch(/^[a-z0-9]+$/)
+    })
+
+    it('generates unique ids', () => {
+      const ids = new Set(Array.from({ length: 100 }, () => generateId()))
+      expect(ids.size).toBeGreaterThan(90)
+    })
+  })
+
+  describe('validatePipelineName', () => {
+    it('returns error for empty string', () => {
+      expect(validatePipelineName('')).toBe('Please enter a name for your pipeline')
+    })
+
+    it('returns error for whitespace-only string', () => {
+      expect(validatePipelineName('   ')).toBe('Please enter a name for your pipeline')
+    })
+
+    it('returns null for valid name', () => {
+      expect(validatePipelineName('My Pipeline')).toBeNull()
+    })
+
+    it('returns null for name with leading/trailing whitespace', () => {
+      expect(validatePipelineName('  My Pipeline  ')).toBeNull()
+    })
+  })
+
+  describe('validatePipelineSteps', () => {
+    it('returns error for empty steps array with saving action', () => {
+      expect(validatePipelineSteps([], 'saving')).toBe(
+        'Add at least one step to the pipeline before saving'
+      )
+    })
+
+    it('returns error for empty steps array with applying action', () => {
+      expect(validatePipelineSteps([], 'applying')).toBe(
+        'Add at least one step to the pipeline before applying'
+      )
+    })
+
+    it('returns error for empty steps array with saving and applying action', () => {
+      expect(validatePipelineSteps([], 'saving and applying')).toBe(
+        'Add at least one step to the pipeline before saving and applying'
+      )
+    })
+
+    it('returns null for non-empty steps array', () => {
+      const steps: PipelineStep[] = [{ id: '1', operationId: 'trim', config: {}, enabled: true }]
+      expect(validatePipelineSteps(steps, 'saving')).toBeNull()
+    })
+  })
+
+  describe('buildPipeline', () => {
+    it('builds pipeline with provided id', () => {
+      const steps: PipelineStep[] = [{ id: '1', operationId: 'trim', config: {}, enabled: true }]
+      const pipeline = buildPipeline({ id: 'test-id', name: 'Test', icon: '🔧', steps })
+      expect(pipeline.id).toBe('test-id')
+      expect(pipeline.name).toBe('Test')
+      expect(pipeline.icon).toBe('🔧')
+      expect(pipeline.steps).toBe(steps)
+    })
+
+    it('generates id when not provided', () => {
+      const pipeline = buildPipeline({ name: 'Test', icon: '🔧', steps: [] })
+      expect(pipeline.id).toHaveLength(7)
+    })
+
+    it('uses default icon when empty string provided', () => {
+      const pipeline = buildPipeline({ name: 'Test', icon: '', steps: [] })
+      expect(pipeline.icon).toBe('🪄')
+    })
+  })
+})

--- a/packages/app/src/components/transformer/pipelineUtils.ts
+++ b/packages/app/src/components/transformer/pipelineUtils.ts
@@ -1,0 +1,54 @@
+import type { PipelineStep, TransformationPipeline } from './types'
+
+/**
+ * Generates a random alphanumeric ID.
+ * @returns A 7-character random string
+ */
+export const generateId = (): string => Math.random().toString(36).substring(2, 9)
+
+/**
+ * Validates a pipeline has a non-empty name.
+ * @param name - The pipeline name to validate
+ * @returns Error message string if invalid, null if valid
+ */
+export function validatePipelineName(name: string): string | null {
+  if (!name.trim()) {
+    return 'Please enter a name for your pipeline'
+  }
+  return null
+}
+
+/**
+ * Validates that a pipeline has at least one step.
+ * @param steps - The pipeline steps array
+ * @param action - The action being performed (for error message customization)
+ * @returns Error message string if invalid, null if valid
+ */
+export function validatePipelineSteps(
+  steps: PipelineStep[],
+  action: 'saving' | 'applying' | 'saving and applying'
+): string | null {
+  if (steps.length === 0) {
+    return `Add at least one step to the pipeline before ${action}`
+  }
+  return null
+}
+
+/**
+ * Builds a TransformationPipeline object from its parts.
+ * @param params - Pipeline construction parameters
+ * @returns A complete TransformationPipeline
+ */
+export function buildPipeline(params: {
+  id?: string
+  name: string
+  icon: string
+  steps: PipelineStep[]
+}): TransformationPipeline {
+  return {
+    id: params.id || generateId(),
+    name: params.name,
+    icon: params.icon || '🪄',
+    steps: params.steps,
+  }
+}

--- a/packages/app/src/components/transformer/types.ts
+++ b/packages/app/src/components/transformer/types.ts
@@ -55,3 +55,8 @@ export interface TransformationPipeline {
   icon: string // Emoji or Lucide icon name
   steps: PipelineStep[]
 }
+
+export interface DragData {
+  sortable?: { index: number }
+  operation?: TransformerOperation
+}

--- a/packages/app/src/hooks/useTransformerDragDrop.ts
+++ b/packages/app/src/hooks/useTransformerDragDrop.ts
@@ -1,0 +1,113 @@
+import { useState, useCallback } from 'react'
+import {
+  useSensor,
+  useSensors,
+  PointerSensor,
+  type DragStartEvent,
+  type DragEndEvent,
+} from '@dnd-kit/core'
+import { arrayMove } from '@dnd-kit/sortable'
+import type { PipelineStep, TransformerOperation, DragData } from '@/components/transformer/types'
+
+interface UseTransformerDragDropParams {
+  steps: PipelineStep[]
+  setSteps: React.Dispatch<React.SetStateAction<PipelineStep[]>>
+  onAddOperation: (operation: TransformerOperation) => void
+}
+
+interface UseTransformerDragDropReturn {
+  sensors: ReturnType<typeof useSensors>
+  activeDragItem: PipelineStep | TransformerOperation | null
+  activeDragWidth: number | undefined
+  handleDragStart: (event: DragStartEvent) => void
+  handleDragEnd: (event: DragEndEvent) => void
+}
+
+/**
+ * Hook managing drag-and-drop state and handlers for the transformer dialog.
+ * @param params - Steps state and callbacks
+ * @returns DnD sensors, active drag state, and event handlers
+ */
+export function useTransformerDragDrop({
+  steps,
+  setSteps,
+  onAddOperation,
+}: UseTransformerDragDropParams): UseTransformerDragDropReturn {
+  const [activeDragItem, setActiveDragItem] = useState<PipelineStep | TransformerOperation | null>(
+    null
+  )
+  const [activeDragWidth, setActiveDragWidth] = useState<number | undefined>(undefined)
+
+  // Configure sensors for drag and drop
+  // Using PointerSensor exclusively provides the best compatibility for both mouse and touch
+  // when touch-action: none is applied to draggable elements.
+  const sensors = useSensors(
+    useSensor(PointerSensor, {
+      activationConstraint: {
+        distance: 8,
+      },
+    })
+  )
+
+  const handleDragStart = useCallback(
+    (event: DragStartEvent) => {
+      const { active } = event
+      const activeData = active.data.current as DragData | undefined
+
+      if (activeData?.sortable?.index !== undefined) {
+        const step = steps.find((s) => s.id === active.id)
+        if (step) setActiveDragItem(step)
+      } else if (activeData?.operation) {
+        setActiveDragItem(activeData.operation)
+      }
+
+      // Capture width of the dragged element to prevent squashing in overlay
+      if (active.id) {
+        const element = document.getElementById(active.id as string)
+        if (element) {
+          setActiveDragWidth(element.offsetWidth)
+        }
+      }
+    },
+    [steps]
+  )
+
+  const handleDragEnd = useCallback(
+    (event: DragEndEvent) => {
+      const { active, over } = event
+      setActiveDragItem(null)
+      setActiveDragWidth(undefined)
+
+      if (!over) return
+
+      // Case 1: Reordering steps
+      if (
+        active.data.current?.sortable?.index !== undefined &&
+        over.data.current?.sortable?.index !== undefined &&
+        active.id !== over.id
+      ) {
+        setSteps((items) => {
+          const oldIndex = items.findIndex((item) => item.id === active.id)
+          const newIndex = items.findIndex((item) => item.id === over.id)
+          return arrayMove(items, oldIndex, newIndex)
+        })
+        return
+      }
+
+      // Case 2: Dropping new operation from toolbox
+      if (active.data.current?.operation && over.id === 'workbench-container') {
+        const operation = active.data.current.operation as TransformerOperation
+        onAddOperation(operation)
+      }
+    },
+    [setSteps, onAddOperation]
+  )
+
+  return {
+    sensors,
+    activeDragItem,
+    activeDragWidth,
+    handleDragStart,
+    handleDragEnd,
+  }
+}

--- a/packages/app/src/hooks/useTransformerPipeline.ts
+++ b/packages/app/src/hooks/useTransformerPipeline.ts
@@ -1,0 +1,220 @@
+import { useState, useCallback, useEffect, useRef, useMemo } from 'react'
+import { useToast } from '@/hooks/useToast'
+import {
+  generateId,
+  validatePipelineName,
+  validatePipelineSteps,
+  buildPipeline,
+} from '@/components/transformer/pipelineUtils'
+import type {
+  PipelineStep,
+  TransformationPipeline,
+  TransformerOperation,
+} from '@/components/transformer/types'
+
+interface UseTransformerPipelineParams {
+  open: boolean
+  editPipeline?: TransformationPipeline | null
+  onSave: (pipeline: TransformationPipeline) => void
+  onApply?: (pipeline: TransformationPipeline) => void
+  onOpenChange: (open: boolean) => void
+}
+
+interface UseTransformerPipelineReturn {
+  pipelineName: string
+  setPipelineName: (name: string) => void
+  pipelineIcon: string
+  setPipelineIcon: (icon: string) => void
+  steps: PipelineStep[]
+  setSteps: React.Dispatch<React.SetStateAction<PipelineStep[]>>
+  activeTab: string
+  setActiveTab: (tab: string) => void
+  isToolboxOpen: boolean
+  setIsToolboxOpen: (open: boolean) => void
+  currentPipeline: TransformationPipeline
+  handleAddOperation: (operation: TransformerOperation) => void
+  handleUpdateStep: (id: string, config: Record<string, unknown>) => void
+  handleRemoveStep: (id: string) => void
+  handleToggleStep: (id: string) => void
+  handleSave: () => void
+  handleApply: () => void
+  handleSaveAndApply: () => void
+}
+
+/**
+ * Hook managing pipeline state and CRUD operations for the transformer dialog.
+ * @param params - Pipeline configuration and callbacks
+ * @returns Pipeline state and handler functions
+ */
+export function useTransformerPipeline({
+  open,
+  editPipeline,
+  onSave,
+  onApply,
+  onOpenChange,
+}: UseTransformerPipelineParams): UseTransformerPipelineReturn {
+  const { toast } = useToast()
+  const [activeTab, setActiveTab] = useState('pipeline')
+  const [pipelineName, setPipelineName] = useState('')
+  const [pipelineIcon, setPipelineIcon] = useState('🪄')
+  const [steps, setSteps] = useState<PipelineStep[]>([])
+  const [isToolboxOpen, setIsToolboxOpen] = useState(false)
+
+  // Track previous open state to detect dialog open transition
+  const wasOpenRef = useRef(open)
+
+  // Load edit state only when dialog transitions from closed to open
+  useEffect(() => {
+    const wasOpen = wasOpenRef.current
+    wasOpenRef.current = open
+
+    // Only run when dialog opens (was closed, now open)
+    if (open && !wasOpen) {
+      // Defer state updates to avoid synchronous setState in effect
+      queueMicrotask(() => {
+        setPipelineName(editPipeline?.name ?? '')
+        setPipelineIcon(editPipeline?.icon ?? '🪄')
+        setSteps(editPipeline?.steps ?? [])
+        setActiveTab('pipeline')
+        setIsToolboxOpen(false)
+      })
+    }
+  }, [open, editPipeline])
+
+  const handleAddOperation = useCallback((operation: TransformerOperation) => {
+    const newStep: PipelineStep = {
+      id: generateId(),
+      operationId: operation.id,
+      config: { ...operation.defaultConfig },
+      enabled: true,
+    }
+    setSteps((prev) => [...prev, newStep])
+    setIsToolboxOpen(false)
+  }, [])
+
+  const handleUpdateStep = useCallback((id: string, config: Record<string, unknown>) => {
+    setSteps((prev) => prev.map((s) => (s.id === id ? { ...s, config } : s)))
+  }, [])
+
+  const handleRemoveStep = useCallback((id: string) => {
+    setSteps((prev) => prev.filter((s) => s.id !== id))
+  }, [])
+
+  const handleToggleStep = useCallback((id: string) => {
+    setSteps((prev) => prev.map((s) => (s.id === id ? { ...s, enabled: !s.enabled } : s)))
+  }, [])
+
+  const resetState = useCallback(() => {
+    setSteps([])
+    setPipelineName('')
+    setPipelineIcon('🪄')
+  }, [])
+
+  const handleSave = useCallback(() => {
+    const nameError = validatePipelineName(pipelineName)
+    if (nameError) {
+      toast({ description: nameError })
+      return
+    }
+
+    const stepsError = validatePipelineSteps(steps, 'saving')
+    if (stepsError) {
+      toast({ description: stepsError })
+      return
+    }
+
+    const pipeline = buildPipeline({
+      id: editPipeline?.id,
+      name: pipelineName,
+      icon: pipelineIcon,
+      steps,
+    })
+
+    onSave(pipeline)
+    onOpenChange(false)
+    resetState()
+  }, [pipelineName, pipelineIcon, steps, editPipeline?.id, onSave, onOpenChange, toast, resetState])
+
+  // Construct temporary pipeline for preview
+  const currentPipeline = useMemo<TransformationPipeline>(
+    () => ({
+      id: 'preview',
+      name: 'Preview',
+      icon: 'preview',
+      steps,
+    }),
+    [steps]
+  )
+
+  const handleApply = useCallback(() => {
+    const stepsError = validatePipelineSteps(steps, 'applying')
+    if (stepsError) {
+      toast({ description: stepsError })
+      return
+    }
+
+    if (onApply) {
+      onApply(currentPipeline)
+      onOpenChange(false)
+    }
+  }, [steps, onApply, onOpenChange, toast, currentPipeline])
+
+  const handleSaveAndApply = useCallback(() => {
+    const nameError = validatePipelineName(pipelineName)
+    if (nameError) {
+      toast({ description: nameError })
+      return
+    }
+
+    const stepsError = validatePipelineSteps(steps, 'saving and applying')
+    if (stepsError) {
+      toast({ description: stepsError })
+      return
+    }
+
+    const pipeline = buildPipeline({
+      id: editPipeline?.id,
+      name: pipelineName,
+      icon: pipelineIcon,
+      steps,
+    })
+
+    onSave(pipeline)
+    if (onApply) {
+      onApply(pipeline)
+    }
+    onOpenChange(false)
+    resetState()
+  }, [
+    pipelineName,
+    pipelineIcon,
+    steps,
+    editPipeline?.id,
+    onSave,
+    onApply,
+    onOpenChange,
+    toast,
+    resetState,
+  ])
+
+  return {
+    pipelineName,
+    setPipelineName,
+    pipelineIcon,
+    setPipelineIcon,
+    steps,
+    setSteps,
+    activeTab,
+    setActiveTab,
+    isToolboxOpen,
+    setIsToolboxOpen,
+    currentPipeline,
+    handleAddOperation,
+    handleUpdateStep,
+    handleRemoveStep,
+    handleToggleStep,
+    handleSave,
+    handleApply,
+    handleSaveAndApply,
+  }
+}

--- a/packages/app/tests/e2e/transformer-dialog.spec.ts
+++ b/packages/app/tests/e2e/transformer-dialog.spec.ts
@@ -73,10 +73,7 @@ test.describe('Transformer Dialog', () => {
 
       // Should show error toast
       await expect(
-        page
-          .locator('ol > li')
-          .filter({ hasText: 'Please enter a name for your pipeline' })
-          .first()
+        page.locator('ol > li').filter({ hasText: 'Please enter a name for your pipeline' }).first()
       ).toBeVisible()
 
       // Dialog should remain open

--- a/packages/app/tests/e2e/transformer-dialog.spec.ts
+++ b/packages/app/tests/e2e/transformer-dialog.spec.ts
@@ -54,7 +54,7 @@ test.describe('Transformer Dialog', () => {
 
       // Verify toast notification (use first() to avoid strict mode violation)
       await expect(
-        page.locator('ol > li').filter({ hasText: 'Pipeline saved!' }).first()
+        page.locator('ol > li').filter({ hasText: 'Pipeline saved' }).first()
       ).toBeVisible()
 
       // Dialog should close
@@ -75,7 +75,7 @@ test.describe('Transformer Dialog', () => {
       await expect(
         page
           .locator('ol > li')
-          .filter({ hasText: 'Please enter a name for your pipeline.' })
+          .filter({ hasText: 'Please enter a name for your pipeline' })
           .first()
       ).toBeVisible()
 
@@ -97,7 +97,7 @@ test.describe('Transformer Dialog', () => {
       await expect(
         page
           .locator('ol > li')
-          .filter({ hasText: 'Add at least one step to the pipeline before saving.' })
+          .filter({ hasText: 'Add at least one step to the pipeline before saving' })
           .first()
       ).toBeVisible()
 


### PR DESCRIPTION
Splits the monolithic `TransformerDialog` component into smaller, focused modules with extracted state management logic, improving maintainability and testability.

- The transformer dialog now organises UI into separate layout components for desktop and mobile views, each with its own clear responsibilities.
- Pipeline state management (name, icon, steps) and validation logic have been extracted into a reusable `useTransformerPipeline` hook.
- Drag-and-drop state and event handling are now managed by `useTransformerDragDrop`, centralising DnD configuration and logic.
- Common pipeline utilities (`generateId`, `validatePipelineName`, `validatePipelineSteps`, `buildPipeline`) are now in `pipelineUtils.ts` with comprehensive unit tests.
- The drag overlay is now a separate `TransformerDragOverlay` component, simplifying the main dialog.
- Dialog header (title, name input, icon picker, action buttons) is extracted into `TransformerDialogHeader`, reducing visual clutter in the main component.
- Selected text from the editor is now captured when editing an existing pipeline, preserving user context during edits.
- Both hooks and utilities follow strict dependency management and are fully testable.

No breaking changes for consumers, the `TransformerDialog` API remains unchanged. Internal refactoring only.
