### PR TITLE
feat(share): Add social preview hero image support

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -21,6 +21,7 @@ Poe includes standard Markdown editor functionality and a set of unique features
 | ------------------------------------------ | ------------------------------------------------------------------------------------ |
 | URL-based document persistence             | Content is compressed into the URL hash; no login or backend storage required.       |
 | Share links with readable metadata         | Shared URLs include a title/snippet path plus compressed hash payload.               |
+| Share preview hero images                  | Social previews can use `?hero=<image-url>`; when multiple doc images exist, first is used. |
 | Dynamic title + emoji favicon from content | First heading drives page title; fallback prefers file name, then shared URL title.  |
 | URL length safety + testing override       | Over-limit warnings are surfaced; `?limit=<n>` can override max length for testing.  |
 | Persisted editor preferences               | Vim mode, line numbers, word count, spell check, and start-empty preference persist. |

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "generate:og": "npm run generate -w packages/og-generator",
     "lint": "npm run lint --workspaces",
     "lint:fix": "npm run lint:fix --workspaces",
+    "tsc": "npm run tsc --workspaces --if-present",
     "format": "npm run format --workspaces",
     "format:check": "npm run format:check --workspaces",
     "test": "npm test -w packages/app",

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -16,7 +16,8 @@
     "test:run": "vitest run",
     "test:coverage": "vitest run --coverage",
     "test:e2e": "playwright test",
-    "deploy": "wrangler deploy"
+    "deploy": "wrangler deploy",
+    "tsc": "tsc --noEmit"
   },
   "dependencies": {
     "@dnd-kit/core": "^6.3.1",

--- a/packages/app/src/hooks/useUrlState.test.ts
+++ b/packages/app/src/hooks/useUrlState.test.ts
@@ -237,4 +237,31 @@ describe('useUrlState', () => {
 
     vi.useRealTimers()
   })
+
+  it('should not preserve existing hero query parameter', () => {
+    vi.useFakeTimers()
+
+    const baseUrl = 'http://localhost:3000/?foo=bar&hero=https%3A%2F%2Fold.example.com%2Fhero.png'
+    Object.defineProperty(window, 'location', {
+      value: new URL(baseUrl),
+      writable: true,
+    })
+
+    const { result } = renderHook(() => useUrlState())
+    const replaceStateSpy = vi.spyOn(window.history, 'replaceState')
+
+    act(() => {
+      result.current.setContent('New Content without image')
+    })
+
+    act(() => {
+      vi.advanceTimersByTime(500)
+    })
+
+    const lastCall = replaceStateSpy.mock.calls[replaceStateSpy.mock.calls.length - 1]
+    expect(lastCall[2]).toContain('?foo=bar')
+    expect(lastCall[2]).not.toContain('hero=')
+
+    vi.useRealTimers()
+  })
 })

