### PR TITLE
feat(export): Add theme-aware HTML export with sepia code blocks

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -34,6 +34,7 @@ Poe includes standard Markdown editor functionality and a set of unique features
 | Mermaid diagram rendering          | Mermaid code blocks render as diagrams in preview.                                 |
 | Theme-aware Mermaid diagrams       | Mermaid output uses separate light/dark theme tokens.                              |
 | Mermaid support in HTML export     | Exported HTML includes Mermaid runtime/init when diagrams exist.                   |
+| Theme-aware HTML export            | Exported HTML now uses the active app theme (light or dark) at download time.     |
 | Code fence language headers        | Fenced code blocks with a language show a header label in preview and HTML export. |
 | Synchronized editor/preview scroll | Scroll sync uses ratio-based matching between Monaco and preview.                  |
 | Preview rich-text copy             | Copy supports both HTML and plain text where browser APIs allow.                   |

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -17,28 +17,29 @@ Poe includes standard Markdown editor functionality and a set of unique features
 
 ### Document and Session
 
-| Feature                                    | Notes                                                                                |
-| ------------------------------------------ | ------------------------------------------------------------------------------------ |
-| URL-based document persistence             | Content is compressed into the URL hash; no login or backend storage required.       |
-| Share links with readable metadata         | Shared URLs include a title/snippet path plus compressed hash payload.               |
+| Feature                                    | Notes                                                                                       |
+| ------------------------------------------ | ------------------------------------------------------------------------------------------- |
+| URL-based document persistence             | Content is compressed into the URL hash; no login or backend storage required.              |
+| Share links with readable metadata         | Shared URLs include a title/snippet path plus compressed hash payload.                      |
 | Share preview hero images                  | Social previews can use `?hero=<image-url>`; when multiple doc images exist, first is used. |
-| Dynamic title + emoji favicon from content | First heading drives page title; fallback prefers file name, then shared URL title.  |
-| URL length safety + testing override       | Over-limit warnings are surfaced; `?limit=<n>` can override max length for testing.  |
-| Persisted editor preferences               | Vim mode, line numbers, word count, spell check, and start-empty preference persist. |
-| App reset                                  | Reset app state is available (saved transformers are intentionally preserved).       |
+| Dynamic title + emoji favicon from content | First heading drives page title; fallback prefers file name, then shared URL title.         |
+| URL length safety + testing override       | Over-limit warnings are surfaced; `?limit=<n>` can override max length for testing.         |
+| Persisted editor preferences               | Vim mode, line numbers, word count, spell check, and start-empty preference persist.        |
+| App reset                                  | Reset app state is available (saved transformers are intentionally preserved).              |
 
 ### Preview and Rendering
 
-| Feature                            | Notes                                                                              |
-| ---------------------------------- | ---------------------------------------------------------------------------------- |
-| Mermaid diagram rendering          | Mermaid code blocks render as diagrams in preview.                                 |
-| Theme-aware Mermaid diagrams       | Mermaid output uses separate light/dark theme tokens.                              |
-| Mermaid support in HTML export     | Exported HTML includes Mermaid runtime/init when diagrams exist.                   |
-| Theme-aware HTML export            | Exported HTML now uses the active app theme (light or dark) at download time.     |
-| Code fence language headers        | Fenced code blocks with a language show a header label in preview and HTML export. |
-| Synchronized editor/preview scroll | Scroll sync uses ratio-based matching between Monaco and preview.                  |
-| Preview rich-text copy             | Copy supports both HTML and plain text where browser APIs allow.                   |
-| Editor markdown quick-copy         | Editor pane includes one-click Markdown copy action.                               |
+| Feature                            | Notes                                                                                                 |
+| ---------------------------------- | ----------------------------------------------------------------------------------------------------- |
+| Mermaid diagram rendering          | Mermaid code blocks render as diagrams in preview.                                                    |
+| Theme-aware Mermaid diagrams       | Mermaid output uses separate light/dark theme tokens.                                                 |
+| Mermaid support in HTML export     | Exported HTML includes Mermaid runtime/init when diagrams exist.                                      |
+| Theme-aware HTML export            | Exported HTML now uses the active app theme (light or dark) at download time.                         |
+| Sepia code blocks in light export  | Light-mode HTML exports render fenced code blocks with sepia borders/backgrounds for better contrast. |
+| Code fence language headers        | Fenced code blocks with a language show a header label in preview and HTML export.                    |
+| Synchronized editor/preview scroll | Scroll sync uses ratio-based matching between Monaco and preview.                                     |
+| Preview rich-text copy             | Copy supports both HTML and plain text where browser APIs allow.                                      |
+| Editor markdown quick-copy         | Editor pane includes one-click Markdown copy action.                                                  |
 
 ### Editing and Input
 

