### PR TITLE
feat(editor): Improve Vim navigation for wrapped lines and add line wrapping toggle

### DIFF
--- a/packages/app/src/components/editor/vim.ts
+++ b/packages/app/src/components/editor/vim.ts
@@ -60,6 +60,15 @@ export function setupVim(): void {
     { type: 'operatorMotion', motion: 'expandToLine', motionArgs: { linewise: true } }
   )
 
+  // Handle :set wrap and :set nowrap
+  Vim.defineOption('wrap', true, 'boolean', [], (value, cm) => {
+    if (cm && cm.editor) {
+      cm.editor.updateOptions({
+        wordWrap: value ? 'on' : 'off',
+      })
+    }
+  })
+
   // Explicitly map p/P back to default 'paste' to ensure no stale 'pasteSystem' mapping remains
   // This fixes the popup issue by avoiding navigator.clipboard.readText() on 'p'
   Vim.mapCommand('p', 'action', 'paste', { after: true, isEdit: true })

--- a/packages/app/src/components/editor/vim.ts
+++ b/packages/app/src/components/editor/vim.ts
@@ -68,4 +68,8 @@ export function setupVim(): void {
   Vim.defineMotion('moveToMatchingBracket', moveToMatchingBracketMotion)
 
   Vim.mapCommand('%', 'motion', 'moveToMatchingBracket')
+
+  // Remap j/k to move by display lines (gj/gk) to handle wrapped lines intuitively
+  Vim.mapCommand('j', 'motion', 'moveByDisplayLines', { forward: true })
+  Vim.mapCommand('k', 'motion', 'moveByDisplayLines', { forward: false })
 }

--- a/packages/app/src/components/editor/vim.ts
+++ b/packages/app/src/components/editor/vim.ts
@@ -5,6 +5,7 @@ import {
   moveByDisplayLinesMotion,
   moveToMatchingBracketMotion,
   moveToEndOfDisplayLineMotion,
+  moveToStartOfDisplayLineMotion,
 } from './vimMotions'
 
 // Setup clipboard integration for monaco-vim
@@ -80,4 +81,9 @@ export function setupVim(): void {
   // Override default g$ to use Monaco's native cursorEnd (end of display line)
   Vim.defineMotion('moveToEndOfDisplayLine', moveToEndOfDisplayLineMotion)
   Vim.mapCommand('g$', 'motion', 'moveToEndOfDisplayLine')
+
+  // Override default g^/g0 to use Monaco's native cursorHome (start of display line)
+  Vim.defineMotion('moveToStartOfDisplayLine', moveToStartOfDisplayLineMotion)
+  Vim.mapCommand('g^', 'motion', 'moveToStartOfDisplayLine')
+  Vim.mapCommand('g0', 'motion', 'moveToStartOfDisplayLine')
 }

--- a/packages/app/src/components/editor/vim.ts
+++ b/packages/app/src/components/editor/vim.ts
@@ -1,7 +1,11 @@
 import { VimMode } from 'monaco-vim'
 import type { CodeMirrorAdapter, VimModeModule } from './vimTypes'
 import { createYankSystemOperator, createPasteSystemAction } from './vimClipboard'
-import { moveByDisplayLinesMotion, moveToMatchingBracketMotion } from './vimMotions'
+import {
+  moveByDisplayLinesMotion,
+  moveToMatchingBracketMotion,
+  moveToEndOfDisplayLineMotion,
+} from './vimMotions'
 
 // Setup clipboard integration for monaco-vim
 // This needs to run only once to register the operators and actions globally
@@ -72,4 +76,8 @@ export function setupVim(): void {
   // Remap j/k to move by display lines (gj/gk) to handle wrapped lines intuitively
   Vim.mapCommand('j', 'motion', 'moveByDisplayLines', { forward: true })
   Vim.mapCommand('k', 'motion', 'moveByDisplayLines', { forward: false })
+
+  // Override default g$ to use Monaco's native cursorEnd (end of display line)
+  Vim.defineMotion('moveToEndOfDisplayLine', moveToEndOfDisplayLineMotion)
+  Vim.mapCommand('g$', 'motion', 'moveToEndOfDisplayLine')
 }