--- a/packages/app/src/hooks/useUrlState.ts
+++ b/packages/app/src/hooks/useUrlState.ts
@@ -275,8 +275,8 @@ export function useUrlState(options?: UseUrlStateOptions): UseUrlStateReturn {
 
       // Copy query params from current URL to new URL
       currentUrl.searchParams.forEach((value, key) => {
-        if (key !== 'limit') {
-          // Don't copy the limit param used for testing
+        if (key !== 'limit' && key !== 'hero') {
+          // Don't copy params managed by generation logic
           newUrl.searchParams.set(key, value)
         }
       })

--- a/packages/app/src/utils/urlShare.test.ts
+++ b/packages/app/src/utils/urlShare.test.ts
@@ -109,6 +109,33 @@ describe('generateShareableUrl', () => {
     expect(url).not.toContain('#')
     expect(url).toBe('https://poemd.dev/title/snippet')
   })
+
+  it('appends hero query param from first markdown image', () => {
+    const content = '# Title\n\n![hero](https://images.example.com/hero.png)\n\nBody text'
+    const url = generateShareableUrl(content, 'untitled.md', 'hash')
+
+    expect(url).toContain('?hero=https%3A%2F%2Fimages.example.com%2Fhero.png')
+    expect(url).toContain('#hash')
+  })
+
+  it('uses the first image when multiple images are referenced', () => {
+    const content = `# Title
+
+![first](https://images.example.com/first.png)
+![second](https://images.example.com/second.png)
+`
+    const url = generateShareableUrl(content, 'untitled.md', 'hash')
+
+    expect(url).toContain('?hero=https%3A%2F%2Fimages.example.com%2Ffirst.png')
+    expect(url).not.toContain('second.png')
+  })
+
+  it('appends hero query param from first html image', () => {
+    const content = '# Title\n\n<img src="https://images.example.com/html-hero.png" alt="hero" />'
+    const url = generateShareableUrl(content, 'untitled.md', 'hash')
+
+    expect(url).toContain('?hero=https%3A%2F%2Fimages.example.com%2Fhtml-hero.png')
+  })
 })
 
 describe('parsePathMetadata', () => {

--- a/packages/app/src/utils/urlShare.ts
+++ b/packages/app/src/utils/urlShare.ts
@@ -2,6 +2,38 @@ import { getFirstHeading } from '@/utils/markdown'
 import { extractFirstEmoji } from '@/utils/emoji'
 
 /**
+ * Extracts the first image URL reference from markdown or HTML image syntax
+ * @param content - The markdown content
+ * @returns The first referenced image URL, or null if none found
+ */
+function extractFirstImageUrl(content: string): string | null {
+  const imagePattern = /!\[[^\]]*?\]\(([^)]+)\)|<img\b[^>]*?\bsrc=["']([^"']+)["'][^>]*?>/gi
+  const match = imagePattern.exec(content)
+
+  if (!match) {
+    return null
+  }
+
+  if (match[2]) {
+    return match[2].trim() || null
+  }
+
+  const markdownUrl = match[1]?.trim()
+  if (!markdownUrl) {
+    return null
+  }
+
+  if (markdownUrl.startsWith('<')) {
+    const closingIndex = markdownUrl.indexOf('>')
+    if (closingIndex > 1) {
+      return markdownUrl.slice(1, closingIndex)
+    }
+  }
+
+  return markdownUrl.split(/\s+/)[0] ?? null
+}
+
+/**
  * Extracts a snippet from content (first non-heading line, truncated)
  * @param content - The markdown content
  * @param maxLength - Maximum length of snippet (default: 80)
@@ -81,13 +113,21 @@ export function generateShareableUrl(content: string, documentName: string, hash
   // Encode path segments
   const encodedTitle = encodePathSegment(title)
   const encodedSnippet = encodePathSegment(snippet)
+  const heroImageUrl = extractFirstImageUrl(content)
 
   // Build the URL
   const baseUrl = window.location.origin
-  const path = `/${encodedTitle}/${encodedSnippet}`
-  const fullHash = hash ? `#${hash}` : ''
+  const shareableUrl = new URL(`/${encodedTitle}/${encodedSnippet}`, baseUrl)
 
-  return `${baseUrl}${path}${fullHash}`
+  if (heroImageUrl) {
+    shareableUrl.searchParams.set('hero', heroImageUrl)
+  }
+
+  if (hash) {
+    shareableUrl.hash = hash
+  }
+
+  return shareableUrl.toString()
 }
 
 /**

--- a/packages/og-generator/package.json
+++ b/packages/og-generator/package.json
@@ -11,7 +11,8 @@
     "format": "prettier --write .",
     "format:check": "prettier --check .",
     "test": "vitest run",
-    "test:watch": "vitest"
+    "test:watch": "vitest",
+    "tsc": "tsc --noEmit"
   },
   "dependencies": {
     "@resvg/resvg-js": "^2.6.2",

--- a/packages/proxy/package.json
+++ b/packages/proxy/package.json
@@ -14,7 +14,8 @@
     "test": "vitest",
     "test:run": "vitest run",
     "format": "prettier --write .",
-    "format:check": "prettier --check ."
+    "format:check": "prettier --check .",
+    "tsc": "tsc --noEmit"
   },
   "dependencies": {
     "react": "^19.2.4"

--- a/packages/proxy/src/handlers.tsx
+++ b/packages/proxy/src/handlers.tsx
@@ -25,7 +25,7 @@ function fetchFromOrigin(url: string, env: Env): Promise<Response> {
  */
 export async function handleMetadataRoute(
   request: Request,
-  metadata: { title: string; snippet: string },
+  metadata: { title: string; snippet: string; heroImageUrl?: string },
   env: Env
 ): Promise<Response> {
   const url = new URL(request.url)
@@ -36,8 +36,11 @@ export async function handleMetadataRoute(
     return fetchFromOrigin(request.url, env)
   }
 
-  const rewriter = new HTMLRewriter()
-    .on('head', createHeadHandler(metadata.title, metadata.snippet, url.toString()))
+  let rewriter = new HTMLRewriter()
+    .on(
+      'head',
+      createHeadHandler(metadata.title, metadata.snippet, url.toString(), metadata.heroImageUrl)
+    )
     .on('title', createTitleHandler(metadata.title))
     .on('meta[property="og:title"]', removeElementHandler)
     .on('meta[property="og:description"]', removeElementHandler)
@@ -49,6 +52,12 @@ export async function handleMetadataRoute(
     .on('meta[name="twitter:description"]', removeElementHandler)
     .on('meta[name="twitter:url"]', removeElementHandler)
     .on('meta[name="description"]', removeElementHandler)
+
+  if (metadata.heroImageUrl) {
+    rewriter = rewriter
+      .on('meta[property="og:image"]', removeElementHandler)
+      .on('meta[name="twitter:image"]', removeElementHandler)
+  }
 
   return rewriter.transform(indexResponse)
 }

--- a/packages/proxy/src/rewriter.test.tsx
+++ b/packages/proxy/src/rewriter.test.tsx
@@ -220,4 +220,44 @@ describe('Worker Rewriter Tests', () => {
     expect(text).not.toContain('<meta property="og:description" content="Old Desc" />')
     expect(text).not.toContain('<meta name="description" content="Old Desc" />')
   })
+
+  it('should replace existing OG/Twitter image tags when hero query param is provided', async () => {
+    const mockHtml = `<!DOCTYPE html>
+<html>
+<head>
+  <title>Default</title>
+  <meta property="og:title" content="Old Title" />
+  <meta property="og:image" content="https://example.com/existing-image.png" />
+  <meta name="twitter:image" content="https://example.com/existing-twitter-image.png" />
+</head>
+<body></body>
+</html>`
+
+    fetchMock.mockResolvedValueOnce(
+      new Response(mockHtml, {
+        status: 200,
+        headers: { 'content-type': 'text/html' },
+      })
+    )
+
+    const request = new Request(
+      'http://localhost:8787/My-Title/My-Snippet?hero=https%3A%2F%2Fcdn.example.com%2Fhero.png'
+    )
+    const response = await worker.fetch(request, {}, {} as ExecutionContext)
+    const text = await response.text()
+
+    expect(response.status).toBe(200)
+    expect(text).toContain(
+      '<meta property="og:image" content="https://cdn.example.com/hero.png" />'
+    )
+    expect(text).toContain(
+      '<meta name="twitter:image" content="https://cdn.example.com/hero.png" />'
+    )
+    expect(text).not.toContain(
+      '<meta property="og:image" content="https://example.com/existing-image.png" />'
+    )
+    expect(text).not.toContain(
+      '<meta name="twitter:image" content="https://example.com/existing-twitter-image.png" />'
+    )
+  })
 })

