### PR TITLE
feat(editor): Add editor auto-focus and enhance vim visual mode support

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -43,14 +43,14 @@ Poe includes standard Markdown editor functionality and a set of unique features
 
 ### Editing and Input
 
-| Feature                                 | Notes                                                                                                                                                                                                               |
-| --------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Editor auto-focus on load               | When the editor pane is visible at startup, Monaco receives focus automatically so typing can begin immediately.                                                                                                    |
-| Enhanced Vim mode (Monaco)              | Includes wrapped-line motions, custom bracket/quote/fence matching, and `%` jumps between opening and closing sets.                                                                                                 |
-| Browser-aware Vim clipboard behavior    | Vim yank writes to system clipboard + register; visual-mode yank restores cursor to selection start; visual-char mode renders cursor at Vim head position; `p/P` stays register-based (due to browser limitations). |
-| Vim spell and wrap options              | Supports Vim `:set spell` sync and `:set wrap`/`:set nowrap` behavior.                                                                                                                                              |
-| Spell check with dictionary integration | Monaco spellcheck uses `typo-js` dictionary data.                                                                                                                                                                   |
-| Auto-continue lists and blockquotes     | Enter key continues or exits list/quote prefixes intelligently.                                                                                                                                                     |
+| Feature                                 | Notes                                                                                                                                                                                                                                   |
+| --------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Editor auto-focus on load               | When the editor pane is visible at startup, Monaco receives focus automatically so typing can begin immediately.                                                                                                                        |
+| Enhanced Vim mode (Monaco)              | Includes wrapped-line motions, custom bracket/quote/fence matching, `%` jumps between opening and closing sets, and reliable `H/M/L` high-middle-low cursor jumps (document-relative when file fits view, viewport-relative otherwise). |
+| Browser-aware Vim clipboard behavior    | Vim yank writes to system clipboard + register; visual-mode yank restores cursor to selection start; visual-char mode renders cursor at Vim head position; `p/P` stays register-based (due to browser limitations).                     |
+| Vim spell and wrap options              | Supports Vim `:set spell` sync and `:set wrap`/`:set nowrap` behavior.                                                                                                                                                                  |
+| Spell check with dictionary integration | Monaco spellcheck uses `typo-js` dictionary data.                                                                                                                                                                                       |
+| Auto-continue lists and blockquotes     | Enter key continues or exits list/quote prefixes intelligently.                                                                                                                                                                         |
 
 ### Markdown Table
 

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -45,6 +45,7 @@ Poe includes standard Markdown editor functionality and a set of unique features
 
 | Feature                                 | Notes                                                                                                               |
 | --------------------------------------- | ------------------------------------------------------------------------------------------------------------------- |
+| Editor auto-focus on load               | When the editor pane is visible at startup, Monaco receives focus automatically so typing can begin immediately.    |
 | Enhanced Vim mode (Monaco)              | Includes wrapped-line motions, custom bracket/quote/fence matching, and `%` jumps between opening and closing sets. |
 | Browser-aware Vim clipboard behavior    | Vim yank writes to system clipboard + register; `p/P` stays register-based (due to browser limitations).            |
 | Vim spell and wrap options              | Supports Vim `:set spell` sync and `:set wrap`/`:set nowrap` behavior.                                              |

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -43,14 +43,14 @@ Poe includes standard Markdown editor functionality and a set of unique features
 
 ### Editing and Input
 
-| Feature                                 | Notes                                                                                                               |
-| --------------------------------------- | ------------------------------------------------------------------------------------------------------------------- |
-| Editor auto-focus on load               | When the editor pane is visible at startup, Monaco receives focus automatically so typing can begin immediately.    |
-| Enhanced Vim mode (Monaco)              | Includes wrapped-line motions, custom bracket/quote/fence matching, and `%` jumps between opening and closing sets. |
-| Browser-aware Vim clipboard behavior    | Vim yank writes to system clipboard + register; `p/P` stays register-based (due to browser limitations).            |
-| Vim spell and wrap options              | Supports Vim `:set spell` sync and `:set wrap`/`:set nowrap` behavior.                                              |
-| Spell check with dictionary integration | Monaco spellcheck uses `typo-js` dictionary data.                                                                   |
-| Auto-continue lists and blockquotes     | Enter key continues or exits list/quote prefixes intelligently.                                                     |
+| Feature                                 | Notes                                                                                                                                                                                                               |
+| --------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Editor auto-focus on load               | When the editor pane is visible at startup, Monaco receives focus automatically so typing can begin immediately.                                                                                                    |
+| Enhanced Vim mode (Monaco)              | Includes wrapped-line motions, custom bracket/quote/fence matching, and `%` jumps between opening and closing sets.                                                                                                 |
+| Browser-aware Vim clipboard behavior    | Vim yank writes to system clipboard + register; visual-mode yank restores cursor to selection start; visual-char mode renders cursor at Vim head position; `p/P` stays register-based (due to browser limitations). |
+| Vim spell and wrap options              | Supports Vim `:set spell` sync and `:set wrap`/`:set nowrap` behavior.                                                                                                                                              |
+| Spell check with dictionary integration | Monaco spellcheck uses `typo-js` dictionary data.                                                                                                                                                                   |
+| Auto-continue lists and blockquotes     | Enter key continues or exits list/quote prefixes intelligently.                                                                                                                                                     |
 
 ### Markdown Table
 

--- a/packages/app/src/components/editor/EditorPane.test.tsx
+++ b/packages/app/src/components/editor/EditorPane.test.tsx
@@ -6,6 +6,13 @@ import { copyToClipboard } from '@/utils/clipboard'
 import { toast } from '@/hooks/useToast'
 import { initVimMode } from 'monaco-vim'
 
