### PR TITLE
feat(preview): Add code fence language headers

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -28,14 +28,15 @@ Poe includes standard Markdown editor functionality and a set of unique features
 
 ### Preview and Rendering
 
-| Feature                            | Notes                                                             |
-| ---------------------------------- | ----------------------------------------------------------------- |
-| Mermaid diagram rendering          | Mermaid code blocks render as diagrams in preview.                |
-| Theme-aware Mermaid diagrams       | Mermaid output uses separate light/dark theme tokens.             |
-| Mermaid support in HTML export     | Exported HTML includes Mermaid runtime/init when diagrams exist.  |
-| Synchronized editor/preview scroll | Scroll sync uses ratio-based matching between Monaco and preview. |
-| Preview rich-text copy             | Copy supports both HTML and plain text where browser APIs allow.  |
-| Editor markdown quick-copy         | Editor pane includes one-click Markdown copy action.              |
+| Feature                            | Notes                                                                              |
+| ---------------------------------- | ---------------------------------------------------------------------------------- |
+| Mermaid diagram rendering          | Mermaid code blocks render as diagrams in preview.                                 |
+| Theme-aware Mermaid diagrams       | Mermaid output uses separate light/dark theme tokens.                              |
+| Mermaid support in HTML export     | Exported HTML includes Mermaid runtime/init when diagrams exist.                   |
+| Code fence language headers        | Fenced code blocks with a language show a header label in preview and HTML export. |
+| Synchronized editor/preview scroll | Scroll sync uses ratio-based matching between Monaco and preview.                  |
+| Preview rich-text copy             | Copy supports both HTML and plain text where browser APIs allow.                   |
+| Editor markdown quick-copy         | Editor pane includes one-click Markdown copy action.                               |
 
 ### Editing and Input
 