--- a/packages/app/MD_TEST.md
+++ b/packages/app/MD_TEST.md
@@ -1,0 +1,250 @@
+# 🧪 Poe Markdown Render Manual Test
+
+Use this document to quickly verify that Markdown rendering, syntax highlighting, Mermaid, tables, and theme behavior all look correct.
+
+## Manual Test Checklist
+
+- Load this file in Poe editor and confirm editor + preview stay in sync while scrolling.
+- Toggle between light and dark theme and confirm readability/contrast remains good for all sections.
+- Confirm first heading text updates page title and emoji favicon (`🧪`).
+- Export as HTML in light mode, open file, confirm light styling.
+- Export as HTML in dark mode, open file, confirm dark styling.
+- Copy preview as rich text and paste into a rich-text target (e.g., docs editor) to verify structure survives.
+- Copy editor markdown and confirm pasted text matches source.
+
+---
+
+## 1) Headings
+
+# H1 Example
+
+## H2 Example
+
+### H3 Example
+
+#### H4 Example
+
+##### H5 Example
+
+###### H6 Example
+
+## 2) Paragraphs, Emphasis, Typography
+
+This paragraph tests **bold**, _italic_, **_bold italic_**, ~~strikethrough~~, and `inline code`.
+
+Typographer checks: "double quotes", 'single quotes', three dots..., double-hyphen -- and em-dash style text.
+
+Long wrapping paragraph check: Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+
+## 3) Links, Autolinks, Images
+
+- Standard link: [Poe Editor Repository](https://github.com/)
+- Autolink text (should become clickable): https://example.com/path?q=poe-editor
+- Mail autolink: test@example.com
+
+Image check:
+
+![Sample Markdown Test Image](https://upload.wikimedia.org/wikipedia/commons/thumb/4/47/PNG_transparency_demonstration_1.png/320px-PNG_transparency_demonstration_1.png)
+
+## 4) Lists
+
+Unordered list:
+
+- Item A
+- Item B
+  - Nested B.1
+  - Nested B.2
+- Item C
+
+Ordered list:
+
+1. First
+2. Second
+3. Third
+
+Mixed content list:
+
+1. Step one with `code`.
+2. Step two with **formatting**.
+3. Step three with a sub-list:
+   - Sub step A
+   - Sub step B
+
+## 5) Blockquotes and Rules
+
+> Blockquote level 1
+>
+> > Blockquote level 2
+>
+> Back to level 1 with **bold text** and a [link](https://example.org).
+
+---
+
+## 6) Tables (Including CJK/Emoji Width)
+
+| Column      | Value          | Notes                    |
+| ----------- | -------------- | ------------------------ |
+| Plain ASCII | abc123         | Baseline width           |
+| CJK         | 漢字かなカナ   | Wide-character alignment |
+| Emoji       | 😀🚀✅         | Emoji width handling     |
+| Mixed       | テスト test ✅ | Mixed width content      |
+
+Alignment table:
+
+| Left | Center | Right |
+| :--- | :----: | ----: |
+| L1   |   C1   |    R1 |
+| L2   |   C2   |    R2 |
+
+## 7) Inline HTML Should Be Escaped (Renderer Safety)
+
+The following should render as text, not active HTML:
+
+<div style="color: red;">This should not be interpreted as live HTML.</div>
+
+And script tags should not execute:
+
+<script>window.__POE_MD_TEST__ = 'should-not-run'</script>
+
+## 8) Code Blocks (Language Labels + Highlighting)
+
+No language fence (should render code block without language header):
+
+```
+plain code block
+with multiple lines
+and no syntax language
+```
+
+JavaScript:
+
+```javascript
+const message = 'Hello, Poe'
+function greet(name) {
+  return `${message}, ${name}!`
+}
+console.log(greet('Markdown'))
+```
+
+TypeScript:
+
+```typescript
+type User = { id: number; name: string }
+const users: User[] = [{ id: 1, name: 'Poe' }]
+```
+
+JSON:
+
+```json
+{
+  "app": "poe-editor",
+  "features": ["markdown", "mermaid", "transformers"],
+  "darkMode": true
+}
+```
+
+YAML:
+
+```yaml
+name: poe-editor
+theme: dark
+modules:
+  - markdown
+  - mermaid
+```
+
+SQL:
+
+```sql
+SELECT id, name
+FROM users
+WHERE active = TRUE
+ORDER BY created_at DESC;
+```
+
+Shell:
+
+```bash
+npm run dev
+npm test
+npm run build
+```
+
+Unknown language (header should still be humanized):
+
+```custom-lang_name
+render this with a generated language label
+```
+
+## 9) Mermaid Diagrams
+
+Flowchart:
+
+```mermaid
+flowchart LR
+  A[Start] --> B{Theme}
+  B -->|Light| C[Light tokens]
+  B -->|Dark| D[Dark tokens]
+  C --> E[Rendered preview]
+  D --> E
+```
+
+Sequence diagram:
+
+```mermaid
+sequenceDiagram
+  participant U as User
+  participant E as Editor
+  participant P as Preview
+  U->>E: Type markdown
+  E->>P: Render HTML
+  P-->>U: Live preview
+```
+
+## 10) Markdown in Quotes and Escapes
+
+Escaped symbols: \*literal asterisks\*, \_literal underscore\_, \`literal backticks\`.
+
+Inline code with markdown syntax inside: `**not bold inside inline code**`.
+
+## 11) Large Section for Scroll Sync
+
+Paragraph 1: The quick brown fox jumps over the lazy dog.
+
+Paragraph 2: The quick brown fox jumps over the lazy dog.
+
+Paragraph 3: The quick brown fox jumps over the lazy dog.
+
+Paragraph 4: The quick brown fox jumps over the lazy dog.
+
+Paragraph 5: The quick brown fox jumps over the lazy dog.
+
+Paragraph 6: The quick brown fox jumps over the lazy dog.
+
+Paragraph 7: The quick brown fox jumps over the lazy dog.
+
+Paragraph 8: The quick brown fox jumps over the lazy dog.
+
+Paragraph 9: The quick brown fox jumps over the lazy dog.
+
+Paragraph 10: The quick brown fox jumps over the lazy dog.
+
+Paragraph 11: The quick brown fox jumps over the lazy dog.
+
+Paragraph 12: The quick brown fox jumps over the lazy dog.
+
+Paragraph 13: The quick brown fox jumps over the lazy dog.
+
+Paragraph 14: The quick brown fox jumps over the lazy dog.
+
+Paragraph 15: The quick brown fox jumps over the lazy dog.
+
+## 12) Final Render Sanity
+
+If everything is working, you should see:
+
+- Correct typography and spacing across all markdown elements.
+- Syntax-highlighted code with language headers (except no-language block).
+- Mermaid diagrams rendered (not raw mermaid code) in preview.
+- Clean table borders/alignment in both themes.
+- Inline HTML displayed as literal text for safety.

--- a/packages/app/src/components/PoeEditor.tsx
+++ b/packages/app/src/components/PoeEditor.tsx
@@ -13,6 +13,7 @@ import { useEditorPreferences } from '@/hooks/useEditorPreferences'
 import { useSpellCheck } from '@/hooks/useSpellCheck'
 import { renderMarkdown } from '@/utils/markdown'
 import { downloadFile } from '@/utils/download'
+import { buildHtmlExportDocument } from '@/utils/htmlExport'
 import { applyPipeline } from '@/utils/transformer-engine'
 import { EditorPane, type EditorPaneHandle, type TableAction } from '@/components/editor'
 import { PreviewPane } from '@/components/PreviewPane'
@@ -40,7 +41,7 @@ import { TransformerImportExportDialog } from '@/components/transformer/Transfor
 import type { TransformationPipeline } from '@/components/transformer/types'
 import { useToast } from '@/hooks/useToast'
 import { generateShareableUrl } from '@/utils/urlShare'
-import { getMermaidInitScript, type MermaidColorMode } from '@/utils/mermaidTheme'
+import type { MermaidColorMode } from '@/utils/mermaidTheme'
 
 import {
   formatBold,
@@ -89,7 +90,7 @@ interface PoeEditorProps {
  * @returns The PoeEditor component
  */
 export function PoeEditor({ onReady }: PoeEditorProps): ReactElement {
-  const { theme, setTheme } = useTheme()
+  const { theme, resolvedTheme, setTheme } = useTheme()
   const { toast } = useToast()
   const [mounted, setMounted] = useState(false)
   const [showAbout, setShowAbout] = useState(false)
@@ -174,7 +175,7 @@ export function PoeEditor({ onReady }: PoeEditorProps): ReactElement {
 
   // Rendered HTML for preview
   const htmlContent = useMemo(() => renderMarkdown(content), [content])
-  const colorMode: MermaidColorMode = mounted && theme === 'dark' ? 'dark' : 'light'
+  const colorMode: MermaidColorMode = mounted && resolvedTheme === 'dark' ? 'dark' : 'light'
 
   // Formatting functions
   const handleFormatBold = useCallback((): void => {
@@ -321,109 +322,11 @@ export function PoeEditor({ onReady }: PoeEditorProps): ReactElement {
   }, [documentName, content, toast])
 
   const handleDownloadHTML = useCallback((): void => {
-    const hasMermaid = htmlContent.includes('language-mermaid')
-    const mermaidInitScript = getMermaidInitScript(colorMode)
-    const mermaidScripts = hasMermaid
-      ? `\n  <script src="https://cdn.jsdelivr.net/npm/mermaid@11.12.2/dist/mermaid.min.js"></script>\n  <script>${mermaidInitScript}</script>`
-      : ''
-    const codeBlockStyles = `
-    .markdown-body .code-block-with-language {
-      margin: 1rem 0;
-      overflow: hidden;
-      border: 1px solid var(--borderColor-muted);
-      border-radius: 12px;
-      background: var(--bgColor-muted);
-    }
-    .markdown-body {
-      --code-syntax-keyword: #a626a4;
-      --code-syntax-string: #50a14f;
-      --code-syntax-variable: #986801;
-      --code-syntax-number: #986801;
-      --code-syntax-entity: #005cc5;
-      --code-syntax-comment: #6a737d;
-    }
-    @media (prefers-color-scheme: dark) {
-      .markdown-body {
-        --code-syntax-keyword: var(--color-prettylights-syntax-keyword);
-        --code-syntax-string: var(--color-prettylights-syntax-string);
-        --code-syntax-variable: var(--color-prettylights-syntax-variable);
-        --code-syntax-number: var(--color-prettylights-syntax-variable);
-        --code-syntax-entity: var(--color-prettylights-syntax-entity);
-        --code-syntax-comment: var(--color-prettylights-syntax-comment);
-      }
-    }
-    .markdown-body .code-block-language-hint {
-      display: flex;
-      align-items: center;
-      min-height: 2rem;
-      padding: 0.35rem 0.8rem;
-      border-bottom: 1px solid var(--borderColor-muted);
-      color: var(--fgColor-muted);
-      font-family: 'JetBrains Mono', 'SFMono-Regular', Menlo, Consolas, monospace;
-      font-size: 0.72rem;
-      font-weight: 600;
-      letter-spacing: 0.03em;
-    }
-    .markdown-body .code-block-with-language pre {
-      margin: 0;
-      border: 0;
-      border-radius: 0;
-      background: transparent !important;
-    }
-    .markdown-body .code-block-with-language pre code.hljs {
-      display: block;
-      padding: 0;
-      background: transparent;
-    }
-    .markdown-body .hljs {
-      color: var(--fgColor-default);
-    }
-    .markdown-body .hljs-keyword,
-    .markdown-body .hljs-selector-tag,
-    .markdown-body .hljs-literal,
-    .markdown-body .hljs-doctag,
-    .markdown-body .hljs-operator {
-      color: var(--code-syntax-keyword);
-    }
-    .markdown-body .hljs-string,
-    .markdown-body .hljs-meta .hljs-string,
-    .markdown-body .hljs-attribute,
-    .markdown-body .hljs-regexp {
-      color: var(--code-syntax-string);
-    }
-    .markdown-body .hljs-number,
-    .markdown-body .hljs-symbol,
-    .markdown-body .hljs-variable,
-    .markdown-body .hljs-template-variable {
-      color: var(--code-syntax-number);
-    }
-    .markdown-body .hljs-title,
-    .markdown-body .hljs-title.class_,
-    .markdown-body .hljs-title.function_ {
-      color: var(--code-syntax-entity);
-    }
-    .markdown-body .hljs-comment,
-    .markdown-body .hljs-quote {
-      color: var(--code-syntax-comment);
-    }`
-
-    const htmlDoc = `<!DOCTYPE html>
-<html lang="en">
-<head>
-  <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>${documentName}</title>
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/github-markdown-css@5/github-markdown.min.css">${mermaidScripts}
-  <style>
-    .markdown-body { box-sizing: border-box; min-width: 200px; max-width: 980px; margin: 0 auto; padding: 45px; }
-    @media (max-width: 767px) { .markdown-body { padding: 15px; } }
-${codeBlockStyles}
-  </style>
-</head>
-<body class="markdown-body">
-${htmlContent}
-</body>
-</html>`
+    const htmlDoc = buildHtmlExportDocument({
+      documentName,
+      htmlContent,
+      colorMode,
+    })
     const htmlFileName = documentName.replace(/\.md$/, '.html')
     downloadFile(htmlFileName, htmlDoc, 'text/html')
     toast({ description: 'Downloaded as HTML' })

--- a/packages/app/src/utils/htmlExport.test.ts
+++ b/packages/app/src/utils/htmlExport.test.ts
@@ -49,5 +49,7 @@ describe('htmlExport', () => {
     expect(withoutMermaid).not.toContain('mermaid.min.js')
     expect(withMermaid).toContain('mermaid.min.js')
     expect(withMermaid).toContain('"primaryBorderColor":"#4493f8"')
+    expect(withMermaid).toContain('.code-block-with-language[data-language="mermaid"]')
+    expect(withMermaid).toContain('display: none;')
   })
 })

--- a/packages/app/src/utils/htmlExport.test.ts
+++ b/packages/app/src/utils/htmlExport.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest'
+import { buildHtmlExportDocument } from '@/utils/htmlExport'
+
+describe('htmlExport', () => {
+  it('uses light markdown stylesheet for light mode exports', () => {
+    const result = buildHtmlExportDocument({
+      documentName: 'light.md',
+      htmlContent: '<h1>Light</h1>',
+      colorMode: 'light',
+    })
+
+    expect(result).toContain('github-markdown-light.min.css')
+    expect(result).toContain('<meta name="color-scheme" content="light">')
+    expect(result).toContain('--code-syntax-keyword: #a626a4;')
+    expect(result).not.toContain('github-markdown-dark.min.css')
+  })
+
+  it('uses dark markdown stylesheet for dark mode exports', () => {
+    const result = buildHtmlExportDocument({
+      documentName: 'dark.md',
+      htmlContent: '<h1>Dark</h1>',
+      colorMode: 'dark',
+    })
+
+    expect(result).toContain('github-markdown-dark.min.css')
+    expect(result).toContain('<meta name="color-scheme" content="dark">')
+    expect(result).toContain('--code-syntax-keyword: var(--color-prettylights-syntax-keyword);')
+    expect(result).toContain('background-color: #0d1117;')
+    expect(result).not.toContain('github-markdown-light.min.css')
+  })
+
+  it('includes mermaid scripts only when rendered mermaid code exists', () => {
+    const withoutMermaid = buildHtmlExportDocument({
+      documentName: 'plain.md',
+      htmlContent: '<p>Plain text</p>',
+      colorMode: 'dark',
+    })
+
+    const withMermaid = buildHtmlExportDocument({
+      documentName: 'diagram.md',
+      htmlContent: '<pre><code class="hljs language-mermaid">graph TD;A-->B</code></pre>',
+      colorMode: 'dark',
+    })
+
+    expect(withoutMermaid).not.toContain('mermaid.min.js')
+    expect(withMermaid).toContain('mermaid.min.js')
+    expect(withMermaid).toContain('"primaryBorderColor":"#4493f8"')
+  })
+})

--- a/packages/app/src/utils/htmlExport.test.ts
+++ b/packages/app/src/utils/htmlExport.test.ts
@@ -11,6 +11,8 @@ describe('htmlExport', () => {
 
     expect(result).toContain('github-markdown-light.min.css')
     expect(result).toContain('<meta name="color-scheme" content="light">')
+    expect(result).toContain('--code-block-background: #f0efeb;')
+    expect(result).toContain('--code-block-border: #c8b28f;')
     expect(result).toContain('--code-syntax-keyword: #a626a4;')
     expect(result).not.toContain('github-markdown-dark.min.css')
   })
@@ -24,6 +26,8 @@ describe('htmlExport', () => {
 
     expect(result).toContain('github-markdown-dark.min.css')
     expect(result).toContain('<meta name="color-scheme" content="dark">')
+    expect(result).toContain('--code-block-background: #151b23;')
+    expect(result).toContain('--code-block-border: #3d444db3;')
     expect(result).toContain('--code-syntax-keyword: var(--color-prettylights-syntax-keyword);')
     expect(result).toContain('background-color: #0d1117;')
     expect(result).not.toContain('github-markdown-light.min.css')

--- a/packages/app/src/utils/htmlExport.ts
+++ b/packages/app/src/utils/htmlExport.ts
@@ -6,6 +6,26 @@ interface BuildHtmlExportDocumentParams {
   colorMode: MermaidColorMode
 }
 
+function getCodeBlockVariables(colorMode: MermaidColorMode): string {
+  if (colorMode === 'dark') {
+    return `
+      --code-block-border: #3d444db3;
+      --code-block-background: #151b23;
+      --code-block-header-border: #3d444db3;
+      --code-block-header-background: #0d1117;
+      --code-block-header-color: #9198a1;
+      --code-block-foreground: #f0f6fc;`
+  }
+
+  return `
+      --code-block-border: #c8b28f;
+      --code-block-background: #f0efeb;
+      --code-block-header-border: #dbcdb6;
+      --code-block-header-background: #faf9f7;
+      --code-block-header-color: #6f5738;
+      --code-block-foreground: #2a2a2a;`
+}
+
 function getCodeSyntaxVariables(colorMode: MermaidColorMode): string {
   if (colorMode === 'dark') {
     return `
@@ -42,6 +62,7 @@ export function buildHtmlExportDocument({
     colorMode === 'dark'
       ? 'background-color: #0d1117; color: #f0f6fc;'
       : 'background-color: #ffffff; color: #24292f;'
+  const codeBlockVariables = getCodeBlockVariables(colorMode)
   const codeSyntaxVariables = getCodeSyntaxVariables(colorMode)
 
   const mermaidScripts = hasMermaid
@@ -68,6 +89,7 @@ export function buildHtmlExportDocument({
       margin: 0 auto;
       padding: 45px;
       color-scheme: ${colorMode};
+${codeBlockVariables}
 ${codeSyntaxVariables}
     }
     @media (max-width: 767px) {
@@ -75,20 +97,28 @@ ${codeSyntaxVariables}
         padding: 15px;
       }
     }
+    .markdown-body pre {
+      margin: 1rem 0;
+      overflow: hidden;
+      border: 1px solid var(--code-block-border);
+      border-radius: 12px;
+      background: var(--code-block-background);
+    }
     .markdown-body .code-block-with-language {
       margin: 1rem 0;
       overflow: hidden;
-      border: 1px solid var(--borderColor-muted);
+      border: 1px solid var(--code-block-border);
       border-radius: 12px;
-      background: var(--bgColor-muted);
+      background: var(--code-block-background);
     }
     .markdown-body .code-block-language-hint {
       display: flex;
       align-items: center;
       min-height: 2rem;
       padding: 0.35rem 0.8rem;
-      border-bottom: 1px solid var(--borderColor-muted);
-      color: var(--fgColor-muted);
+      border-bottom: 1px solid var(--code-block-header-border);
+      color: var(--code-block-header-color);
+      background: var(--code-block-header-background);
       font-family: 'JetBrains Mono', 'SFMono-Regular', Menlo, Consolas, monospace;
       font-size: 0.72rem;
       font-weight: 600;
@@ -106,7 +136,7 @@ ${codeSyntaxVariables}
       background: transparent;
     }
     .markdown-body .hljs {
-      color: var(--fgColor-default);
+      color: var(--code-block-foreground);
     }
     .markdown-body .hljs-keyword,
     .markdown-body .hljs-selector-tag,

--- a/packages/app/src/utils/htmlExport.ts
+++ b/packages/app/src/utils/htmlExport.ts
@@ -130,6 +130,14 @@ ${codeSyntaxVariables}
       border-radius: 0;
       background: transparent !important;
     }
+    .markdown-body .code-block-with-language[data-language="mermaid"] {
+      border: 0;
+      border-radius: 0;
+      background: transparent;
+    }
+    .markdown-body .code-block-with-language[data-language="mermaid"] .code-block-language-hint {
+      display: none;
+    }
     .markdown-body .code-block-with-language pre code.hljs {
       display: block;
       padding: 0;

--- a/packages/app/src/utils/htmlExport.ts
+++ b/packages/app/src/utils/htmlExport.ts
@@ -1,0 +1,145 @@
+import { getMermaidInitScript, type MermaidColorMode } from '@/utils/mermaidTheme'
+
+interface BuildHtmlExportDocumentParams {
+  documentName: string
+  htmlContent: string
+  colorMode: MermaidColorMode
+}
+
+function getCodeSyntaxVariables(colorMode: MermaidColorMode): string {
+  if (colorMode === 'dark') {
+    return `
+      --code-syntax-keyword: var(--color-prettylights-syntax-keyword);
+      --code-syntax-string: var(--color-prettylights-syntax-string);
+      --code-syntax-variable: var(--color-prettylights-syntax-variable);
+      --code-syntax-number: var(--color-prettylights-syntax-variable);
+      --code-syntax-entity: var(--color-prettylights-syntax-entity);
+      --code-syntax-comment: var(--color-prettylights-syntax-comment);`
+  }
+
+  return `
+      --code-syntax-keyword: #a626a4;
+      --code-syntax-string: #50a14f;
+      --code-syntax-variable: #986801;
+      --code-syntax-number: #986801;
+      --code-syntax-entity: #005cc5;
+      --code-syntax-comment: #6a737d;`
+}
+
+/**
+ * Builds a complete HTML export document for rendered markdown content.
+ * @param params - HTML export options
+ * @returns A full HTML document string ready for file download
+ */
+export function buildHtmlExportDocument({
+  documentName,
+  htmlContent,
+  colorMode,
+}: BuildHtmlExportDocumentParams): string {
+  const hasMermaid = htmlContent.includes('language-mermaid')
+  const markdownStylesheet = `https://cdn.jsdelivr.net/npm/github-markdown-css@5/github-markdown-${colorMode}.min.css`
+  const bodyColors =
+    colorMode === 'dark'
+      ? 'background-color: #0d1117; color: #f0f6fc;'
+      : 'background-color: #ffffff; color: #24292f;'
+  const codeSyntaxVariables = getCodeSyntaxVariables(colorMode)
+
+  const mermaidScripts = hasMermaid
+    ? `\n  <script src="https://cdn.jsdelivr.net/npm/mermaid@11.12.2/dist/mermaid.min.js"></script>\n  <script>${getMermaidInitScript(colorMode)}</script>`
+    : ''
+
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="color-scheme" content="${colorMode}">
+  <title>${documentName}</title>
+  <link rel="stylesheet" href="${markdownStylesheet}">${mermaidScripts}
+  <style>
+    body {
+      margin: 0;
+      ${bodyColors}
+    }
+    .markdown-body {
+      box-sizing: border-box;
+      min-width: 200px;
+      max-width: 980px;
+      margin: 0 auto;
+      padding: 45px;
+      color-scheme: ${colorMode};
+${codeSyntaxVariables}
+    }
+    @media (max-width: 767px) {
+      .markdown-body {
+        padding: 15px;
+      }
+    }
+    .markdown-body .code-block-with-language {
+      margin: 1rem 0;
+      overflow: hidden;
+      border: 1px solid var(--borderColor-muted);
+      border-radius: 12px;
+      background: var(--bgColor-muted);
+    }
+    .markdown-body .code-block-language-hint {
+      display: flex;
+      align-items: center;
+      min-height: 2rem;
+      padding: 0.35rem 0.8rem;
+      border-bottom: 1px solid var(--borderColor-muted);
+      color: var(--fgColor-muted);
+      font-family: 'JetBrains Mono', 'SFMono-Regular', Menlo, Consolas, monospace;
+      font-size: 0.72rem;
+      font-weight: 600;
+      letter-spacing: 0.03em;
+    }
+    .markdown-body .code-block-with-language pre {
+      margin: 0;
+      border: 0;
+      border-radius: 0;
+      background: transparent !important;
+    }
+    .markdown-body .code-block-with-language pre code.hljs {
+      display: block;
+      padding: 0;
+      background: transparent;
+    }
+    .markdown-body .hljs {
+      color: var(--fgColor-default);
+    }
+    .markdown-body .hljs-keyword,
+    .markdown-body .hljs-selector-tag,
+    .markdown-body .hljs-literal,
+    .markdown-body .hljs-doctag,
+    .markdown-body .hljs-operator {
+      color: var(--code-syntax-keyword);
+    }
+    .markdown-body .hljs-string,
+    .markdown-body .hljs-meta .hljs-string,
+    .markdown-body .hljs-attribute,
+    .markdown-body .hljs-regexp {
+      color: var(--code-syntax-string);
+    }
+    .markdown-body .hljs-number,
+    .markdown-body .hljs-symbol,
+    .markdown-body .hljs-variable,
+    .markdown-body .hljs-template-variable {
+      color: var(--code-syntax-number);
+    }
+    .markdown-body .hljs-title,
+    .markdown-body .hljs-title.class_,
+    .markdown-body .hljs-title.function_ {
+      color: var(--code-syntax-entity);
+    }
+    .markdown-body .hljs-comment,
+    .markdown-body .hljs-quote {
+      color: var(--code-syntax-comment);
+    }
+  </style>
+</head>
+<body class="markdown-body">
+${htmlContent}
+</body>
+</html>`
+}


### PR DESCRIPTION
Extracts HTML export logic into a dedicated utility module with theme-aware styling. Exported HTML now uses the active app theme (light or dark) at download time, and light-mode exports render fenced code blocks with sepia borders and backgrounds for improved contrast.

- Refactored HTML export document generation into `buildHtmlExportDocument()` utility function.
- Added theme-specific CSS variables for code block borders, backgrounds, and syntax highlighting.
- Light mode exports now use sepia-toned code block styling (`#f0efeb` background, `#c8b28f` border).
- Dark mode exports use GitHub dark theme tokens with proper contrast ratios.
- Integrated Mermaid theme detection to match exported HTML colour scheme.
- Added comprehensive unit tests covering light/dark mode exports and Mermaid detection.
- Updated `PoeEditor` to use `resolvedTheme` from `useTheme()` hook for accurate theme detection.
- Added `MD_TEST.md` file with comprehensive Markdown rendering test suite for manual verification.
- Updated `FEATURES.md` documentation to reflect new theme-aware export capabilities.
