### PR TITLE
ci(release): Simplify version bump workflow with dedicated GitHub Action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,18 +45,13 @@ jobs:
 
       - name: Bump Version
         if: steps.bump.outputs.result != 'norelease'
+        uses: reedyuk/npm-version@1.1.1
+        with:
+          version: '${{ steps.bump.outputs.result }} --workspaces --include-workspace-root'
+          git-tag-version: 'true'
+
+      - name: Push Changes
+        if: steps.bump.outputs.result != 'norelease'
         run: |
-          # Bump version in root and all workspaces
-          npm version ${{ steps.bump.outputs.result }} --workspaces --include-workspace-root --no-git-tag-version
-          
-          # Get new version
-          NEW_VERSION=$(npm pkg get version | tr -d '"')
-          
-          # Commit changes
-          git add .
-          git commit -m "chore(release): bump version to $NEW_VERSION"
-          
-          # Create and push tag
-          git tag v$NEW_VERSION
           git push origin main
-          git push origin v$NEW_VERSION
+          git push origin --tags

--- a/TEST_VERSION_BUMP.md
+++ b/TEST_VERSION_BUMP.md
@@ -1,1 +1,0 @@
-Test version bump


### PR DESCRIPTION
Replaces inline shell commands with the `reedyuk/npm-version` Action to streamline the release process.

- Version bumping, git tagging, and committing are now handled by a single reusable Action instead of custom bash scripts.
- Release workflow is more maintainable and reduces the risk of manual step errors.
- Push operations are now consolidated into a single step for clarity.
