### PR TITLE
ci(dependabot): Improve PR labelling automation and mark peer dependencies

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -24,6 +24,10 @@ jobs:
           PR_URL: ${{ github.event.pull_request.html_url }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          for label in major minor patch norelease; do
+            gh pr edit "$PR_URL" --remove-label "$label" || true
+          done
+
           case "${{ steps.metadata.outputs.update-type }}" in
             version-update:semver-major)
               gh pr edit "$PR_URL" --add-label "minor"


### PR DESCRIPTION
Enhances the Dependabot auto-merge workflow to better track dependency updates and marks numerous packages as peer dependencies to reduce duplication and clarify optional dependency relationships.

- Dependabot PRs are now correctly re-labelled when update types change by removing previous labels (`major`, `minor`, `patch`, `norelease`) before applying the new one.
- Reduced false positives in release classification by properly signalling peer dependency relationships across the project.
