### PR TITLE
ci: Update release workflow to use SSH deploy key and inline versioning

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          token: ${{ secrets.GITHUB_TOKEN }}
+          ssh-key: ${{ secrets.DEPLOY_KEY }}
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -40,18 +40,22 @@ jobs:
             if (labels.includes('major')) return 'major';
             if (labels.includes('minor')) return 'minor';
             if (labels.includes('patch')) return 'patch';
-            return 'norelease';
           result-encoding: string
 
       - name: Bump Version
         if: steps.bump.outputs.result != 'norelease'
-        uses: reedyuk/npm-version@1.1.1
-        with:
-          version: '${{ steps.bump.outputs.result }} --workspaces --include-workspace-root'
-          git-tag-version: 'true'
-
-      - name: Push Changes
-        if: steps.bump.outputs.result != 'norelease'
         run: |
+          # Bump version in root and all workspaces
+          npm version ${{ steps.bump.outputs.result }} --workspaces --include-workspace-root --no-git-tag-version
+          
+          # Get new version
+          NEW_VERSION=$(npm pkg get version | tr -d '"')
+          
+          # Commit changes
+          git add .
+          git commit -m "chore(release): bump version to $NEW_VERSION"
+          
+          # Create and push tag
+          git tag v$NEW_VERSION
           git push origin main
-          git push origin --tags
+          git push origin v$NEW_VERSION


### PR DESCRIPTION
- Replace GITHUB_TOKEN with SSH deploy key for authentication
- Remove npm-version action and implement inline version bumping script
- Add explicit git commit and tag creation for version changes
- Simplify push operations to use git commands directly