--- a/packages/app/src/components/editor/vimMotions.ts
+++ b/packages/app/src/components/editor/vimMotions.ts
@@ -68,7 +68,7 @@ export const moveToMatchingBracketMotion = (
  * Uses Monaco's native cursorHome command which respects line wrapping.
  * @param cm - The CodeMirror adapter wrapping the Monaco editor
  * @param head - The 0-indexed cursor position
- * @returns The 0-indexed target position
+ * @returns { { line: number; ch: number } } The 0-indexed target position
  */
 export const moveToStartOfDisplayLineMotion = (
   cm: CodeMirrorAdapter,
@@ -92,7 +92,7 @@ export const moveToStartOfDisplayLineMotion = (
  * Uses Monaco's native cursorEnd command which respects line wrapping.
  * @param cm - The CodeMirror adapter wrapping the Monaco editor
  * @param head - The 0-indexed cursor position
- * @returns The 0-indexed target position
+ * @returns { { line: number; ch: number } } The 0-indexed target position
  */
 export const moveToEndOfDisplayLineMotion = (
   cm: CodeMirrorAdapter,

--- a/packages/app/src/components/editor/vimMotions.ts
+++ b/packages/app/src/components/editor/vimMotions.ts
@@ -64,6 +64,30 @@ export const moveToMatchingBracketMotion = (
 }
 
 /**
+ * Vim motion that moves the cursor to the start of the display (wrapped) line.
+ * Uses Monaco's native cursorHome command which respects line wrapping.
+ * @param cm - The CodeMirror adapter wrapping the Monaco editor
+ * @param head - The 0-indexed cursor position
+ * @returns The 0-indexed target position
+ */
+export const moveToStartOfDisplayLineMotion = (
+  cm: CodeMirrorAdapter,
+  head: { line: number; ch: number }
+): { line: number; ch: number } => {
+  // Sync Monaco position
+  const startPos = { lineNumber: head.line + 1, column: head.ch + 1 }
+  cm.editor.setPosition(startPos)
+
+  // Trigger 'cursorHome' which usually handles display lines
+  cm.editor.trigger('vim', 'cursorHome', {})
+
+  // Return new position
+  const newPos = cm.editor.getPosition()
+  if (!newPos) return { line: head.line, ch: head.ch }
+  return { line: newPos.lineNumber - 1, ch: newPos.column - 1 }
+}
+
+/**
  * Vim motion that moves the cursor to the end of the display (wrapped) line.
  * Uses Monaco's native cursorEnd command which respects line wrapping.
  * @param cm - The CodeMirror adapter wrapping the Monaco editor

--- a/packages/app/src/components/editor/vimTypes.ts
+++ b/packages/app/src/components/editor/vimTypes.ts
@@ -59,6 +59,13 @@ export interface VimAPI {
       motionArgs: { repeat?: number; forward?: boolean }
     ) => { line: number; ch: number } | void
   ) => void
+  defineOption: (
+    name: string,
+    defaultValue: string | number | boolean | undefined,
+    type: string,
+    aliases?: string[],
+    callback?: (value: string | number | boolean | undefined, cm: CodeMirrorAdapter) => void
+  ) => void
 }
 
 export interface VimModeModule {


### PR DESCRIPTION
Enhances Vim mode to handle wrapped lines more intuitively and adds support for the `:set wrap` command.

- Remap `j` and `k` to move by display lines, so navigation respects visual line breaks instead of logical lines.
- Override `g$` and `g0`/`g^` to move to the start and end of display lines using Monaco's native cursor commands.
- Add `:set wrap` and `:set nowrap` commands to toggle word wrapping in the editor.
- Cursor now behaves correctly on wrapped content, matching standard Vim expectations for visual-line operations.
