### PR TITLE
feat(mermaid): Add theme-aware diagram rendering with light/dark mode support

### DIFF
--- a/packages/app/src/components/MermaidDiagram.tsx
+++ b/packages/app/src/components/MermaidDiagram.tsx
@@ -1,10 +1,12 @@
 import { useState, useEffect, useRef, type ReactElement } from 'react'
+import { getMermaidInitializeOptions, type MermaidColorMode } from '@/utils/mermaidTheme'
 
 interface MermaidDiagramProps {
   code: string
+  colorMode?: MermaidColorMode
 }
 
-let mermaidInitialized = false
+let initializedColorMode: MermaidColorMode | null = null
 let renderCounter = 0
 
 /**
@@ -13,9 +15,10 @@ let renderCounter = 0
  * a styled code block on syntax errors (e.g., mid-keystroke).
  * @param props - Component props
  * @param props.code - The Mermaid diagram source code
+ * @param props.colorMode - Active app color mode
  * @returns A rendered SVG diagram or a fallback code block
  */
-export function MermaidDiagram({ code }: MermaidDiagramProps): ReactElement {
+export function MermaidDiagram({ code, colorMode = 'light' }: MermaidDiagramProps): ReactElement {
   const [svg, setSvg] = useState<string | null>(null)
   const [error, setError] = useState(false)
   const containerRef = useRef<HTMLDivElement>(null)
@@ -27,9 +30,9 @@ export function MermaidDiagram({ code }: MermaidDiagramProps): ReactElement {
       try {
         const mermaid = (await import('mermaid')).default
 
-        if (!mermaidInitialized) {
-          mermaid.initialize({ startOnLoad: false, theme: 'default' })
-          mermaidInitialized = true
+        if (initializedColorMode !== colorMode) {
+          mermaid.initialize(getMermaidInitializeOptions(colorMode))
+          initializedColorMode = colorMode
         }
 
         const id = `mermaid-diagram-${++renderCounter}`
@@ -51,7 +54,7 @@ export function MermaidDiagram({ code }: MermaidDiagramProps): ReactElement {
     return () => {
       cancelled = true
     }
-  }, [code])
+  }, [code, colorMode])
 
   if (svg && !error) {
     return (

--- a/packages/app/src/components/PoeEditor.tsx
+++ b/packages/app/src/components/PoeEditor.tsx
@@ -40,6 +40,7 @@ import { TransformerImportExportDialog } from '@/components/transformer/Transfor
 import type { TransformationPipeline } from '@/components/transformer/types'
 import { useToast } from '@/hooks/useToast'
 import { generateShareableUrl } from '@/utils/urlShare'
+import { getMermaidInitScript, type MermaidColorMode } from '@/utils/mermaidTheme'
 
 import {
   formatBold,
@@ -173,6 +174,7 @@ export function PoeEditor({ onReady }: PoeEditorProps): ReactElement {
 
   // Rendered HTML for preview
   const htmlContent = useMemo(() => renderMarkdown(content), [content])
+  const colorMode: MermaidColorMode = mounted && theme === 'dark' ? 'dark' : 'light'
 
   // Formatting functions
   const handleFormatBold = useCallback((): void => {
@@ -320,8 +322,9 @@ export function PoeEditor({ onReady }: PoeEditorProps): ReactElement {
 
   const handleDownloadHTML = useCallback((): void => {
     const hasMermaid = htmlContent.includes('language-mermaid')
+    const mermaidInitScript = getMermaidInitScript(colorMode)
     const mermaidScripts = hasMermaid
-      ? `\n  <script src="https://cdn.jsdelivr.net/npm/mermaid@11.12.2/dist/mermaid.min.js"></script>\n  <script>mermaid.initialize({startOnLoad:false}); mermaid.run({querySelector: '.language-mermaid'});</script>`
+      ? `\n  <script src="https://cdn.jsdelivr.net/npm/mermaid@11.12.2/dist/mermaid.min.js"></script>\n  <script>${mermaidInitScript}</script>`
       : ''
 
     const htmlDoc = `<!DOCTYPE html>
@@ -343,7 +346,7 @@ ${htmlContent}
     const htmlFileName = documentName.replace(/\.md$/, '.html')
     downloadFile(htmlFileName, htmlDoc, 'text/html')
     toast({ description: 'Downloaded as HTML' })
-  }, [documentName, htmlContent, toast])
+  }, [documentName, htmlContent, toast, colorMode])
 
   const handleCopyLink = useCallback(async (): Promise<void> => {
     try {
@@ -635,6 +638,7 @@ ${htmlContent}
                         htmlContent={htmlContent}
                         viewMode={viewMode}
                         onToggleLayout={handleTogglePreview}
+                        colorMode={colorMode}
                       />
                     </div>
                   </ResizablePanel>
@@ -694,7 +698,7 @@ ${htmlContent}
               <div
                 className={cn('flex-1 p-4 mt-0 overflow-auto', activeTab !== 'preview' && 'hidden')}
               >
-                <PreviewPane ref={targetRef} htmlContent={htmlContent} />
+                <PreviewPane ref={targetRef} htmlContent={htmlContent} colorMode={colorMode} />
               </div>
             </div>
           )}

--- a/packages/app/src/components/PreviewPane.tsx
+++ b/packages/app/src/components/PreviewPane.tsx
@@ -7,11 +7,13 @@ import { toast } from '@/hooks/useToast'
 import { copyToClipboard, stripHtml } from '@/utils/clipboard'
 import { splitHtmlAtMermaid } from '@/utils/splitHtmlAtMermaid'
 import { MermaidDiagram } from '@/components/MermaidDiagram'
+import type { MermaidColorMode } from '@/utils/mermaidTheme'
 
 interface PreviewPaneProps {
   htmlContent: string
   viewMode?: 'editor' | 'preview' | 'split'
   onToggleLayout?: () => void
+  colorMode?: MermaidColorMode
 }
 
 /**
@@ -19,7 +21,7 @@ interface PreviewPaneProps {
  * Displays styled HTML with GitHub markdown styles and copy-to-clipboard functionality.
  */
 export const PreviewPane = forwardRef<HTMLDivElement, PreviewPaneProps>(
-  ({ htmlContent, viewMode, onToggleLayout }, ref): ReactElement => {
+  ({ htmlContent, viewMode, onToggleLayout, colorMode = 'light' }, ref): ReactElement => {
     const [copied, setCopied] = useState(false)
 
     const segments = useMemo(() => splitHtmlAtMermaid(htmlContent), [htmlContent])
@@ -93,7 +95,7 @@ export const PreviewPane = forwardRef<HTMLDivElement, PreviewPaneProps>(
             segment.type === 'html' ? (
               <div key={i} dangerouslySetInnerHTML={{ __html: segment.content }} />
             ) : (
-              <MermaidDiagram key={i} code={segment.code} />
+              <MermaidDiagram key={i} code={segment.code} colorMode={colorMode} />
             )
           )}
         </div>

--- a/packages/app/src/utils/mermaidTheme.test.ts
+++ b/packages/app/src/utils/mermaidTheme.test.ts
@@ -33,8 +33,10 @@ describe('mermaidTheme', () => {
   it('serializes initialize and run script for exports', () => {
     const script = getMermaidInitScript('dark')
 
+    expect(script).toContain('document.readyState')
+    expect(script).toContain("document.addEventListener('DOMContentLoaded'")
     expect(script).toContain('mermaid.initialize(')
     expect(script).toContain('"primaryBorderColor":"#4493f8"')
-    expect(script).toContain("mermaid.run({querySelector: '.language-mermaid'});")
+    expect(script).toContain("mermaid.run({ querySelector: '.language-mermaid' })")
   })
 })

--- a/packages/app/src/utils/mermaidTheme.test.ts
+++ b/packages/app/src/utils/mermaidTheme.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest'
+import { getMermaidInitializeOptions, getMermaidInitScript } from '@/utils/mermaidTheme'
+
+describe('mermaidTheme', () => {
+  it('returns light options aligned with light palette', () => {
+    const options = getMermaidInitializeOptions('light')
+
+    expect(options.theme).toBe('base')
+    expect(options.startOnLoad).toBe(false)
+    expect(options.themeVariables.primaryColor).toBe('#f0efeb')
+    expect(options.themeVariables.primaryTextColor).toBe('#2a2a2a')
+    expect(options.themeVariables.primaryBorderColor).toBe('#8b6f47')
+  })
+
+  it('returns dark options aligned with dark palette', () => {
+    const options = getMermaidInitializeOptions('dark')
+
+    expect(options.theme).toBe('base')
+    expect(options.startOnLoad).toBe(false)
+    expect(options.themeVariables.primaryColor).toBe('#151b23')
+    expect(options.themeVariables.primaryTextColor).toBe('#f0f6fc')
+    expect(options.themeVariables.primaryBorderColor).toBe('#4493f8')
+  })
+
+  it('returns copied objects so callers cannot mutate shared config', () => {
+    const first = getMermaidInitializeOptions('light')
+    first.themeVariables.primaryColor = '#000000'
+
+    const second = getMermaidInitializeOptions('light')
+    expect(second.themeVariables.primaryColor).toBe('#f0efeb')
+  })
+
+  it('serializes initialize and run script for exports', () => {
+    const script = getMermaidInitScript('dark')
+
+    expect(script).toContain('mermaid.initialize(')
+    expect(script).toContain('"primaryBorderColor":"#4493f8"')
+    expect(script).toContain("mermaid.run({querySelector: '.language-mermaid'});")
+  })
+})

--- a/packages/app/src/utils/mermaidTheme.ts
+++ b/packages/app/src/utils/mermaidTheme.ts
@@ -88,5 +88,17 @@ export function getMermaidInitializeOptions(colorMode: MermaidColorMode): Mermai
  */
 export function getMermaidInitScript(colorMode: MermaidColorMode): string {
   const options = getMermaidInitializeOptions(colorMode)
-  return `mermaid.initialize(${JSON.stringify(options)}); mermaid.run({querySelector: '.language-mermaid'});`
+  return `(() => {
+  const runMermaid = () => {
+    if (typeof mermaid === 'undefined') return
+    mermaid.initialize(${JSON.stringify(options)})
+    mermaid.run({ querySelector: '.language-mermaid' })
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', runMermaid, { once: true })
+  } else {
+    runMermaid()
+  }
+})()`
 }

--- a/packages/app/src/utils/mermaidTheme.ts
+++ b/packages/app/src/utils/mermaidTheme.ts
@@ -40,7 +40,7 @@ const MERMAID_THEME_OPTIONS: Record<MermaidColorMode, MermaidInitializeOptions> 
       clusterBkg: '#f0efeb',
       clusterBorder: '#e5e3df',
       edgeLabelBackground: '#faf9f7',
-      fontFamily: 'Inter, Inter Fallback, sans-serif',
+      fontFamily: 'Crimson Text, serif',
     },
   },
   dark: {
@@ -60,7 +60,7 @@ const MERMAID_THEME_OPTIONS: Record<MermaidColorMode, MermaidInitializeOptions> 
       clusterBkg: '#151b23',
       clusterBorder: '#3d444d',
       edgeLabelBackground: '#151b23',
-      fontFamily: 'Inter, Inter Fallback, sans-serif',
+      fontFamily: 'Crimson Text, serif',
     },
   },
 }

--- a/packages/app/src/utils/mermaidTheme.ts
+++ b/packages/app/src/utils/mermaidTheme.ts
@@ -1,0 +1,92 @@
+export type MermaidColorMode = 'light' | 'dark'
+
+interface MermaidThemeVariables {
+  background: string
+  primaryColor: string
+  primaryTextColor: string
+  primaryBorderColor: string
+  secondaryColor: string
+  secondaryTextColor: string
+  tertiaryColor: string
+  tertiaryTextColor: string
+  lineColor: string
+  clusterBkg: string
+  clusterBorder: string
+  edgeLabelBackground: string
+  fontFamily: string
+}
+
+export interface MermaidInitializeOptions {
+  startOnLoad: boolean
+  theme: 'base'
+  themeVariables: MermaidThemeVariables
+}
+
+const MERMAID_THEME_OPTIONS: Record<MermaidColorMode, MermaidInitializeOptions> = {
+  light: {
+    startOnLoad: false,
+    theme: 'base',
+    themeVariables: {
+      // Align with light design tokens and markdown palette.
+      background: '#faf9f7',
+      primaryColor: '#f0efeb',
+      primaryTextColor: '#2a2a2a',
+      primaryBorderColor: '#8b6f47',
+      secondaryColor: '#faf9f7',
+      secondaryTextColor: '#2a2a2a',
+      tertiaryColor: '#f0efeb',
+      tertiaryTextColor: '#2a2a2a',
+      lineColor: '#8b6f47',
+      clusterBkg: '#f0efeb',
+      clusterBorder: '#e5e3df',
+      edgeLabelBackground: '#faf9f7',
+      fontFamily: 'Inter, Inter Fallback, sans-serif',
+    },
+  },
+  dark: {
+    startOnLoad: false,
+    theme: 'base',
+    themeVariables: {
+      // Align with existing dark markdown colors.
+      background: '#0d1117',
+      primaryColor: '#151b23',
+      primaryTextColor: '#f0f6fc',
+      primaryBorderColor: '#4493f8',
+      secondaryColor: '#0d1117',
+      secondaryTextColor: '#f0f6fc',
+      tertiaryColor: '#151b23',
+      tertiaryTextColor: '#f0f6fc',
+      lineColor: '#4493f8',
+      clusterBkg: '#151b23',
+      clusterBorder: '#3d444d',
+      edgeLabelBackground: '#151b23',
+      fontFamily: 'Inter, Inter Fallback, sans-serif',
+    },
+  },
+}
+
+/**
+ * Returns Mermaid initialization options for the active color mode.
+ * @param colorMode - The application color mode
+ * @returns Mermaid options with theme variables matching the app palette
+ */
+export function getMermaidInitializeOptions(colorMode: MermaidColorMode): MermaidInitializeOptions {
+  const options = MERMAID_THEME_OPTIONS[colorMode]
+
+  return {
+    ...options,
+    themeVariables: {
+      ...options.themeVariables,
+    },
+  }
+}
+
+/**
+ * Returns a serialized Mermaid init script for static HTML export.
+ * @param colorMode - The application color mode
+ * @returns Script body that initializes and runs Mermaid diagrams
+ */
+export function getMermaidInitScript(colorMode: MermaidColorMode): string {
+  const options = getMermaidInitializeOptions(colorMode)
+  return `mermaid.initialize(${JSON.stringify(options)}); mermaid.run({querySelector: '.language-mermaid'});`
+}


### PR DESCRIPTION
Mermaid diagrams now automatically adapt their appearance to match the application's active colour mode, ensuring visual consistency across light and dark themes.

- Diagrams render with colour palettes aligned to the app's light and dark design tokens.
- The `MermaidDiagram` component accepts a `colorMode` prop to control theme appearance.
- Exported HTML files include properly themed Mermaid diagrams that respect the colour mode at export time.
- Theme colours are applied consistently across flowcharts, sequence diagrams, and other Mermaid diagram types.

Theme reinitialisation now tracks the active colour mode rather than initialising once. No breaking changes for existing users; `colorMode` defaults to `'light'` if not provided.