+const mockEditorFocus = vi.fn()
+const mockCreateContextKey = vi.fn().mockReturnValue({
+  set: vi.fn(),
+  get: vi.fn(),
+  reset: vi.fn(),
+})
+
 // Mock the utilities and toast hook
 vi.mock('@/utils/clipboard', () => ({
   copyToClipboard: vi.fn(),
@@ -57,12 +64,8 @@ vi.mock('@monaco-editor/react', () => {
             getPosition: vi.fn(),
             executeEdits: vi.fn(),
             setPosition: vi.fn(),
-            focus: vi.fn(),
-            createContextKey: vi.fn().mockReturnValue({
-              set: vi.fn(),
-              get: vi.fn(),
-              reset: vi.fn(),
-            }),
+            focus: mockEditorFocus,
+            createContextKey: mockCreateContextKey,
             getModel: vi.fn(),
             onDidChangeModelContent: vi.fn(),
           },
@@ -92,6 +95,8 @@ describe('EditorPane', () => {
 
   beforeEach(() => {
     vi.clearAllMocks()
+    mockCreateContextKey.mockClear()
+    mockEditorFocus.mockClear()
   })
 
   it('renders progress and editor', () => {
@@ -133,5 +138,22 @@ describe('EditorPane', () => {
     await waitFor(() => {
       expect(initVimMode).toHaveBeenCalled()
     })
+  })
+
+  it('focuses editor on mount when pane is visible', async () => {
+    render(<EditorPane value={value} onChange={() => {}} viewMode="editor" />)
+
+    await waitFor(() => {
+      expect(mockEditorFocus).toHaveBeenCalled()
+    })
+  })
+
+  it('does not focus editor on mount when pane is preview-only', async () => {
+    render(<EditorPane value={value} onChange={() => {}} viewMode="preview" />)
+
+    await waitFor(() => {
+      expect(mockCreateContextKey).toHaveBeenCalled()
+    })
+    expect(mockEditorFocus).not.toHaveBeenCalled()
   })
 })

--- a/packages/app/src/components/editor/EditorPane.test.tsx
+++ b/packages/app/src/components/editor/EditorPane.test.tsx
@@ -12,6 +12,7 @@ const mockCreateContextKey = vi.fn().mockReturnValue({
   get: vi.fn(),
   reset: vi.fn(),
 })
+let monacoMountDelayMs = 0
 
 // Mock the utilities and toast hook
 vi.mock('@/utils/clipboard', () => ({
@@ -50,33 +51,37 @@ vi.mock('@monaco-editor/react', () => {
       onMount: (editor: unknown, monaco: unknown) => void
     }) {
       useEffect(() => {
-        // Simulate mount asynchronously to avoid React state updates during render
-        onMount(
-          {
-            getDomNode: () => document.createElement('div'),
-            getScrollTop: () => 0,
-            getScrollHeight: () => 100,
-            getLayoutInfo: () => ({ height: 500 }),
-            onDidScrollChange: vi.fn(),
-            onDidChangeCursorPosition: vi.fn(),
-            addCommand: vi.fn(),
-            onKeyDown: vi.fn(),
-            getPosition: vi.fn(),
-            executeEdits: vi.fn(),
-            setPosition: vi.fn(),
-            focus: mockEditorFocus,
-            createContextKey: mockCreateContextKey,
-            getModel: vi.fn(),
-            onDidChangeModelContent: vi.fn(),
-          },
-          {
-            KeyMod: { CtrlCmd: 2048, Shift: 1024 },
-            KeyCode: { KeyB: 32, KeyI: 39, KeyK: 41, KeyE: 35, Enter: 13 },
-            editor: {
-              setModelMarkers: vi.fn(),
+        // Simulate mount asynchronously to avoid React state updates during render.
+        // Delay is configurable per test to reproduce reload timing edge cases.
+        const timeout = setTimeout(() => {
+          onMount(
+            {
+              getDomNode: () => document.createElement('div'),
+              getScrollTop: () => 0,
+              getScrollHeight: () => 100,
+              getLayoutInfo: () => ({ height: 500 }),
+              onDidScrollChange: vi.fn(),
+              onDidChangeCursorPosition: vi.fn(),
+              addCommand: vi.fn(),
+              onKeyDown: vi.fn(),
+              getPosition: vi.fn(),
+              executeEdits: vi.fn(),
+              setPosition: vi.fn(),
+              focus: mockEditorFocus,
+              createContextKey: mockCreateContextKey,
+              getModel: vi.fn(),
+              onDidChangeModelContent: vi.fn(),
             },
-          }
-        )
+            {
+              KeyMod: { CtrlCmd: 2048, Shift: 1024 },
+              KeyCode: { KeyB: 32, KeyI: 39, KeyK: 41, KeyE: 35, Enter: 13 },
+              editor: {
+                setModelMarkers: vi.fn(),
+              },
+            }
+          )
+        }, monacoMountDelayMs)
+        return () => clearTimeout(timeout)
         // eslint-disable-next-line react-hooks/exhaustive-deps
       }, [])
       return <div data-testid="monaco-editor" />
@@ -97,6 +102,7 @@ describe('EditorPane', () => {
     vi.clearAllMocks()
     mockCreateContextKey.mockClear()
     mockEditorFocus.mockClear()
+    monacoMountDelayMs = 0
   })
 
   it('renders progress and editor', () => {
@@ -135,6 +141,15 @@ describe('EditorPane', () => {
     render(<EditorPane value={value} onChange={() => {}} vimMode={true} />)
 
     // Wait for the useEffect timeout
+    await waitFor(() => {
+      expect(initVimMode).toHaveBeenCalled()
+    })
+  })
+
+  it('initializes vim mode after delayed editor mount (reload timing)', async () => {
+    monacoMountDelayMs = 25
+    render(<EditorPane value={value} onChange={() => {}} vimMode={true} />)
+
     await waitFor(() => {
       expect(initVimMode).toHaveBeenCalled()
     })

--- a/packages/app/src/components/editor/EditorPane.tsx
+++ b/packages/app/src/components/editor/EditorPane.tsx
@@ -2,7 +2,7 @@ import { useRef, forwardRef, useState } from 'react'
 import Editor, { type OnMount } from '@monaco-editor/react'
 import type { editor } from 'monaco-editor'
 import * as monaco from 'monaco-editor'
-import { initVimMode, type VimMode as VimAdapter } from 'monaco-vim'
+import type { VimMode as VimAdapter } from 'monaco-vim'
 import { Copy, Check, Maximize2, Minimize2 } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
@@ -11,7 +11,6 @@ import { copyToClipboard } from '@/utils/clipboard'
 import { getAutoContinueEdit } from '@/utils/formatting'
 import { cn } from '@/utils/classnames'
 
-import { setupVim } from './vim'
 import { getTableAtCursor } from './table'
 import { registerEditorKeybindings } from './hooks/useEditorKeybindings'
 import { useEditorVim } from './hooks/useEditorVim'
@@ -148,12 +147,6 @@ export const EditorPane = forwardRef<EditorPaneHandle, EditorPaneProps>(
         resolve(disposable)
       }
       pendingScrollCallbacks.current = []
-
-      // Initialize vim mode immediately after editor mounts if vimMode is enabled
-      if (vimMode) {
-        setupVim()
-        vimInstanceRef.current = initVimMode(editor, statusBarRef.current)
-      }
 
       // Initialize context key for table detection
       const isInTableContext = editor.createContextKey<boolean>('isInTable', false)

--- a/packages/app/src/components/editor/EditorPane.tsx
+++ b/packages/app/src/components/editor/EditorPane.tsx
@@ -201,7 +201,7 @@ export const EditorPane = forwardRef<EditorPaneHandle, EditorPaneProps>(
       })
     }
 
-    useEditorVim({ editorRef, vimInstanceRef, statusBarRef, vimMode })
+    useEditorVim({ editorInstance, editorRef, vimInstanceRef, statusBarRef, vimMode })
     useEditorSpellCheck({
       editorRef,
       monacoRef,

--- a/packages/app/src/components/editor/EditorPane.tsx
+++ b/packages/app/src/components/editor/EditorPane.tsx
@@ -137,6 +137,11 @@ export const EditorPane = forwardRef<EditorPaneHandle, EditorPaneProps>(
       setEditorInstance(editor)
       monacoRef.current = monacoInstance
 
+      // Focus on initial mount whenever the editor pane is visible.
+      if (viewMode !== 'preview') {
+        editor.focus()
+      }
+
       // Drain any scroll callbacks that were queued before Monaco mounted
       for (const { callback, resolve } of pendingScrollCallbacks.current) {
         const disposable = editor.onDidScrollChange(() => callback())

--- a/packages/app/src/components/editor/hooks/useEditorVim.ts
+++ b/packages/app/src/components/editor/hooks/useEditorVim.ts
@@ -151,6 +151,7 @@ const attachVisualCursorSync = (
 }
 
 interface UseEditorVimParams {
+  editorInstance: editor.IStandaloneCodeEditor | null
   editorRef: React.RefObject<editor.IStandaloneCodeEditor | null>
   vimInstanceRef: React.MutableRefObject<VimAdapter | null>
   statusBarRef: React.RefObject<HTMLDivElement | null>
@@ -165,6 +166,7 @@ interface UseEditorVimParams {
  * @returns void
  */
 export function useEditorVim({
+  editorInstance,
   editorRef,
   vimInstanceRef,
   statusBarRef,
@@ -186,7 +188,7 @@ export function useEditorVim({
       return
     }
 
-    const ed = editorRef.current
+    const ed = editorInstance ?? editorRef.current
     const statusBar = statusBarRef.current
 
     if (!ed || !statusBar) {
@@ -208,15 +210,18 @@ export function useEditorVim({
     }
 
     const timer = setTimeout(() => {
-      if (editorRef.current && statusBarRef.current && !vimInstanceRef.current) {
+      const currentEditor = editorInstance ?? editorRef.current
+      const currentStatusBar = statusBarRef.current
+
+      if (currentEditor && currentStatusBar && !vimInstanceRef.current) {
         try {
           setupVim()
-          vimInstanceRef.current = initVimMode(editorRef.current, statusBarRef.current)
+          vimInstanceRef.current = initVimMode(currentEditor, currentStatusBar)
           visualCursorCleanupRef.current = attachVisualCursorSync(
-            editorRef.current,
+            currentEditor,
             vimInstanceRef.current
           )
-          visualCursorEditorRef.current = editorRef.current
+          visualCursorEditorRef.current = currentEditor
         } catch {
           toast({
             description: 'Error initializing vim mode',
@@ -229,7 +234,7 @@ export function useEditorVim({
     return () => {
       clearTimeout(timer)
     }
-  }, [vimMode, editorRef, vimInstanceRef, statusBarRef])
+  }, [vimMode, editorInstance, editorRef, vimInstanceRef, statusBarRef])
 
   useEffect(
     () => () => {

--- a/packages/app/src/components/editor/hooks/useEditorVim.ts
+++ b/packages/app/src/components/editor/hooks/useEditorVim.ts
@@ -1,7 +1,154 @@
-import { useEffect } from 'react'
+import { useEffect, useRef } from 'react'
 import type { editor } from 'monaco-editor'
 import { initVimMode, type VimMode as VimAdapter } from 'monaco-vim'
 import { toast } from '@/hooks/useToast'
+import { setupVim } from '../vim'
+
+const VISUAL_CURSOR_CLASS = 'vim-visual-head-cursor'
+const VISUAL_CURSOR_ACTIVE_CLASS = 'vim-visual-char-active'
+
+interface VimCursor {
+  line: number
+  ch: number
+}
+
+interface VimModeChangeEvent {
+  mode: string
+  subMode?: string
+}
+
+interface VimStateWithSelection {
+  state?: {
+    vim?: {
+      sel?: {
+        head?: VimCursor
+      }
+    }
+  }
+}
+
+const isObject = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null
+
+const isVimCursor = (value: unknown): value is VimCursor => {
+  if (!isObject(value)) {
+    return false
+  }
+  return typeof value.line === 'number' && typeof value.ch === 'number'
+}
+
+const isVimModeChangeEvent = (value: unknown): value is VimModeChangeEvent => {
+  if (!isObject(value)) {
+    return false
+  }
+  if (typeof value.mode !== 'string') {
+    return false
+  }
+  if (typeof value.subMode !== 'undefined' && typeof value.subMode !== 'string') {
+    return false
+  }
+  return true
+}
+
+const getVisualHead = (vim: VimAdapter): VimCursor | null => {
+  const maybeState = vim as unknown as VimStateWithSelection
+  const head = maybeState.state?.vim?.sel?.head
+  return isVimCursor(head) ? head : null
+}
+
+const attachVisualCursorSync = (
+  editor: editor.IStandaloneCodeEditor,
+  vim: VimAdapter
+): (() => void) => {
+  let decorationIds: string[] = []
+  let isVisualCharMode = false
+  const domNode = editor.getDomNode()
+
+  const clearDecoration = (): void => {
+    if (decorationIds.length > 0) {
+      decorationIds = editor.deltaDecorations(decorationIds, [])
+    }
+    domNode?.classList.remove(VISUAL_CURSOR_ACTIVE_CLASS)
+  }
+
+  const applyDecoration = (): void => {
+    if (!isVisualCharMode) {
+      clearDecoration()
+      return
+    }
+
+    const model = editor.getModel()
+    const head = getVisualHead(vim)
+    if (!model || !head) {
+      clearDecoration()
+      return
+    }
+
+    const lineNumber = head.line + 1
+    if (lineNumber < 1 || lineNumber > model.getLineCount()) {
+      clearDecoration()
+      return
+    }
+
+    const maxColumn = model.getLineMaxColumn(lineNumber)
+    // Empty lines cannot receive an inline one-character decoration.
+    if (maxColumn <= 1) {
+      clearDecoration()
+      return
+    }
+
+    const startColumn = Math.min(Math.max(1, head.ch + 1), maxColumn - 1)
+    const endColumn = startColumn + 1
+
+    decorationIds = editor.deltaDecorations(decorationIds, [
+      {
+        range: {
+          startLineNumber: lineNumber,
+          startColumn,
+          endLineNumber: lineNumber,
+          endColumn,
+        },
+        options: {
+          inlineClassName: VISUAL_CURSOR_CLASS,
+        },
+      },
+    ])
+
+    domNode?.classList.add(VISUAL_CURSOR_ACTIVE_CLASS)
+  }
+
+  const onModeChange = (event: unknown): void => {
+    if (!isVimModeChangeEvent(event)) {
+      isVisualCharMode = false
+      clearDecoration()
+      return
+    }
+
+    isVisualCharMode = event.mode === 'visual' && !event.subMode
+    applyDecoration()
+  }
+
+  vim.on('vim-mode-change', onModeChange)
+
+  const cursorSelectionDisposable = editor.onDidChangeCursorSelection(() => {
+    if (isVisualCharMode) {
+      applyDecoration()
+    }
+  })
+
+  const modelChangeDisposable = editor.onDidChangeModel(() => {
+    if (isVisualCharMode) {
+      applyDecoration()
+    }
+  })
+
+  return () => {
+    vim.off('vim-mode-change', onModeChange)
+    cursorSelectionDisposable.dispose()
+    modelChangeDisposable.dispose()
+    clearDecoration()
+  }
+}
 
 interface UseEditorVimParams {
   editorRef: React.RefObject<editor.IStandaloneCodeEditor | null>
@@ -23,8 +170,15 @@ export function useEditorVim({
   statusBarRef,
   vimMode,
 }: UseEditorVimParams): void {
+  const visualCursorCleanupRef = useRef<(() => void) | null>(null)
+  const visualCursorEditorRef = useRef<editor.IStandaloneCodeEditor | null>(null)
+
   useEffect(() => {
     if (!vimMode) {
+      visualCursorCleanupRef.current?.()
+      visualCursorCleanupRef.current = null
+      visualCursorEditorRef.current = null
+
       if (vimInstanceRef.current) {
         vimInstanceRef.current.dispose()
         vimInstanceRef.current = null
@@ -35,14 +189,34 @@ export function useEditorVim({
     const ed = editorRef.current
     const statusBar = statusBarRef.current
 
-    if (!ed || !statusBar || vimInstanceRef.current) {
+    if (!ed || !statusBar) {
+      return
+    }
+
+    if (visualCursorEditorRef.current !== ed) {
+      visualCursorCleanupRef.current?.()
+      visualCursorCleanupRef.current = null
+      visualCursorEditorRef.current = null
+    }
+
+    if (vimInstanceRef.current) {
+      if (!visualCursorCleanupRef.current) {
+        visualCursorCleanupRef.current = attachVisualCursorSync(ed, vimInstanceRef.current)
+        visualCursorEditorRef.current = ed
+      }
       return
     }
 
     const timer = setTimeout(() => {
       if (editorRef.current && statusBarRef.current && !vimInstanceRef.current) {
         try {
+          setupVim()
           vimInstanceRef.current = initVimMode(editorRef.current, statusBarRef.current)
+          visualCursorCleanupRef.current = attachVisualCursorSync(
+            editorRef.current,
+            vimInstanceRef.current
+          )
+          visualCursorEditorRef.current = editorRef.current
         } catch {
           toast({
             description: 'Error initializing vim mode',
@@ -56,4 +230,17 @@ export function useEditorVim({
       clearTimeout(timer)
     }
   }, [vimMode, editorRef, vimInstanceRef, statusBarRef])
+
+  useEffect(
+    () => () => {
+      visualCursorCleanupRef.current?.()
+      visualCursorCleanupRef.current = null
+      visualCursorEditorRef.current = null
+      if (vimInstanceRef.current) {
+        vimInstanceRef.current.dispose()
+        vimInstanceRef.current = null
+      }
+    },
+    [vimInstanceRef]
+  )
 }

--- a/packages/app/src/components/editor/vim.ts
+++ b/packages/app/src/components/editor/vim.ts
@@ -3,6 +3,9 @@ import type { CodeMirrorAdapter, VimModeModule } from './vimTypes'
 import { createYankSystemOperator, createPasteSystemAction } from './vimClipboard'
 import {
   moveByDisplayLinesMotion,
+  moveToHighDocumentPositionMotion,
+  moveToLowDocumentPositionMotion,
+  moveToMiddleDocumentPositionMotion,
   moveToMatchingBracketMotion,
   moveToEndOfDisplayLineMotion,
 } from './vimMotions'
@@ -93,6 +96,14 @@ export function setupVim(): void {
   // Override default g^/g0 to use Monaco's native cursorHome (start of display line)
   Vim.mapCommand('g^', 'motion', 'moveToStartOfDisplayLine')
   Vim.mapCommand('g0', 'motion', 'moveToStartOfDisplayLine')
+
+  // Override H/M/L to ensure reliable high/middle/low line jumps with Monaco viewport behavior
+  Vim.defineMotion('moveToHighDocumentPosition', moveToHighDocumentPositionMotion)
+  Vim.defineMotion('moveToMiddleDocumentPosition', moveToMiddleDocumentPositionMotion)
+  Vim.defineMotion('moveToLowDocumentPosition', moveToLowDocumentPositionMotion)
+  Vim.mapCommand('H', 'motion', 'moveToHighDocumentPosition')
+  Vim.mapCommand('M', 'motion', 'moveToMiddleDocumentPosition')
+  Vim.mapCommand('L', 'motion', 'moveToLowDocumentPosition')
 
   // Register spell check option
   // We use a custom event to notify React when Vim changes this option

--- a/packages/app/src/components/editor/vimClipboard.test.ts
+++ b/packages/app/src/components/editor/vimClipboard.test.ts
@@ -31,10 +31,13 @@ const createVim = () => {
   return { vim, pushText, handleKey }
 }
 
-const createAdapter = (selection: string): CodeMirrorAdapter =>
+const createAdapter = (
+  selection: string,
+  vimState: CodeMirrorAdapter['state']['vim'] = { visualBlock: false }
+): CodeMirrorAdapter =>
   ({
     getSelection: () => selection,
-    state: { vim: { visualBlock: false } },
+    state: { vim: vimState },
     editor: {} as CodeMirrorAdapter['editor'],
   }) as CodeMirrorAdapter
 
@@ -101,6 +104,41 @@ describe('vimClipboard', () => {
 
     expect(clipboard.writeText).not.toHaveBeenCalled()
     expect(pushText).not.toHaveBeenCalled()
+  })
+
+  it('moves cursor to visual selection start after yank in visual mode', async () => {
+    const clipboard = {
+      writeText: vi.fn().mockResolvedValue(undefined),
+      readText: vi.fn(),
+    }
+    setClipboard(clipboard)
+
+    const { vim } = createVim()
+    const yank = createYankSystemOperator(vim)
+    const oldAnchor = { line: 10, ch: 4 }
+
+    const result = yank(
+      createAdapter('selected text', {
+        visualMode: true,
+        visualBlock: false,
+        sel: {
+          anchor: { line: 1, ch: 3 },
+          head: { line: 1, ch: 7 },
+        },
+      }),
+      { registerName: '"', linewise: false },
+      [
+        {
+          anchor: { line: 1, ch: 3 },
+          head: { line: 1, ch: 8 },
+        },
+      ],
+      oldAnchor
+    )
+
+    await Promise.resolve()
+
+    expect(result).toEqual({ line: 1, ch: 3 })
   })
 
   it('pastes clipboard text after or before the cursor', async () => {

--- a/packages/app/src/components/editor/vimClipboard.ts
+++ b/packages/app/src/components/editor/vimClipboard.ts
@@ -1,6 +1,67 @@
 import { toast } from '@/hooks/useToast'
 import type { VimAPI, CodeMirrorAdapter, VimOperatorArgs } from './vimTypes'
 
+interface VimCursor {
+  line: number
+  ch: number
+}
+
+interface VimRange {
+  anchor: VimCursor
+  head: VimCursor
+}
+
+const isVimCursor = (value: unknown): value is VimCursor => {
+  if (typeof value !== 'object' || value === null) {
+    return false
+  }
+  const candidate = value as Partial<VimCursor>
+  return typeof candidate.line === 'number' && typeof candidate.ch === 'number'
+}
+
+const isVimRange = (value: unknown): value is VimRange => {
+  if (typeof value !== 'object' || value === null) {
+    return false
+  }
+  const candidate = value as Partial<VimRange>
+  return isVimCursor(candidate.anchor) && isVimCursor(candidate.head)
+}
+
+const isVimRangeArray = (value: unknown): value is VimRange[] => {
+  return Array.isArray(value) && value.every(isVimRange)
+}
+
+const compareCursors = (left: VimCursor, right: VimCursor): number => {
+  if (left.line !== right.line) {
+    return left.line - right.line
+  }
+  return left.ch - right.ch
+}
+
+const getVisualYankCursor = (
+  cm: CodeMirrorAdapter,
+  ranges: unknown,
+  oldAnchor: unknown
+): VimCursor | unknown => {
+  const selAnchor = cm.state.vim.sel?.anchor
+  const selHead = cm.state.vim.sel?.head
+  if (
+    !cm.state.vim.visualMode ||
+    !isVimCursor(selAnchor) ||
+    !isVimCursor(selHead) ||
+    !isVimRangeArray(ranges) ||
+    ranges.length === 0
+  ) {
+    return oldAnchor
+  }
+
+  const [firstRange] = ranges
+  const cursors = [selAnchor, selHead, firstRange.anchor, firstRange.head]
+  return cursors.reduce((minimum, current) =>
+    compareCursors(current, minimum) < 0 ? current : minimum
+  )
+}
+
 /**
  * Creates a yank operator that copies selected text to the system clipboard.
  * @param Vim - The Vim API instance for register access
@@ -8,7 +69,7 @@ import type { VimAPI, CodeMirrorAdapter, VimOperatorArgs } from './vimTypes'
  */
 export const createYankSystemOperator =
   (Vim: VimAPI) =>
-  (cm: CodeMirrorAdapter, args: VimOperatorArgs, _ranges: unknown, oldAnchor: unknown) => {
+  (cm: CodeMirrorAdapter, args: VimOperatorArgs, ranges: unknown, oldAnchor: unknown) => {
     const text = cm.getSelection()
     if (text) {
       navigator.clipboard.writeText(text).catch(() => {
@@ -27,7 +88,7 @@ export const createYankSystemOperator =
         cm.state.vim.visualBlock
       )
     }
-    return oldAnchor
+    return getVisualYankCursor(cm, ranges, oldAnchor)
   }
 
 /**

--- a/packages/app/src/components/editor/vimMotions.test.ts
+++ b/packages/app/src/components/editor/vimMotions.test.ts
@@ -4,6 +4,9 @@ import type { CodeMirrorAdapter } from './vimTypes'
 import {
   moveByDisplayLinesMotion,
   moveToEndOfDisplayLineMotion,
+  moveToHighDocumentPositionMotion,
+  moveToLowDocumentPositionMotion,
+  moveToMiddleDocumentPositionMotion,
   moveToMatchingBracketMotion,
   moveToStartOfDisplayLineMotion,
 } from './vimMotions'
@@ -16,23 +19,32 @@ interface Position {
 interface MockTextModel {
   getLineContent: (lineNumber: number) => string
   getLineCount: () => number
+  getLineFirstNonWhitespaceColumn: (lineNumber: number) => number
 }
 
 const createModel = (lines: string[]): editor.ITextModel =>
   ({
     getLineContent: (lineNumber: number) => lines[lineNumber - 1] ?? '',
     getLineCount: () => lines.length,
+    getLineFirstNonWhitespaceColumn: (lineNumber: number) => {
+      const line = lines[lineNumber - 1] ?? ''
+      const firstNonWhitespaceIndex = line.search(/\S/)
+      return firstNonWhitespaceIndex === -1 ? 0 : firstNonWhitespaceIndex + 1
+    },
   }) as unknown as editor.ITextModel
 
 const createCodeMirrorAdapter = ({
   position,
   model,
+  visibleRange,
 }: {
   position: Position
   model?: MockTextModel | null
+  visibleRange?: { startLineNumber: number; endLineNumber: number }
 }): CodeMirrorAdapter => {
   let currentPosition = position
   const currentModel = model ?? null
+  const currentVisibleRange = visibleRange ?? { startLineNumber: 1, endLineNumber: 20 }
 
   const editorMock = {
     setPosition: vi.fn((next: Position) => {
@@ -63,6 +75,13 @@ const createCodeMirrorAdapter = ({
     }),
     getPosition: vi.fn(() => currentPosition),
     getModel: vi.fn(() => currentModel),
+    getVisibleRanges: vi.fn(() => [
+      {
+        ...currentVisibleRange,
+        startColumn: 1,
+        endColumn: 1,
+      },
+    ]),
   }
 
   return {
@@ -97,6 +116,122 @@ describe('vimMotions', () => {
 
     const target = moveByDisplayLinesMotion(cm, { line: 1, ch: 1 }, { forward: true })
     expect(target).toEqual({ line: 1, ch: 1 })
+  })
+
+  it('moves to high/middle/low using the full document when it fits in view', () => {
+    const model = createModel(['  one', 'two', '    three', 'four', '     five'])
+    const cm = createCodeMirrorAdapter({
+      position: { lineNumber: 3, column: 3 },
+      model,
+      visibleRange: { startLineNumber: 1, endLineNumber: 20 },
+    })
+
+    expect(moveToHighDocumentPositionMotion(cm, { line: 2, ch: 2 }, { repeat: 1 })).toEqual({
+      line: 0,
+      ch: 2,
+    })
+    expect(moveToMiddleDocumentPositionMotion(cm, { line: 2, ch: 2 })).toEqual({
+      line: 2,
+      ch: 4,
+    })
+    expect(moveToLowDocumentPositionMotion(cm, { line: 2, ch: 2 }, { repeat: 1 })).toEqual({
+      line: 4,
+      ch: 5,
+    })
+  })
+
+  it('moves to high/middle/low using visible viewport when file exceeds view height', () => {
+    const model = createModel([
+      'line 1',
+      'line 2',
+      'line 3',
+      'line 4',
+      'line 5',
+      'line 6',
+      'line 7',
+      'line 8',
+      'line 9',
+      'line 10',
+      'line 11',
+      'line 12',
+    ])
+    const cm = createCodeMirrorAdapter({
+      position: { lineNumber: 8, column: 2 },
+      model,
+      visibleRange: { startLineNumber: 4, endLineNumber: 8 },
+    })
+
+    expect(moveToHighDocumentPositionMotion(cm, { line: 7, ch: 1 }, { repeat: 1 })).toEqual({
+      line: 3,
+      ch: 0,
+    })
+    expect(moveToMiddleDocumentPositionMotion(cm, { line: 7, ch: 1 })).toEqual({
+      line: 5,
+      ch: 0,
+    })
+    expect(moveToLowDocumentPositionMotion(cm, { line: 7, ch: 1 }, { repeat: 1 })).toEqual({
+      line: 7,
+      ch: 0,
+    })
+  })
+
+  it('clamps high/low repeat counts inside the computed target bounds', () => {
+    const model = createModel(['a', 'b', 'c', 'd', 'e', 'f'])
+    const cm = createCodeMirrorAdapter({
+      position: { lineNumber: 3, column: 1 },
+      model,
+      visibleRange: { startLineNumber: 2, endLineNumber: 4 },
+    })
+
+    expect(moveToHighDocumentPositionMotion(cm, { line: 2, ch: 0 }, { repeat: 50 })).toEqual({
+      line: 3,
+      ch: 0,
+    })
+    expect(moveToLowDocumentPositionMotion(cm, { line: 2, ch: 0 }, { repeat: 50 })).toEqual({
+      line: 1,
+      ch: 0,
+    })
+  })
+
+  it('falls back to the current head when H/M/L cannot resolve model or viewport', () => {
+    const noModelAdapter = createCodeMirrorAdapter({
+      position: { lineNumber: 2, column: 2 },
+      model: null,
+    })
+
+    expect(
+      moveToHighDocumentPositionMotion(noModelAdapter, { line: 5, ch: 3 }, { repeat: 1 })
+    ).toEqual({
+      line: 5,
+      ch: 3,
+    })
+    expect(moveToMiddleDocumentPositionMotion(noModelAdapter, { line: 5, ch: 3 })).toEqual({
+      line: 5,
+      ch: 3,
+    })
+    expect(
+      moveToLowDocumentPositionMotion(noModelAdapter, { line: 5, ch: 3 }, { repeat: 1 })
+    ).toEqual({
+      line: 5,
+      ch: 3,
+    })
+
+    const noVisibleRangeAdapter = createCodeMirrorAdapter({
+      position: { lineNumber: 2, column: 2 },
+      model: createModel(['one', 'two']),
+    })
+    vi.mocked(noVisibleRangeAdapter.editor.getVisibleRanges).mockReturnValue([])
+
+    expect(
+      moveToHighDocumentPositionMotion(noVisibleRangeAdapter, { line: 1, ch: 1 }, { repeat: 1 })
+    ).toEqual({ line: 1, ch: 1 })
+    expect(moveToMiddleDocumentPositionMotion(noVisibleRangeAdapter, { line: 1, ch: 1 })).toEqual({
+      line: 1,
+      ch: 1,
+    })
+    expect(
+      moveToLowDocumentPositionMotion(noVisibleRangeAdapter, { line: 1, ch: 1 }, { repeat: 1 })
+    ).toEqual({ line: 1, ch: 1 })
   })
 
   it('prefers markdown fences and quotes before bracket fallback', () => {

--- a/packages/app/src/components/editor/vimMotions.ts
+++ b/packages/app/src/components/editor/vimMotions.ts
@@ -5,6 +5,49 @@ import {
   findStandardBracketTarget,
 } from './vimBracketHelpers'
 
+interface VisibleLineBounds {
+  startLineNumber: number
+  endLineNumber: number
+}
+
+const clampLineNumber = (lineNumber: number, bounds: VisibleLineBounds): number =>
+  Math.min(Math.max(lineNumber, bounds.startLineNumber), bounds.endLineNumber)
+
+const getFirstNonWhitespaceColumn = (cm: CodeMirrorAdapter, lineNumber: number): number => {
+  const model = cm.editor.getModel()
+  if (!model) {
+    return 1
+  }
+
+  const firstNonWhitespaceColumn = model.getLineFirstNonWhitespaceColumn(lineNumber)
+  return firstNonWhitespaceColumn > 0 ? firstNonWhitespaceColumn : 1
+}
+
+const getTargetLineBounds = (cm: CodeMirrorAdapter): VisibleLineBounds | null => {
+  const model = cm.editor.getModel()
+  if (!model) {
+    return null
+  }
+
+  const visibleRanges = cm.editor.getVisibleRanges()
+  const visibleRange = visibleRanges[0]
+  if (!visibleRange) {
+    return null
+  }
+
+  const totalLineCount = model.getLineCount()
+  const visibleLineCount = visibleRange.endLineNumber - visibleRange.startLineNumber + 1
+
+  if (totalLineCount <= visibleLineCount) {
+    return { startLineNumber: 1, endLineNumber: totalLineCount }
+  }
+
+  return {
+    startLineNumber: visibleRange.startLineNumber,
+    endLineNumber: visibleRange.endLineNumber,
+  }
+}
+
 /**
  * Vim motion that moves the cursor by display (wrapped) lines using Monaco's native cursor movement.
  * @param cm - The CodeMirror adapter wrapping the Monaco editor
@@ -32,6 +75,82 @@ export const moveByDisplayLinesMotion = (
   if (!newPos) return { line: head.line, ch: head.ch }
 
   return { line: newPos.lineNumber - 1, ch: newPos.column - 1 }
+}
+
+/**
+ * Vim motion that jumps to a high document position.
+ * Uses viewport-relative lines when the file is taller than the viewport,
+ * otherwise uses the whole document.
+ * @param cm - The CodeMirror adapter wrapping the Monaco editor
+ * @param head - The 0-indexed cursor position
+ * @param motionArgs - Motion arguments including optional repeat count
+ * @returns { { line: number; ch: number } } The 0-indexed target position
+ */
+export const moveToHighDocumentPositionMotion = (
+  cm: CodeMirrorAdapter,
+  head: { line: number; ch: number },
+  motionArgs: { repeat?: number }
+): { line: number; ch: number } => {
+  const bounds = getTargetLineBounds(cm)
+  if (!bounds) {
+    return { line: head.line, ch: head.ch }
+  }
+
+  const repeat = motionArgs.repeat || 1
+  const targetLineNumber = clampLineNumber(bounds.startLineNumber + repeat - 1, bounds)
+  const targetColumn = getFirstNonWhitespaceColumn(cm, targetLineNumber)
+
+  return { line: targetLineNumber - 1, ch: targetColumn - 1 }
+}
+
+/**
+ * Vim motion that jumps to a middle document position.
+ * Uses viewport-relative lines when the file is taller than the viewport,
+ * otherwise uses the whole document.
+ * @param cm - The CodeMirror adapter wrapping the Monaco editor
+ * @param head - The 0-indexed cursor position
+ * @returns { { line: number; ch: number } } The 0-indexed target position
+ */
+export const moveToMiddleDocumentPositionMotion = (
+  cm: CodeMirrorAdapter,
+  head: { line: number; ch: number }
+): { line: number; ch: number } => {
+  const bounds = getTargetLineBounds(cm)
+  if (!bounds) {
+    return { line: head.line, ch: head.ch }
+  }
+
+  const targetLineNumber =
+    bounds.startLineNumber + Math.floor((bounds.endLineNumber - bounds.startLineNumber) / 2)
+  const targetColumn = getFirstNonWhitespaceColumn(cm, targetLineNumber)
+
+  return { line: targetLineNumber - 1, ch: targetColumn - 1 }
+}
+
+/**
+ * Vim motion that jumps to a low document position.
+ * Uses viewport-relative lines when the file is taller than the viewport,
+ * otherwise uses the whole document.
+ * @param cm - The CodeMirror adapter wrapping the Monaco editor
+ * @param head - The 0-indexed cursor position
+ * @param motionArgs - Motion arguments including optional repeat count
+ * @returns { { line: number; ch: number } } The 0-indexed target position
+ */
+export const moveToLowDocumentPositionMotion = (
+  cm: CodeMirrorAdapter,
+  head: { line: number; ch: number },
+  motionArgs: { repeat?: number }
+): { line: number; ch: number } => {
+  const bounds = getTargetLineBounds(cm)
+  if (!bounds) {
+    return { line: head.line, ch: head.ch }
+  }
+
+  const repeat = motionArgs.repeat || 1
+  const targetLineNumber = clampLineNumber(bounds.endLineNumber - repeat + 1, bounds)
+  const targetColumn = getFirstNonWhitespaceColumn(cm, targetLineNumber)
+
+  return { line: targetLineNumber - 1, ch: targetColumn - 1 }
 }
 
 /**

--- a/packages/app/src/components/editor/vimTypes.ts
+++ b/packages/app/src/components/editor/vimTypes.ts
@@ -12,7 +12,12 @@ export interface VimRegisterController {
 
 export interface VimState {
   vim: {
+    visualMode?: boolean
     visualBlock: boolean
+    sel?: {
+      anchor: { line: number; ch: number }
+      head: { line: number; ch: number }
+    }
   }
 }
 

--- a/packages/app/src/globals.css
+++ b/packages/app/src/globals.css
@@ -170,6 +170,17 @@
   flex: 1 !important;
 }
 
+/* Visual mode caret fix for Monaco+Vim integration.
+   Monaco renders inclusive visual selections with a caret one character ahead. */
+.monaco-editor.vim-visual-char-active .cursor {
+  opacity: 0 !important;
+}
+
+.monaco-editor .vim-visual-head-cursor {
+  background-color: color-mix(in srgb, var(--foreground) 28%, transparent);
+  box-shadow: inset 0 0 0 1px var(--foreground);
+}
+
 /* Github Markdown CSS Overrides for Theme Support */
 html:not(.dark) .markdown-body {
   color-scheme: light;


### PR DESCRIPTION
Adds editor auto-focus on startup when the pane is visible, improves vim visual-character mode cursor rendering, and enhances H/M/L motions with viewport-aware positioning.

- Editor now receives focus automatically on mount when not in preview-only mode, allowing immediate typing.
- Visual-character mode cursor now displays at the vim head position with a custom decorator, fixing Monaco's inclusive selection rendering.
- Visual-mode yank restores cursor to selection anchor instead of the yanked region, matching vim behaviour.
- H/M/L motions now use viewport-relative calculations when the file exceeds view height, falling back to full-document positioning for smaller files.
- Vim initialisation moved to useEditorVim hook with configurable delay support to handle reload timing edge cases.
- Added comprehensive type guards for vim state structures to ensure type safety across clipboard and motion operations.
- Extended feature documentation in FEATURES.md to describe new auto-focus, enhanced H/M/L, clipboard, and visual mode improvements.