--- a/packages/proxy/src/rewriter.ts
+++ b/packages/proxy/src/rewriter.ts
@@ -22,23 +22,29 @@ export const removeElementHandler = {
  * Creates an HTMLRewriter handler for the <head> element to inject OG meta tags
  * @param title - The page title
  * @param snippet - The page snippet/description
- * @param ogImageUrl - The standard OG image URL
- * @param twitterOgImageUrl - The Twitter-specific OG image URL
  * @param url - The current page URL
+ * @param heroImageUrl - Optional image URL for OG/Twitter previews
  * @returns Element handler object for HTMLRewriter
  */
 export function createHeadHandler(
   title: string,
   snippet: string,
-  url: string
+  url: string,
+  heroImageUrl?: string
 ): ElementContentHandlers {
   const origin = new URL(url).origin
+  const imageMetaTags = heroImageUrl
+    ? `<meta property="og:image" content="${escapeHtml(heroImageUrl)}" />
+<meta name="twitter:image" content="${escapeHtml(heroImageUrl)}" />
+`
+    : ''
+
   return {
     element(element: Element): void {
       const metaTags = `
 <meta property="og:title" content="${escapeHtml(title)}" />
 <meta property="og:description" content="${escapeHtml(snippet)}" />
-<meta property="og:type" content="article" />
+${imageMetaTags}<meta property="og:type" content="article" />
 <meta property="og:url" content="${url}" />
 <meta property="og:site_name" content="Poe Markdown Editor" />
 <meta property="og:logo" content="${origin}/favicon.svg" />

--- a/packages/proxy/src/worker.test.tsx
+++ b/packages/proxy/src/worker.test.tsx
@@ -40,8 +40,53 @@ describe('Worker Routing', () => {
     const request = new Request('http://localhost:8787/My-Title/My-Snippet')
     const response = await worker.fetch(request, {}, {} as ExecutionContext)
 
-    expect(handleMetadataRoute).toHaveBeenCalled()
+    expect(handleMetadataRoute).toHaveBeenCalledWith(
+      request,
+      {
+        title: 'My Title',
+        snippet: 'My Snippet',
+        heroImageUrl: undefined,
+      },
+      {}
+    )
+    expect(handleMetadataRoute).toHaveBeenCalledTimes(1)
     expect(response.status).toBe(200)
     expect(await response.text()).toBe('Metadata')
+  })
+
+  it('should pass hero query param to metadata handler', async () => {
+    const request = new Request(
+      'http://localhost:8787/My-Title/My-Snippet?hero=https%3A%2F%2Fcdn.example.com%2Fhero.png'
+    )
+
+    await worker.fetch(request, {}, {} as ExecutionContext)
+
+    expect(handleMetadataRoute).toHaveBeenCalledWith(
+      request,
+      {
+        title: 'My Title',
+        snippet: 'My Snippet',
+        heroImageUrl: 'https://cdn.example.com/hero.png',
+      },
+      {}
+    )
+  })
+
+  it('should ignore non-http hero query params', async () => {
+    const request = new Request(
+      'http://localhost:8787/My-Title/My-Snippet?hero=javascript%3Aalert%281%29'
+    )
+
+    await worker.fetch(request, {}, {} as ExecutionContext)
+
+    expect(handleMetadataRoute).toHaveBeenCalledWith(
+      request,
+      {
+        title: 'My Title',
+        snippet: 'My Snippet',
+        heroImageUrl: undefined,
+      },
+      {}
+    )
   })
 })

--- a/packages/proxy/src/worker.tsx
+++ b/packages/proxy/src/worker.tsx
@@ -19,6 +19,29 @@ function proxyToOrigin(request: Request, env: Env): Promise<Response> {
   return fetch(request)
 }
 
+/**
+ * Reads and normalizes the optional hero image URL from query params
+ * @param url - Incoming request URL
+ * @returns Absolute hero image URL, or undefined if missing/invalid
+ */
+function parseHeroImageUrl(url: URL): string | undefined {
+  const hero = url.searchParams.get('hero')
+  if (!hero) {
+    return undefined
+  }
+
+  try {
+    const parsedHeroUrl = new URL(hero, url.origin)
+    if (parsedHeroUrl.protocol !== 'http:' && parsedHeroUrl.protocol !== 'https:') {
+      return undefined
+    }
+
+    return parsedHeroUrl.toString()
+  } catch {
+    return undefined
+  }
+}
+
 export default {
   async fetch(request: Request, env: Env, _ctx: ExecutionContext): Promise<Response> {
     const url = new URL(request.url)
@@ -26,7 +49,8 @@ export default {
 
     const metadata = parsePathMetadata(pathname)
     if (metadata) {
-      return handleMetadataRoute(request, metadata, env)
+      const heroImageUrl = parseHeroImageUrl(url)
+      return handleMetadataRoute(request, { ...metadata, heroImageUrl }, env)
     }
 
     return proxyToOrigin(request, env)


### PR DESCRIPTION
Adds the ability to specify a custom image for social media previews via the `?hero=<image-url>` query parameter. When generating shareable URLs from document content, the first referenced image (markdown or HTML syntax) is automatically extracted and appended as the hero parameter.

- Implemented image extraction from markdown and HTML image syntax in content.
- Hero query parameter is automatically appended to shareable URLs when images are detected.
- Social preview metadata (og:image, twitter:image) is injected when hero parameter is present.
- Existing hero parameters are stripped when content is regenerated to prevent stale image references.
- Added validation to reject non-HTTP(S) hero URLs for security.
- Added TypeScript type checking script (`tsc`) to all workspace packages.
- Extended test coverage for image extraction, URL generation, and metadata handling.
