### PR TITLE
feat: Add automated semantic versioning and release workflow

### DIFF
--- a/.github/workflows/check-labels.yml
+++ b/.github/workflows/check-labels.yml
@@ -1,0 +1,26 @@
+name: Check Version Labels
+
+on:
+  pull_request:
+    types: [opened, labeled, unlabeled, synchronize, reopened]
+
+jobs:
+  check-labels:
+    name: Enforce Semantic Versioning
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check for version labels
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const labels = context.payload.pull_request.labels.map(l => l.name);
+            const versionLabels = ['major', 'minor', 'patch', 'norelease'];
+            const presentLabels = labels.filter(l => versionLabels.includes(l));
+
+            if (presentLabels.length === 0) {
+              core.setFailed('PR must have at least one of the following labels: ' + versionLabels.join(', '));
+            }
+
+            if (presentLabels.length > 1) {
+              core.setFailed('PR must have EXACTLY one version label, found: ' + presentLabels.join(', '));
+            }

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -19,6 +19,23 @@ jobs:
         with:
           github-token: '${{ secrets.GITHUB_TOKEN }}'
 
+      - name: Add semantic version labels
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          case "${{ steps.metadata.outputs.update-type }}" in
+            version-update:semver-major)
+              gh pr edit "$PR_URL" --add-label "minor"
+              ;;
+            version-update:semver-minor)
+              gh pr edit "$PR_URL" --add-label "patch"
+              ;;
+            version-update:semver-patch)
+              gh pr edit "$PR_URL" --add-label "patch"
+              ;;
+          esac
+
       - name: Enable auto-merge for minor and patch updates
         if: ${{ steps.metadata.outputs.update-type == 'version-update:semver-minor' || steps.metadata.outputs.update-type == 'version-update:semver-patch' }}
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,62 @@
+name: Release
+
+on:
+  pull_request:
+    types: [closed]
+    branches:
+      - main
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+          cache: 'npm'
+
+      - name: Configure Git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Determine Version Bump
+        id: bump
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const labels = context.payload.pull_request.labels.map(l => l.name);
+            if (labels.includes('major')) return 'major';
+            if (labels.includes('minor')) return 'minor';
+            if (labels.includes('patch')) return 'patch';
+            return 'norelease';
+          result-encoding: string
+
+      - name: Bump Version
+        if: steps.bump.outputs.result != 'norelease'
+        run: |
+          # Bump version in root and all workspaces
+          npm version ${{ steps.bump.outputs.result }} --workspaces --include-workspace-root --no-git-tag-version
+          
+          # Get new version
+          NEW_VERSION=$(npm pkg get version | tr -d '"')
+          
+          # Commit changes
+          git add .
+          git commit -m "chore(release): bump version to $NEW_VERSION"
+          
+          # Create and push tag
+          git tag v$NEW_VERSION
+          git push origin main
+          git push origin v$NEW_VERSION

--- a/packages/app/src/components/AboutDialog.tsx
+++ b/packages/app/src/components/AboutDialog.tsx
@@ -41,7 +41,7 @@ export function AboutDialog({ open, onOpenChange }: AboutDialogProps): ReactElem
             </ul>
           </div>
           <div className="text-xs text-muted-foreground border-t border-border pt-4">
-            <p className="font-semibold mb-2">Version 1.0.0</p>
+            <p className="font-semibold mb-2">Version {__APP_VERSION__}</p>
             <div className="flex gap-4 items-start">
               <div className="flex-1">
                 <p className="mb-1">

--- a/packages/app/src/components/SplashScreen.tsx
+++ b/packages/app/src/components/SplashScreen.tsx
@@ -115,7 +115,7 @@ export function SplashScreen({
           <p className="mt-2 text-2xl font-light text-muted-foreground">Markdown Editor</p>
 
           <div className="mt-8 space-y-2">
-            <p className="text-sm text-muted-foreground">Version 1.0.0</p>
+            <p className="text-sm text-muted-foreground">Version {__APP_VERSION__}</p>
             <p className="text-sm text-muted-foreground">{tagline}</p>
           </div>
 

--- a/packages/app/src/vite-env.d.ts
+++ b/packages/app/src/vite-env.d.ts
@@ -1,1 +1,3 @@
 /// <reference types="vite/client" />
+
+declare const __APP_VERSION__: string

--- a/packages/app/vite.config.ts
+++ b/packages/app/vite.config.ts
@@ -18,4 +18,7 @@ export default defineConfig({
     outDir: 'dist',
     sourcemap: false,
   },
+  define: {
+    __APP_VERSION__: JSON.stringify(process.env.npm_package_version),
+  },
 })

--- a/packages/app/vitest.config.ts
+++ b/packages/app/vitest.config.ts
@@ -20,4 +20,7 @@ export default defineConfig({
       '@': path.resolve(__dirname, './src'),
     },
   },
+  define: {
+    __APP_VERSION__: JSON.stringify(process.env.npm_package_version || '0.0.0-test'),
+  },
 })


### PR DESCRIPTION
Introduces automated version bumping and release management based on pull request labels, enabling consistent semantic versioning across the project.

- Pull requests targeting `main` must be labelled with exactly one of `major`, `minor`, `patch`, or `norelease` to enforce semantic versioning discipline.
- Merged pull requests automatically trigger version bumps in the root package and all workspace packages according to their label.
- Version tags are automatically created and pushed to the repository after each release.
- The application now displays its current version dynamically (`__APP_VERSION__`) in the About Dialog and Splash Screen, pulling from `package.json` at build time.
- Release workflow runs only on merged pull requests, preventing accidental version increments from other events.

Requires pull request labels to be set before merging. The `github-actions[bot]` user will commit version changes and create release tags automatically.