--- a/packages/app/src/components/PoeEditor.tsx
+++ b/packages/app/src/components/PoeEditor.tsx
@@ -326,6 +326,68 @@ export function PoeEditor({ onReady }: PoeEditorProps): ReactElement {
     const mermaidScripts = hasMermaid
       ? `\n  <script src="https://cdn.jsdelivr.net/npm/mermaid@11.12.2/dist/mermaid.min.js"></script>\n  <script>${mermaidInitScript}</script>`
       : ''
+    const codeBlockStyles = `
+    .markdown-body .code-block-with-language {
+      margin: 1rem 0;
+      overflow: hidden;
+      border: 1px solid var(--borderColor-muted);
+      border-radius: 12px;
+      background: var(--bgColor-muted);
+    }
+    .markdown-body .code-block-language-hint {
+      display: flex;
+      align-items: center;
+      min-height: 2rem;
+      padding: 0.35rem 0.8rem;
+      border-bottom: 1px solid var(--borderColor-muted);
+      color: var(--fgColor-muted);
+      font-family: 'JetBrains Mono', 'SFMono-Regular', Menlo, Consolas, monospace;
+      font-size: 0.72rem;
+      font-weight: 600;
+      letter-spacing: 0.03em;
+    }
+    .markdown-body .code-block-with-language pre {
+      margin: 0;
+      border: 0;
+      border-radius: 0;
+      background: transparent !important;
+    }
+    .markdown-body .code-block-with-language pre code.hljs {
+      display: block;
+      padding: 0;
+      background: transparent;
+    }
+    .markdown-body .hljs {
+      color: var(--fgColor-default);
+    }
+    .markdown-body .hljs-keyword,
+    .markdown-body .hljs-selector-tag,
+    .markdown-body .hljs-literal,
+    .markdown-body .hljs-doctag,
+    .markdown-body .hljs-operator {
+      color: var(--color-prettylights-syntax-keyword);
+    }
+    .markdown-body .hljs-string,
+    .markdown-body .hljs-meta .hljs-string,
+    .markdown-body .hljs-attribute,
+    .markdown-body .hljs-regexp {
+      color: var(--color-prettylights-syntax-string);
+    }
+    .markdown-body .hljs-number,
+    .markdown-body .hljs-symbol,
+    .markdown-body .hljs-variable,
+    .markdown-body .hljs-template-variable {
+      color: var(--color-prettylights-syntax-variable);
+    }
+    .markdown-body .hljs-title,
+    .markdown-body .hljs-title.class_,
+    .markdown-body .hljs-title.function_ {
+      color: var(--color-prettylights-syntax-entity);
+    }
+    .markdown-body .hljs-comment,
+    .markdown-body .hljs-quote {
+      color: var(--color-prettylights-syntax-comment);
+    }`
 
     const htmlDoc = `<!DOCTYPE html>
 <html lang="en">
@@ -337,6 +399,7 @@ export function PoeEditor({ onReady }: PoeEditorProps): ReactElement {
   <style>
     .markdown-body { box-sizing: border-box; min-width: 200px; max-width: 980px; margin: 0 auto; padding: 45px; }
     @media (max-width: 767px) { .markdown-body { padding: 15px; } }
+${codeBlockStyles}
   </style>
 </head>
 <body class="markdown-body">

--- a/packages/app/src/components/PoeEditor.tsx
+++ b/packages/app/src/components/PoeEditor.tsx
@@ -334,6 +334,24 @@ export function PoeEditor({ onReady }: PoeEditorProps): ReactElement {
       border-radius: 12px;
       background: var(--bgColor-muted);
     }
+    .markdown-body {
+      --code-syntax-keyword: #a626a4;
+      --code-syntax-string: #50a14f;
+      --code-syntax-variable: #986801;
+      --code-syntax-number: #986801;
+      --code-syntax-entity: #005cc5;
+      --code-syntax-comment: #6a737d;
+    }
+    @media (prefers-color-scheme: dark) {
+      .markdown-body {
+        --code-syntax-keyword: var(--color-prettylights-syntax-keyword);
+        --code-syntax-string: var(--color-prettylights-syntax-string);
+        --code-syntax-variable: var(--color-prettylights-syntax-variable);
+        --code-syntax-number: var(--color-prettylights-syntax-variable);
+        --code-syntax-entity: var(--color-prettylights-syntax-entity);
+        --code-syntax-comment: var(--color-prettylights-syntax-comment);
+      }
+    }
     .markdown-body .code-block-language-hint {
       display: flex;
       align-items: center;
@@ -365,28 +383,28 @@ export function PoeEditor({ onReady }: PoeEditorProps): ReactElement {
     .markdown-body .hljs-literal,
     .markdown-body .hljs-doctag,
     .markdown-body .hljs-operator {
-      color: var(--color-prettylights-syntax-keyword);
+      color: var(--code-syntax-keyword);
     }
     .markdown-body .hljs-string,
     .markdown-body .hljs-meta .hljs-string,
     .markdown-body .hljs-attribute,
     .markdown-body .hljs-regexp {
-      color: var(--color-prettylights-syntax-string);
+      color: var(--code-syntax-string);
     }
     .markdown-body .hljs-number,
     .markdown-body .hljs-symbol,
     .markdown-body .hljs-variable,
     .markdown-body .hljs-template-variable {
-      color: var(--color-prettylights-syntax-variable);
+      color: var(--code-syntax-number);
     }
     .markdown-body .hljs-title,
     .markdown-body .hljs-title.class_,
     .markdown-body .hljs-title.function_ {
-      color: var(--color-prettylights-syntax-entity);
+      color: var(--code-syntax-entity);
     }
     .markdown-body .hljs-comment,
     .markdown-body .hljs-quote {
-      color: var(--color-prettylights-syntax-comment);
+      color: var(--code-syntax-comment);
     }`
 
     const htmlDoc = `<!DOCTYPE html>

--- a/packages/app/src/globals.css
+++ b/packages/app/src/globals.css
@@ -226,6 +226,12 @@ html:not(.dark) .markdown-body {
   --color-prettylights-syntax-markup-ignored-bg: #0550ae;
   --color-prettylights-syntax-meta-diff-range: #8250df;
   --color-prettylights-syntax-sublimelinter-gutter-mark: #818b98;
+  --code-syntax-keyword: #a626a4;
+  --code-syntax-string: #50a14f;
+  --code-syntax-variable: #986801;
+  --code-syntax-number: #986801;
+  --code-syntax-entity: #005cc5;
+  --code-syntax-comment: #6a737d;
   /* Ensure list styles are visible */
   ul {
     list-style-type: disc;
@@ -292,6 +298,12 @@ html:not(.dark) .markdown-body {
   --color-prettylights-syntax-markup-ignored-bg: #1158c7;
   --color-prettylights-syntax-meta-diff-range: #d2a8ff;
   --color-prettylights-syntax-sublimelinter-gutter-mark: #3d444d;
+  --code-syntax-keyword: var(--color-prettylights-syntax-keyword);
+  --code-syntax-string: var(--color-prettylights-syntax-string);
+  --code-syntax-variable: var(--color-prettylights-syntax-variable);
+  --code-syntax-number: var(--color-prettylights-syntax-variable);
+  --code-syntax-entity: var(--color-prettylights-syntax-entity);
+  --code-syntax-comment: var(--color-prettylights-syntax-comment);
   /* Ensure list styles are visible */
   ul {
     list-style-type: disc;
@@ -346,30 +358,30 @@ html:not(.dark) .markdown-body {
 .markdown-body .hljs-literal,
 .markdown-body .hljs-doctag,
 .markdown-body .hljs-operator {
-  color: var(--color-prettylights-syntax-keyword);
+  color: var(--code-syntax-keyword);
 }
 
 .markdown-body .hljs-string,
 .markdown-body .hljs-meta .hljs-string,
 .markdown-body .hljs-attribute,
 .markdown-body .hljs-regexp {
-  color: var(--color-prettylights-syntax-string);
+  color: var(--code-syntax-string);
 }
 
 .markdown-body .hljs-number,
 .markdown-body .hljs-symbol,
 .markdown-body .hljs-variable,
 .markdown-body .hljs-template-variable {
-  color: var(--color-prettylights-syntax-variable);
+  color: var(--code-syntax-number);
 }
 
 .markdown-body .hljs-title,
 .markdown-body .hljs-title.class_,
 .markdown-body .hljs-title.function_ {
-  color: var(--color-prettylights-syntax-entity);
+  color: var(--code-syntax-entity);
 }
 
 .markdown-body .hljs-comment,
 .markdown-body .hljs-quote {
-  color: var(--color-prettylights-syntax-comment);
+  color: var(--code-syntax-comment);
 }

--- a/packages/app/src/globals.css
+++ b/packages/app/src/globals.css
@@ -302,3 +302,74 @@ html:not(.dark) .markdown-body {
     padding-left: 1.5em;
   }
 }
+
+.markdown-body .code-block-with-language {
+  margin: 1rem 0;
+  overflow: hidden;
+  border: 1px solid var(--borderColor-muted);
+  border-radius: 12px;
+  background: var(--bgColor-muted);
+}
+
+.markdown-body .code-block-language-hint {
+  display: flex;
+  align-items: center;
+  min-height: 2rem;
+  padding: 0.35rem 0.8rem;
+  border-bottom: 1px solid var(--borderColor-muted);
+  color: var(--fgColor-muted);
+  font-family: 'JetBrains Mono', 'SFMono-Regular', Menlo, Consolas, monospace;
+  font-size: 0.72rem;
+  font-weight: 600;
+  letter-spacing: 0.03em;
+}
+
+.markdown-body .code-block-with-language pre {
+  margin: 0;
+  border: 0;
+  border-radius: 0;
+  background: transparent !important;
+}
+
+.markdown-body .code-block-with-language pre code.hljs {
+  display: block;
+  padding: 0;
+  background: transparent;
+}
+
+.markdown-body .hljs {
+  color: var(--fgColor-default);
+}
+
+.markdown-body .hljs-keyword,
+.markdown-body .hljs-selector-tag,
+.markdown-body .hljs-literal,
+.markdown-body .hljs-doctag,
+.markdown-body .hljs-operator {
+  color: var(--color-prettylights-syntax-keyword);
+}
+
+.markdown-body .hljs-string,
+.markdown-body .hljs-meta .hljs-string,
+.markdown-body .hljs-attribute,
+.markdown-body .hljs-regexp {
+  color: var(--color-prettylights-syntax-string);
+}
+
+.markdown-body .hljs-number,
+.markdown-body .hljs-symbol,
+.markdown-body .hljs-variable,
+.markdown-body .hljs-template-variable {
+  color: var(--color-prettylights-syntax-variable);
+}
+
+.markdown-body .hljs-title,
+.markdown-body .hljs-title.class_,
+.markdown-body .hljs-title.function_ {
+  color: var(--color-prettylights-syntax-entity);
+}
+
+.markdown-body .hljs-comment,
+.markdown-body .hljs-quote {
+  color: var(--color-prettylights-syntax-comment);
+}

--- a/packages/app/src/utils/markdown.test.ts
+++ b/packages/app/src/utils/markdown.test.ts
@@ -13,16 +13,33 @@ describe('renderMarkdown', () => {
   it('should render code blocks with highlighting classes', () => {
     const markdown = '```js\nconsole.log("hi")\n```'
     const html = renderMarkdown(markdown)
+    expect(html).toContain('<div class="code-block-with-language" data-language="js">')
+    expect(html).toContain('<div class="code-block-language-hint">JavaScript</div>')
     expect(html).toContain('<pre><code class="hljs language-js">')
     expect(html).toContain('console')
     expect(html).toContain('log')
   })
 
+  it('should map ts shorthand to a TypeScript label', () => {
+    const markdown = '```ts\nconst value: string = "x"\n```'
+    const html = renderMarkdown(markdown)
+    expect(html).toContain('<div class="code-block-language-hint">TypeScript</div>')
+    expect(html).toContain('class="hljs language-ts"')
+  })
+
   it('should render mermaid code blocks as standard code blocks', () => {
     const markdown = '```mermaid\ngraph TD;\n    A-->B;\n```'
     const html = renderMarkdown(markdown)
+    expect(html).toContain('<div class="code-block-language-hint">Mermaid</div>')
     expect(html).toContain('<pre><code class="hljs language-mermaid">')
     expect(html).toContain('graph TD;')
+  })
+
+  it('should not render language hint when code block has no language', () => {
+    const markdown = '```\nplain text\n```'
+    const html = renderMarkdown(markdown)
+    expect(html).toContain('<pre><code class="hljs">')
+    expect(html).not.toContain('code-block-language-hint')
   })
 
   it('should handle empty input', () => {

--- a/packages/app/src/utils/markdown.ts
+++ b/packages/app/src/utils/markdown.ts
@@ -1,11 +1,82 @@
 import MarkdownIt from 'markdown-it'
 import highlightjs from 'markdown-it-highlightjs'
 
+const LANGUAGE_DISPLAY_NAMES: Record<string, string> = {
+  bash: 'Bash',
+  c: 'C',
+  'c++': 'C++',
+  cpp: 'C++',
+  cs: 'C#',
+  csharp: 'C#',
+  css: 'CSS',
+  go: 'Go',
+  html: 'HTML',
+  java: 'Java',
+  javascript: 'JavaScript',
+  js: 'JavaScript',
+  json: 'JSON',
+  jsx: 'JSX',
+  kotlin: 'Kotlin',
+  markdown: 'Markdown',
+  md: 'Markdown',
+  mermaid: 'Mermaid',
+  php: 'PHP',
+  py: 'Python',
+  python: 'Python',
+  rb: 'Ruby',
+  rs: 'Rust',
+  ruby: 'Ruby',
+  rust: 'Rust',
+  scss: 'SCSS',
+  shell: 'Shell',
+  sh: 'Shell',
+  sql: 'SQL',
+  swift: 'Swift',
+  ts: 'TypeScript',
+  tsx: 'TSX',
+  typescript: 'TypeScript',
+  xml: 'XML',
+  yaml: 'YAML',
+  yml: 'YAML',
+  zsh: 'Shell',
+}
+
+function toLanguageLabel(language: string): string {
+  const normalized = language.toLowerCase()
+  const predefined = LANGUAGE_DISPLAY_NAMES[normalized]
+  if (predefined) return predefined
+
+  return normalized
+    .split(/[_-]/)
+    .filter(Boolean)
+    .map((part) => (part.length <= 3 ? part.toUpperCase() : part[0].toUpperCase() + part.slice(1)))
+    .join(' ')
+}
+
 const md = new MarkdownIt({
   html: false,
   linkify: true,
   typographer: true,
 }).use(highlightjs)
+
+const defaultFenceRenderer = md.renderer.rules.fence?.bind(md.renderer.rules)
+
+md.renderer.rules.fence = (tokens, idx, options, env, self): string => {
+  const language = tokens[idx].info.trim().split(/\s+/)[0]?.toLowerCase()
+
+  const renderedFence =
+    language === 'mermaid'
+      ? `<pre><code class="hljs language-mermaid">${md.utils.escapeHtml(tokens[idx].content)}</code></pre>`
+      : (defaultFenceRenderer?.(tokens, idx, options, env, self) ??
+        self.renderToken(tokens, idx, options))
+
+  if (!language) return renderedFence
+
+  const escapedLanguage = md.utils.escapeHtml(language)
+  const escapedLabel = md.utils.escapeHtml(toLanguageLabel(language))
+
+  return `<div class="code-block-with-language" data-language="${escapedLanguage}"><div class="code-block-language-hint">${escapedLabel}</div>${renderedFence}</div>`
+}
 
 /**
  * Renders markdown text to HTML

--- a/packages/app/src/utils/splitHtmlAtMermaid.test.ts
+++ b/packages/app/src/utils/splitHtmlAtMermaid.test.ts
@@ -56,6 +56,32 @@ describe('splitHtmlAtMermaid', () => {
     expect(result).toEqual([{ type: 'mermaid', code: 'A & B <-- C > D "E" \'F\'' }])
   })
 
+  it('extracts wrapped mermaid code blocks with language hints', () => {
+    const html =
+      '<p>Before</p><div class="code-block-with-language" data-language="mermaid"><div class="code-block-language-hint">Mermaid</div><pre><code class="hljs language-mermaid">graph TD;\nA--&gt;B;</code></pre></div><p>After</p>'
+    const result = splitHtmlAtMermaid(html)
+    expect(result).toEqual([
+      { type: 'html', content: '<p>Before</p>' },
+      { type: 'mermaid', code: 'graph TD;\nA-->B;' },
+      { type: 'html', content: '<p>After</p>' },
+    ])
+  })
+
+  it('keeps non-mermaid wrapped code blocks when mermaid exists in the same html', () => {
+    const html =
+      '<p>Intro</p><div class="code-block-with-language" data-language="ts"><div class="code-block-language-hint">TypeScript</div><pre><code class="hljs language-ts">const value = 1</code></pre></div><p>Middle</p><div class="code-block-with-language" data-language="mermaid"><div class="code-block-language-hint">Mermaid</div><pre><code class="hljs language-mermaid">graph TD;\nA--&gt;B;</code></pre></div><p>End</p>'
+    const result = splitHtmlAtMermaid(html)
+    expect(result).toEqual([
+      {
+        type: 'html',
+        content:
+          '<p>Intro</p><div class="code-block-with-language" data-language="ts"><div class="code-block-language-hint">TypeScript</div><pre><code class="hljs language-ts">const value = 1</code></pre></div><p>Middle</p>',
+      },
+      { type: 'mermaid', code: 'graph TD;\nA-->B;' },
+      { type: 'html', content: '<p>End</p>' },
+    ])
+  })
+
   it('returns empty array for empty input', () => {
     expect(splitHtmlAtMermaid('')).toEqual([])
   })

--- a/packages/app/src/utils/splitHtmlAtMermaid.ts
+++ b/packages/app/src/utils/splitHtmlAtMermaid.ts
@@ -5,14 +5,18 @@
 export type HtmlSegment = { type: 'html'; content: string } | { type: 'mermaid'; code: string }
 
 /**
- * Splits an HTML string at `<pre><code class="...language-mermaid...">` blocks,
- * extracting the mermaid source code from each match.
+ * Splits an HTML string at Mermaid code blocks, extracting the mermaid source code.
+ * Supports both plain `<pre><code ...language-mermaid...>` blocks and wrapped
+ * language-hint code blocks used by preview/export rendering.
  * @param html - The full HTML string from markdown rendering
  * @returns An array of segments alternating between HTML and mermaid code
  */
 export function splitHtmlAtMermaid(html: string): HtmlSegment[] {
-  // Match <pre><code class="hljs language-mermaid">...code...</code></pre>
-  const pattern = /<pre><code class="[^"]*language-mermaid[^"]*">([\s\S]*?)<\/code><\/pre>/g
+  // Match either:
+  // 1) Wrapped mermaid block (<div class="code-block-with-language" data-language="mermaid">...)
+  // 2) Plain mermaid block (<pre><code class="...language-mermaid...">...</code></pre>)
+  const pattern =
+    /<div class="code-block-with-language"[^>]*data-language="mermaid"[^>]*>\s*<div class="code-block-language-hint"[^>]*>[\s\S]*?<\/div>\s*<pre><code class="[^"]*language-mermaid[^"]*">([\s\S]*?)<\/code><\/pre>\s*<\/div>|<pre><code class="[^"]*language-mermaid[^"]*">([\s\S]*?)<\/code><\/pre>/g
 
   const segments: HtmlSegment[] = []
   let lastIndex = 0
@@ -25,7 +29,13 @@ export function splitHtmlAtMermaid(html: string): HtmlSegment[] {
     }
 
     // Decode HTML entities in the mermaid source
-    const code = match[1]
+    const encodedCode = match[1] ?? match[2]
+    if (encodedCode === undefined) {
+      lastIndex = match.index + match[0].length
+      continue
+    }
+
+    const code = encodedCode
       .replace(/&lt;/g, '<')
       .replace(/&gt;/g, '>')
       .replace(/&amp;/g, '&')


### PR DESCRIPTION
Adds visual language labels to fenced code blocks in preview and HTML export rendering.

- Implemented language display name mapping for common programming languages with sensible fallbacks for unmapped languages.
- Added styled language hint header above code blocks with monospace typography and theme-aware colours.
- Extended HTML export to include code block wrapper styling with proper light and dark mode support.
- Updated mermaid diagram extraction to handle wrapped code blocks with language hints.
- Added comprehensive unit tests for language label rendering and wrapped code block handling.
