### PR TITLE
feat(task-list): Add interactive task list support

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -6,7 +6,7 @@ Poe includes standard Markdown editor functionality and a set of unique features
 
 - Live Markdown preview while typing.
 - Split-pane editing and preview, with editor-only and preview-only modes.
-- Standard formatting actions: headings, bold/italic, links, inline code, code blocks, quotes, and lists.
+- Standard formatting actions: headings, bold/italic, links, inline code, code blocks, quotes, and lists (bullet, numbered, task).
 - Syntax-highlighted code blocks in preview.
 - Keyboard shortcuts and in-app shortcuts help.
 - Export/download as Markdown (`.md`) and HTML (`.html`).
@@ -36,6 +36,7 @@ Poe includes standard Markdown editor functionality and a set of unique features
 | Code fence language headers        | Fenced code blocks with a language show a header label.                                                                                                                                                                    |
 | GitHub-safe HTML tag rendering     | Preview supports a sanitized subset of common GitHub-safe HTML tags (e.g., `details`, `kbd`, tables, and images).                                                                                                          |
 | GitHub callout rendering           | GitHub alert syntax blockquotes (`[!NOTE]`, `[!TIP]`, `[!IMPORTANT]`, `[!WARNING]`, `[!CAUTION]`) render with `markdown-alert` styling.                                                                                    |
+| Interactive task list checkboxes   | Markdown task items (`- [ ]` / `- [x]`) render as clickable checkboxes in preview and update source markdown state.                                                                                                         |
 | Synchronized editor/preview scroll | Scroll sync uses ratio-based matching between Monaco and preview.                                                                                                                                                          |
 | Preview rich-text copy             | Copy supports both HTML and plain text where browser APIs allow.                                                                                                                                                           |
 | Preview code-block quick-copy      | Fenced code blocks in preview include one-click source copy controls; Mermaid blocks provide split actions for image copy and source copy.                                                                                 |
@@ -50,7 +51,7 @@ Poe includes standard Markdown editor functionality and a set of unique features
 | Browser-aware Vim clipboard behavior    | Vim yank writes to system clipboard + register; visual-mode yank restores cursor to selection start; visual-char mode renders cursor at Vim head position; `p/P` stays register-based (due to browser limitations).                     |
 | Vim spell and wrap options              | Supports Vim `:set spell` sync and `:set wrap`/`:set nowrap` behavior.                                                                                                                                                                  |
 | Spell check with dictionary integration | Monaco spellcheck uses `typo-js` dictionary data.                                                                                                                                                                                       |
-| Auto-continue lists and blockquotes     | Enter key continues or exits list/quote prefixes intelligently.                                                                                                                                                                         |
+| Auto-continue lists and blockquotes     | Enter key continues or exits list/quote prefixes intelligently, including preserving task list checked state for new items.                                                                                                     |
 
 ### Markdown Table
 

--- a/packages/app/MD_TEST.md
+++ b/packages/app/MD_TEST.md
@@ -13,6 +13,7 @@ Use this document to quickly verify that Markdown rendering, syntax highlighting
 - Copy editor markdown and confirm pasted text matches source.
 - Verify GitHub callouts (`NOTE`, `TIP`, `IMPORTANT`, `WARNING`, `CAUTION`) render with alert styling.
 - Verify GitHub-safe HTML tags render correctly and unsafe HTML is sanitized.
+- Verify task list checkboxes render in preview, can be clicked, and update markdown source markers.
 
 ---
 
@@ -71,6 +72,14 @@ Mixed content list:
 3. Step three with a sub-list:
    - Sub step A
    - Sub step B
+
+Task list:
+
+- [ ] Plan release notes
+- [x] Merge dependency upgrades
+- [ ] Validate print output
+  - [x] Verify headings and tables
+  - [ ] Verify task list checkboxes
 
 ## 5) Blockquotes and Rules
 

--- a/packages/app/src/components/EditorToolbar.test.tsx
+++ b/packages/app/src/components/EditorToolbar.test.tsx
@@ -30,6 +30,7 @@ describe('EditorToolbar', () => {
     onFormatQuote: vi.fn(),
     onFormatBulletList: vi.fn(),
     onFormatNumberedList: vi.fn(),
+    onFormatTaskList: vi.fn(),
     onFormatCodeBlock: vi.fn(),
     onTableAction: vi.fn(),
     isInTable: false,
@@ -103,8 +104,6 @@ describe('EditorToolbar', () => {
     await user.click(screen.getByRole('button', { name: 'Link' }))
     await user.click(screen.getByRole('button', { name: 'Code' }))
     await user.click(screen.getByRole('button', { name: 'Quote' }))
-    await user.click(screen.getByRole('button', { name: 'Bullet List' }))
-    await user.click(screen.getByRole('button', { name: 'Numbered List' }))
     await user.click(screen.getByRole('button', { name: 'Code Block' }))
     await user.click(screen.getByRole('button', { name: 'Transform Selection' }))
     await user.click(screen.getByRole('button', { name: 'Vim Mode' }))
@@ -115,15 +114,13 @@ describe('EditorToolbar', () => {
     expect(props.onFormatLink).toHaveBeenCalledTimes(1)
     expect(props.onFormatCode).toHaveBeenCalledTimes(1)
     expect(props.onFormatQuote).toHaveBeenCalledTimes(1)
-    expect(props.onFormatBulletList).toHaveBeenCalledTimes(1)
-    expect(props.onFormatNumberedList).toHaveBeenCalledTimes(1)
     expect(props.onFormatCodeBlock).toHaveBeenCalledTimes(1)
     expect(props.onOpenTransformer).toHaveBeenCalledTimes(1)
     expect(props.toggleVimMode).toHaveBeenCalledTimes(1)
     expect(props.toggleTheme).toHaveBeenCalledTimes(1)
   })
 
-  it('triggers heading and table menu actions', async () => {
+  it('triggers heading, list, and table menu actions', async () => {
     const user = userEvent.setup()
     const props = renderToolbar()
 
@@ -132,6 +129,24 @@ describe('EditorToolbar', () => {
 
     await waitFor(() => {
       expect(props.onFormatHeading).toHaveBeenCalledWith(2)
+    })
+
+    await user.click(screen.getByRole('button', { name: 'Lists' }))
+    await user.click(await screen.findByText('Bullet List'))
+    await waitFor(() => {
+      expect(props.onFormatBulletList).toHaveBeenCalledTimes(1)
+    })
+
+    await user.click(screen.getByRole('button', { name: 'Lists' }))
+    await user.click(await screen.findByText('Numbered List'))
+    await waitFor(() => {
+      expect(props.onFormatNumberedList).toHaveBeenCalledTimes(1)
+    })
+
+    await user.click(screen.getByRole('button', { name: 'Lists' }))
+    await user.click(await screen.findByText('Task List'))
+    await waitFor(() => {
+      expect(props.onFormatTaskList).toHaveBeenCalledTimes(1)
     })
 
     await user.click(screen.getByRole('button', { name: 'Table Operations' }))

--- a/packages/app/src/components/EditorToolbar.tsx
+++ b/packages/app/src/components/EditorToolbar.tsx
@@ -86,6 +86,7 @@ import {
   Columns,
   Rows,
   SpellCheck,
+  Check,
 } from 'lucide-react'
 import { ICON_MAP } from '@/components/transformer/constants'
 import { cn } from '@/utils/classnames'
@@ -264,6 +265,7 @@ interface EditorToolbarProps {
   onFormatQuote: () => void
   onFormatBulletList: () => void
   onFormatNumberedList: () => void
+  onFormatTaskList: () => void
   onFormatCodeBlock: () => void
   onTableAction: (action: TableAction) => void
   isInTable: boolean
@@ -317,6 +319,7 @@ export function EditorToolbar({
   onFormatQuote,
   onFormatBulletList,
   onFormatNumberedList,
+  onFormatTaskList,
   onFormatCodeBlock,
   onTableAction,
   isInTable,
@@ -348,6 +351,7 @@ export function EditorToolbar({
   const [activeDragPipeline, setActiveDragPipeline] = useState<TransformationPipeline | null>(null)
   const clearTimerRef = useRef<NodeJS.Timeout | null>(null)
   const headingActionRef = useRef(false)
+  const listActionRef = useRef(false)
 
   const handleClearSelect = (e: Event) => {
     if (!isConfirmingClear) {
@@ -523,8 +527,54 @@ export function EditorToolbar({
           </DropdownMenuContent>
         </DropdownMenu>
         <ToolbarButton icon={Quote} label="Quote" onClick={onFormatQuote} />
-        <ToolbarButton icon={List} label="Bullet List" onClick={onFormatBulletList} />
-        <ToolbarButton icon={ListOrdered} label="Numbered List" onClick={onFormatNumberedList} />
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <Button
+              variant="ghost"
+              size="icon-sm"
+              className="text-muted-foreground hover:text-foreground"
+            >
+              <List className="size-4" />
+              <span className="sr-only">Lists</span>
+            </Button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent
+            onCloseAutoFocus={(e) => {
+              if (listActionRef.current) {
+                e.preventDefault()
+                listActionRef.current = false
+              }
+            }}
+          >
+            <DropdownMenuItem
+              onClick={() => {
+                listActionRef.current = true
+                setTimeout(() => onFormatBulletList(), 50)
+              }}
+            >
+              <List className="size-4" />
+              Bullet List
+            </DropdownMenuItem>
+            <DropdownMenuItem
+              onClick={() => {
+                listActionRef.current = true
+                setTimeout(() => onFormatNumberedList(), 50)
+              }}
+            >
+              <ListOrdered className="size-4" />
+              Numbered List
+            </DropdownMenuItem>
+            <DropdownMenuItem
+              onClick={() => {
+                listActionRef.current = true
+                setTimeout(() => onFormatTaskList(), 50)
+              }}
+            >
+              <Check className="size-4" />
+              Task List
+            </DropdownMenuItem>
+          </DropdownMenuContent>
+        </DropdownMenu>
         <ToolbarButton icon={CodeSquare} label="Code Block" onClick={onFormatCodeBlock} />
 
         <DropdownMenu>

--- a/packages/app/src/components/PoeEditor.tsx
+++ b/packages/app/src/components/PoeEditor.tsx
@@ -53,6 +53,8 @@ import {
   formatQuote,
   formatBulletList,
   formatNumberedList,
+  formatTaskList,
+  toggleTaskListItem,
 } from '@/utils/formatting'
 
 const DEFAULT_CONTENT = `# Poe Markdown Editor
@@ -217,6 +219,10 @@ export function PoeEditor({ onReady }: PoeEditorProps): ReactElement {
     formatNumberedList(sourceRef.current)
   }, [sourceRef])
 
+  const handleFormatTaskList = useCallback((): void => {
+    formatTaskList(sourceRef.current)
+  }, [sourceRef])
+
   // Deprecated usage from keyboard shortcut, can map to format-table
   const handleFormatTable = useCallback((): void => {
     sourceRef.current?.performTableAction('format-table')
@@ -366,6 +372,16 @@ export function PoeEditor({ onReady }: PoeEditorProps): ReactElement {
     setContent('')
     toast({ description: 'Content cleared' })
   }, [setContent, toast])
+
+  const handleTaskListToggle = useCallback(
+    (taskIndex: number, checked: boolean): void => {
+      const updatedContent = toggleTaskListItem(content, taskIndex, checked)
+      if (updatedContent !== content) {
+        setContent(updatedContent)
+      }
+    },
+    [content, setContent]
+  )
 
   const handleSave = useCallback((): void => {
     // Save is automatic via URL state, just show confirmation
@@ -531,6 +547,7 @@ export function PoeEditor({ onReady }: PoeEditorProps): ReactElement {
           onFormatQuote={handleFormatQuote}
           onFormatBulletList={handleFormatBulletList}
           onFormatNumberedList={handleFormatNumberedList}
+          onFormatTaskList={handleFormatTaskList}
           onFormatCodeBlock={handleFormatCodeBlock}
           onTableAction={handleTableAction}
           isInTable={isInTable}
@@ -630,6 +647,7 @@ export function PoeEditor({ onReady }: PoeEditorProps): ReactElement {
                       <PreviewPane
                         ref={targetRef}
                         htmlContent={htmlContent}
+                        onTaskListToggle={handleTaskListToggle}
                         viewMode={viewMode}
                         onToggleLayout={handleTogglePreview}
                         colorMode={colorMode}
@@ -692,7 +710,12 @@ export function PoeEditor({ onReady }: PoeEditorProps): ReactElement {
               <div
                 className={cn('flex-1 p-4 mt-0 overflow-auto', activeTab !== 'preview' && 'hidden')}
               >
-                <PreviewPane ref={targetRef} htmlContent={htmlContent} colorMode={colorMode} />
+                <PreviewPane
+                  ref={targetRef}
+                  htmlContent={htmlContent}
+                  onTaskListToggle={handleTaskListToggle}
+                  colorMode={colorMode}
+                />
               </div>
             </div>
           )}

--- a/packages/app/src/components/PreviewPane.test.tsx
+++ b/packages/app/src/components/PreviewPane.test.tsx
@@ -120,4 +120,25 @@ describe('PreviewPane', () => {
 
     expect(screen.queryByRole('button')).not.toBeInTheDocument()
   })
+
+  it('calls onTaskListToggle when task checkbox is clicked', async () => {
+    const markdown = '- [ ] first task\n- [x] done task'
+    const renderedHtml = renderMarkdown(markdown)
+    const onTaskListToggle = vi.fn()
+
+    const { container } = render(
+      <PreviewPane htmlContent={renderedHtml} onTaskListToggle={onTaskListToggle} />
+    )
+
+    const firstCheckbox = container.querySelector<HTMLInputElement>(
+      'input.task-list-item-checkbox[data-task-index="0"]'
+    )
+    expect(firstCheckbox).toBeTruthy()
+
+    fireEvent.click(firstCheckbox!)
+
+    await waitFor(() => {
+      expect(onTaskListToggle).toHaveBeenCalledWith(0, true)
+    })
+  })
 })

--- a/packages/app/src/components/PreviewPane.tsx
+++ b/packages/app/src/components/PreviewPane.tsx
@@ -11,6 +11,7 @@ import type { MermaidColorMode } from '@/utils/mermaidTheme'
 
 interface PreviewPaneProps {
   htmlContent: string
+  onTaskListToggle?: (taskIndex: number, checked: boolean) => void
   viewMode?: 'editor' | 'preview' | 'split'
   onToggleLayout?: () => void
   colorMode?: MermaidColorMode
@@ -29,6 +30,7 @@ export const PreviewPane = forwardRef<HTMLDivElement, PreviewPaneProps>(
   (
     {
       htmlContent,
+      onTaskListToggle,
       viewMode,
       onToggleLayout,
       colorMode = 'light',
@@ -124,6 +126,22 @@ export const PreviewPane = forwardRef<HTMLDivElement, PreviewPaneProps>(
         const target = event.target
         if (!(target instanceof Element)) return
 
+        const taskCheckbox = target.closest<HTMLInputElement>('input.task-list-item-checkbox')
+        if (taskCheckbox && root.contains(taskCheckbox) && onTaskListToggle) {
+          event.preventDefault()
+          event.stopPropagation()
+
+          const taskIndexText = taskCheckbox.getAttribute('data-task-index')
+          if (!taskIndexText) return
+
+          const taskIndex = Number.parseInt(taskIndexText, 10)
+          if (Number.isNaN(taskIndex)) return
+
+          const currentlyChecked = taskCheckbox.hasAttribute('checked')
+          onTaskListToggle(taskIndex, !currentlyChecked)
+          return
+        }
+
         const button = target.closest<HTMLButtonElement>('.preview-code-copy-button')
         if (!button || !root.contains(button)) return
 
@@ -193,7 +211,7 @@ export const PreviewPane = forwardRef<HTMLDivElement, PreviewPaneProps>(
           host.classList.remove('preview-code-copy-host')
         }
       }
-    }, [htmlContent, printFriendly])
+    }, [htmlContent, onTaskListToggle, printFriendly])
 
     const handleCopy = async (): Promise<void> => {
       try {

--- a/packages/app/src/globals.css
+++ b/packages/app/src/globals.css
@@ -326,6 +326,24 @@ html:not(.dark) .markdown-body {
   }
 }
 
+.markdown-body .contains-task-list {
+  list-style: none;
+  padding-left: 1.4rem;
+}
+
+.markdown-body .task-list-item {
+  list-style: none;
+}
+
+.markdown-body .task-list-item > .task-list-item-checkbox {
+  margin: 0 0.5rem 0.1rem 0;
+  inline-size: 0.95rem;
+  block-size: 0.95rem;
+  vertical-align: middle;
+  cursor: pointer;
+  accent-color: var(--fgColor-accent);
+}
+
 .markdown-body .code-block-with-language {
   margin: 1rem 0;
   overflow: hidden;
@@ -656,6 +674,27 @@ html:not(.dark) .markdown-body {
 
   .poe-editor-print-shell .poe-editor-print-markdown-body li {
     margin: 0.2rem 0;
+  }
+
+  .poe-editor-print-shell .poe-editor-print-markdown-body .contains-task-list {
+    list-style: none;
+    padding-left: 1.4rem;
+  }
+
+  .poe-editor-print-shell .poe-editor-print-markdown-body .task-list-item {
+    list-style: none;
+  }
+
+  .poe-editor-print-shell
+    .poe-editor-print-markdown-body
+    .task-list-item
+    > .task-list-item-checkbox {
+    margin: 0 0.5rem 0.1rem 0;
+    inline-size: 0.95rem;
+    block-size: 0.95rem;
+    vertical-align: middle;
+    pointer-events: none;
+    accent-color: #000;
   }
 
   .poe-editor-print-shell .poe-editor-print-markdown-body a {

--- a/packages/app/src/utils/formatting.test.ts
+++ b/packages/app/src/utils/formatting.test.ts
@@ -291,6 +291,24 @@ describe('formatting utils', () => {
       expect(replaceSelectionMock).toHaveBeenCalledWith('- item 1\n- item 2')
     })
 
+    it('should convert task list to bullet list', () => {
+      getSelectionRangeMock.mockReturnValue({
+        startLineNumber: 1,
+        endLineNumber: 2,
+        startColumn: 1,
+        endColumn: 13,
+      })
+      getLineContentMock.mockImplementation((line) => {
+        if (line === 1) return '- [ ] item 1'
+        if (line === 2) return '- [x] item 2'
+        return ''
+      })
+
+      formatBulletList(mockEditor)
+
+      expect(replaceSelectionMock).toHaveBeenCalledWith('- item 1\n- item 2')
+    })
+
     it('should insert bullet list item if no selection', () => {
       getSelectionRangeMock.mockReturnValue({
         startLineNumber: 1,
@@ -353,6 +371,24 @@ describe('formatting utils', () => {
       getLineContentMock.mockImplementation((line) => {
         if (line === 1) return '- item 1'
         if (line === 2) return '- item 2'
+        return ''
+      })
+
+      formatNumberedList(mockEditor)
+
+      expect(replaceSelectionMock).toHaveBeenCalledWith('1. item 1\n2. item 2')
+    })
+
+    it('should convert task list to numbered list without checkbox markers', () => {
+      getSelectionRangeMock.mockReturnValue({
+        startLineNumber: 1,
+        endLineNumber: 2,
+        startColumn: 1,
+        endColumn: 13,
+      })
+      getLineContentMock.mockImplementation((line) => {
+        if (line === 1) return '- [ ] item 1'
+        if (line === 2) return '- [x] item 2'
         return ''
       })
 

--- a/packages/app/src/utils/formatting.test.ts
+++ b/packages/app/src/utils/formatting.test.ts
@@ -9,6 +9,8 @@ import {
   formatQuote,
   formatBulletList,
   formatNumberedList,
+  formatTaskList,
+  toggleTaskListItem,
 } from './formatting'
 import type { EditorPaneHandle } from '@/components/editor'
 
@@ -374,6 +376,94 @@ describe('formatting utils', () => {
     })
   })
 
+  describe('formatTaskList', () => {
+    it('should prefix lines with unchecked task markers', () => {
+      getSelectionRangeMock.mockReturnValue({
+        startLineNumber: 1,
+        endLineNumber: 2,
+        startColumn: 1,
+        endColumn: 7,
+      })
+      getLineContentMock.mockImplementation((line) => {
+        if (line === 1) return 'item 1'
+        if (line === 2) return 'item 2'
+        return ''
+      })
+
+      formatTaskList(mockEditor)
+
+      expect(replaceSelectionMock).toHaveBeenCalledWith('- [ ] item 1\n- [ ] item 2')
+    })
+
+    it('should convert bullet list to task list', () => {
+      getSelectionRangeMock.mockReturnValue({
+        startLineNumber: 1,
+        endLineNumber: 2,
+        startColumn: 1,
+        endColumn: 9,
+      })
+      getLineContentMock.mockImplementation((line) => {
+        if (line === 1) return '- item 1'
+        if (line === 2) return '* item 2'
+        return ''
+      })
+
+      formatTaskList(mockEditor)
+
+      expect(replaceSelectionMock).toHaveBeenCalledWith('- [ ] item 1\n- [ ] item 2')
+    })
+
+    it('should convert numbered list to task list', () => {
+      getSelectionRangeMock.mockReturnValue({
+        startLineNumber: 1,
+        endLineNumber: 2,
+        startColumn: 1,
+        endColumn: 10,
+      })
+      getLineContentMock.mockImplementation((line) => {
+        if (line === 1) return '1. item 1'
+        if (line === 2) return '2. item 2'
+        return ''
+      })
+
+      formatTaskList(mockEditor)
+
+      expect(replaceSelectionMock).toHaveBeenCalledWith('- [ ] item 1\n- [ ] item 2')
+    })
+
+    it('should toggle off task list markers', () => {
+      getSelectionRangeMock.mockReturnValue({
+        startLineNumber: 1,
+        endLineNumber: 2,
+        startColumn: 1,
+        endColumn: 12,
+      })
+      getLineContentMock.mockImplementation((line) => {
+        if (line === 1) return '- [ ] item 1'
+        if (line === 2) return '- [x] item 2'
+        return ''
+      })
+
+      formatTaskList(mockEditor)
+
+      expect(replaceSelectionMock).toHaveBeenCalledWith('item 1\nitem 2')
+    })
+
+    it('should insert task list marker on empty line', () => {
+      getSelectionRangeMock.mockReturnValue({
+        startLineNumber: 1,
+        endLineNumber: 1,
+        startColumn: 1,
+        endColumn: 1,
+      })
+      getLineContentMock.mockReturnValue('')
+
+      formatTaskList(mockEditor)
+
+      expect(insertTextMock).toHaveBeenCalledWith('- [ ] ')
+    })
+  })
+
   it('should do nothing if editor is null', () => {
     formatBold(null)
     // Expect no errors
@@ -381,6 +471,23 @@ describe('formatting utils', () => {
 })
 
 import { getAutoContinueEdit, type AutoContinueResult } from './formatting'
+
+describe('toggleTaskListItem', () => {
+  it('updates matching task marker to checked', () => {
+    const input = '- [ ] first\n- [x] second'
+    expect(toggleTaskListItem(input, 0, true)).toBe('- [x] first\n- [x] second')
+  })
+
+  it('updates matching task marker to unchecked', () => {
+    const input = '- [x] first\n- [x] second'
+    expect(toggleTaskListItem(input, 1, false)).toBe('- [x] first\n- [ ] second')
+  })
+
+  it('returns original markdown when index does not exist', () => {
+    const input = '- [ ] first'
+    expect(toggleTaskListItem(input, 3, true)).toBe(input)
+  })
+})
 
 describe('getAutoContinueEdit', () => {
   it('should return null if no pattern matches', () => {
@@ -428,6 +535,41 @@ describe('getAutoContinueEdit', () => {
       range: {
         startColumn: 9,
         endColumn: 9,
+      },
+    })
+  })
+
+  it('should return exit action for empty task list item', () => {
+    const result = getAutoContinueEdit('- [ ] ', 7)
+    expect(result).toEqual<AutoContinueResult>({
+      action: 'exit',
+      range: {
+        startColumn: 1,
+        endColumn: 7,
+      },
+    })
+  })
+
+  it('should continue unchecked task list', () => {
+    const result = getAutoContinueEdit('- [ ] todo', 11)
+    expect(result).toEqual<AutoContinueResult>({
+      action: 'continue',
+      text: '\n- [ ] ',
+      range: {
+        startColumn: 11,
+        endColumn: 11,
+      },
+    })
+  })
+
+  it('should continue checked task list', () => {
+    const result = getAutoContinueEdit('- [x] done', 11)
+    expect(result).toEqual<AutoContinueResult>({
+      action: 'continue',
+      text: '\n- [x] ',
+      range: {
+        startColumn: 11,
+        endColumn: 11,
       },
     })
   })

--- a/packages/app/src/utils/formatting.ts
+++ b/packages/app/src/utils/formatting.ts
@@ -279,6 +279,82 @@ export function formatNumberedList(editor: EditorPaneHandle | null): void {
   })
 }
 
+/**
+ * Formats selected text as a task list or removes existing task formatting
+ * @param editor - Editor instance handle
+ * @returns void
+ */
+export function formatTaskList(editor: EditorPaneHandle | null): void {
+  if (!editor) return
+
+  applyLineFormatting({
+    editor,
+    placeholder: '- [ ] ',
+    transform: (lines) => {
+      const processableLines = lines.filter((line) => line.trim().length > 0)
+      const isTaskList =
+        processableLines.length > 0 &&
+        processableLines.every((line) => /^\s*[-*+]\s+\[[ xX]\]\s/.test(line))
+      const isBulletList =
+        !isTaskList &&
+        processableLines.length > 0 &&
+        processableLines.every((line) => /^\s*[-*+]\s/.test(line))
+      const isNumberedList =
+        !isTaskList &&
+        !isBulletList &&
+        processableLines.length > 0 &&
+        processableLines.every((line) => /^\s*\d+\.\s/.test(line))
+
+      return lines.map((line) => {
+        if (line.trim().length === 0) return line
+
+        if (isTaskList) {
+          return line.replace(/^(\s*)[-*+]\s+\[[ xX]\]\s*/, '$1')
+        }
+
+        if (isBulletList) {
+          return line.replace(/^(\s*)[-*+]\s+/, '$1- [ ] ')
+        }
+
+        if (isNumberedList) {
+          return line.replace(/^(\s*)\d+\.\s+/, '$1- [ ] ')
+        }
+
+        return `- [ ] ${line}`
+      })
+    },
+  })
+}
+
+/**
+ * Toggles a task list checkbox marker by rendered task index.
+ * @param markdown - Source markdown
+ * @param taskIndex - Zero-based index of task item in render order
+ * @param checked - Next checked state
+ * @returns Updated markdown
+ */
+export function toggleTaskListItem(markdown: string, taskIndex: number, checked: boolean): string {
+  if (!markdown || taskIndex < 0) return markdown
+
+  const lines = markdown.split('\n')
+  let currentTaskIndex = 0
+
+  const updatedLines = lines.map((line) => {
+    const taskMatch = line.match(/^(\s*[-*+]\s+\[)([ xX])(\])(.*)$/)
+    if (!taskMatch) return line
+
+    if (currentTaskIndex !== taskIndex) {
+      currentTaskIndex += 1
+      return line
+    }
+
+    currentTaskIndex += 1
+    return `${taskMatch[1]}${checked ? 'x' : ' '}${taskMatch[3]}${taskMatch[4]}`
+  })
+
+  return updatedLines.join('\n')
+}
+
 export interface AutoContinueResult {
   action: 'exit' | 'continue'
   text?: string
@@ -303,6 +379,8 @@ export function getAutoContinueEdit(
   const beforeCursor = lineContent.substring(0, cursorColumn - 1)
 
   // Patterns
+  const taskListPattern = /^(\s*)[-*+]\s+\[[ xX]\]\s*$/
+  const taskListContentPattern = /^(\s*)([-*+])\s+\[([ xX])\]\s+(.+)/
   const unorderedListPattern = /^(\s*)[-*+]\s+$/
   const unorderedListContentPattern = /^(\s*)([-*+])\s+(.+)/
   const orderedListPattern = /^(\s*)(\d+)\.\s+$/
@@ -312,6 +390,7 @@ export function getAutoContinueEdit(
 
   // Check for empty list/quote (to exit)
   if (
+    taskListPattern.test(beforeCursor) ||
     unorderedListPattern.test(beforeCursor) ||
     orderedListPattern.test(beforeCursor) ||
     quotePattern.test(beforeCursor)
@@ -326,6 +405,21 @@ export function getAutoContinueEdit(
   }
 
   // Check for content (to continue)
+  const taskListMatch = beforeCursor.match(taskListContentPattern)
+  if (taskListMatch) {
+    const indent = taskListMatch[1]
+    const prefix = taskListMatch[2]
+    const state = taskListMatch[3].toLowerCase() === 'x' ? 'x' : ' '
+    return {
+      action: 'continue',
+      text: `\n${indent}${prefix} [${state}] `,
+      range: {
+        startColumn: cursorColumn,
+        endColumn: cursorColumn,
+      },
+    }
+  }
+
   const ulMatch = beforeCursor.match(unorderedListContentPattern)
   if (ulMatch) {
     const indent = ulMatch[1]

--- a/packages/app/src/utils/formatting.ts
+++ b/packages/app/src/utils/formatting.ts
@@ -219,16 +219,25 @@ export function formatBulletList(editor: EditorPaneHandle | null): void {
     placeholder: '- ',
     transform: (lines) => {
       const processableLines = lines.filter((line) => line.trim().length > 0)
+      const isTaskList =
+        processableLines.length > 0 &&
+        processableLines.every((line) => /^\s*[-*+]\s+\[[ xX]\]\s/.test(line))
       const isBulletList =
-        processableLines.length > 0 && processableLines.every((line) => /^\s*[-*]\s/.test(line))
+        !isTaskList &&
+        processableLines.length > 0 &&
+        processableLines.every((line) => /^\s*[-*]\s/.test(line))
       const isNumberedList =
         !isBulletList &&
+        !isTaskList &&
         processableLines.length > 0 &&
         processableLines.every((line) => /^\s*\d+\.\s/.test(line))
 
       return lines.map((line) => {
         if (line.trim().length === 0) return line
 
+        if (isTaskList) {
+          return line.replace(/^(\s*)[-*+]\s+\[[ xX]\]\s+/, '$1- ')
+        }
         if (isBulletList) {
           return line.replace(/^(\s*)([-*]\s+)/, '$1')
         }
@@ -254,9 +263,13 @@ export function formatNumberedList(editor: EditorPaneHandle | null): void {
     placeholder: '1. ',
     transform: (lines) => {
       const processableLines = lines.filter((line) => line.trim().length > 0)
+      const isTaskList =
+        processableLines.length > 0 &&
+        processableLines.every((line) => /^\s*[-*+]\s+\[[ xX]\]\s/.test(line))
       const isNumberedList =
         processableLines.length > 0 && processableLines.every((line) => /^\s*\d+\.\s/.test(line))
       const isBulletList =
+        !isTaskList &&
         !isNumberedList &&
         processableLines.length > 0 &&
         processableLines.every((line) => /^\s*[-*]\s/.test(line))
@@ -270,6 +283,9 @@ export function formatNumberedList(editor: EditorPaneHandle | null): void {
         }
 
         const prefix = `${counter++}. `
+        if (isTaskList) {
+          return line.replace(/^(\s*)[-*+]\s+\[[ xX]\]\s+/, `$1${prefix}`)
+        }
         if (isBulletList) {
           return line.replace(/^(\s*)([-*]\s+)/, `$1${prefix}`)
         }

--- a/packages/app/src/utils/githubSafeHtml.test.ts
+++ b/packages/app/src/utils/githubSafeHtml.test.ts
@@ -7,6 +7,7 @@ describe('sanitizeGithubSafeHtml', () => {
       <details open>
         <summary>See more</summary>
         <div align="center" data-raw-code="graph TD;A--&gt;B;">
+          <input type="checkbox" class="task-list-item-checkbox" checked data-task-index="0" />
           <kbd>Ctrl</kbd> + <kbd>C</kbd>
           <img src="/image.png" alt="Preview" width="240" />
         </div>
@@ -18,6 +19,9 @@ describe('sanitizeGithubSafeHtml', () => {
     expect(sanitized).toContain('<details open="">')
     expect(sanitized).toContain('<summary>See more</summary>')
     expect(sanitized).toContain('<div align="center" data-raw-code="graph TD;A-->B;">')
+    expect(sanitized).toContain(
+      '<input type="checkbox" class="task-list-item-checkbox" checked="" data-task-index="0">'
+    )
     expect(sanitized).toContain('<kbd>Ctrl</kbd>')
     expect(sanitized).toContain('<img src="/image.png" alt="Preview" width="240">')
   })
@@ -43,5 +47,12 @@ describe('sanitizeGithubSafeHtml', () => {
     const html = '<section><p><strong>hello</strong> world</p></section>'
     const sanitized = sanitizeGithubSafeHtml(html)
     expect(sanitized).toBe('<p><strong>hello</strong> world</p>')
+  })
+
+  it('removes non-checkbox input elements', () => {
+    const html = '<input type="text" value="x"><input type="checkbox" checked>'
+    const sanitized = sanitizeGithubSafeHtml(html)
+
+    expect(sanitized).toBe('<input type="checkbox" checked="">')
   })
 })

--- a/packages/app/src/utils/githubSafeHtml.ts
+++ b/packages/app/src/utils/githubSafeHtml.ts
@@ -16,6 +16,7 @@ const ALLOWED_TAGS = new Set([
   'hr',
   'img',
   'ins',
+  'input',
   'kbd',
   'li',
   'mark',
@@ -40,8 +41,10 @@ const DROP_CONTENT_TAGS = new Set(['embed', 'form', 'iframe', 'object', 'script'
 
 const GLOBAL_ALLOWED_ATTRIBUTES = new Set([
   'align',
+  'aria-label',
   'class',
   'data-language',
+  'data-task-index',
   'data-raw-code',
   'title',
 ])
@@ -49,6 +52,7 @@ const TAG_ALLOWED_ATTRIBUTES: Record<string, Set<string>> = {
   a: new Set(['href', 'title']),
   details: new Set(['open']),
   img: new Set(['align', 'alt', 'height', 'src', 'title', 'width']),
+  input: new Set(['checked', 'disabled', 'type']),
   li: new Set(['value']),
   ol: new Set(['start']),
   td: new Set(['align', 'colspan', 'rowspan']),
@@ -108,6 +112,16 @@ function sanitizeAttributes(element: Element): void {
     if (URL_ATTRIBUTE_NAMES.has(attributeName) && !isSafeUrl(attributeValue)) {
       element.removeAttribute(attribute.name)
     }
+  }
+
+  if (tagName === 'input') {
+    const inputType = (element.getAttribute('type') ?? '').toLowerCase()
+    if (inputType !== 'checkbox') {
+      element.remove()
+      return
+    }
+
+    element.setAttribute('type', 'checkbox')
   }
 }
 

--- a/packages/app/src/utils/htmlExport.test.ts
+++ b/packages/app/src/utils/htmlExport.test.ts
@@ -20,6 +20,8 @@ describe('htmlExport', () => {
     )
     expect(result).toContain('fonts.googleapis.com/css2?family=Crimson+Text')
     expect(result).toContain('preview-code-copy-button')
+    expect(result).toContain('.markdown-body .contains-task-list')
+    expect(result).toContain('.markdown-body .task-list-item > .task-list-item-checkbox')
     expect(result).not.toContain('github-markdown-dark.min.css')
   })
 
@@ -88,6 +90,8 @@ describe('htmlExport', () => {
     expect(result).toContain('.markdown-body details > *')
     expect(result).toContain(".markdown-body svg[id^='mermaid-'] text")
     expect(result).toContain('.markdown-body pre code *')
+    expect(result).toContain('.markdown-body .contains-task-list')
+    expect(result).toContain('.markdown-body .task-list-item > .task-list-item-checkbox')
     expect(result).toContain('.markdown-body table,')
     expect(result).toContain(
       ".markdown-body .code-block-with-language[data-language='mermaid'] svg .label"

--- a/packages/app/src/utils/htmlExport.ts
+++ b/packages/app/src/utils/htmlExport.ts
@@ -509,6 +509,20 @@ ${codeSyntaxVariables}
         padding: 15px;
       }
     }
+    .markdown-body .contains-task-list {
+      list-style: none;
+      padding-left: 1.4rem;
+    }
+    .markdown-body .task-list-item {
+      list-style: none;
+    }
+    .markdown-body .task-list-item > .task-list-item-checkbox {
+      margin: 0 0.5rem 0.1rem 0;
+      inline-size: 0.95rem;
+      block-size: 0.95rem;
+      vertical-align: middle;
+      accent-color: var(--fgColor-accent);
+    }
     .markdown-body pre {
       margin: 1rem 0;
       overflow: hidden;
@@ -828,6 +842,21 @@ ${codeSyntaxVariables}
       }
       .markdown-body li {
         margin: 0.2rem 0;
+      }
+      .markdown-body .contains-task-list {
+        list-style: none;
+        padding-left: 1.4rem;
+      }
+      .markdown-body .task-list-item {
+        list-style: none;
+      }
+      .markdown-body .task-list-item > .task-list-item-checkbox {
+        margin: 0 0.5rem 0.1rem 0;
+        inline-size: 0.95rem;
+        block-size: 0.95rem;
+        vertical-align: middle;
+        pointer-events: none;
+        accent-color: #000;
       }
       .markdown-body a {
         color: #000 !important;

--- a/packages/app/src/utils/markdown.test.ts
+++ b/packages/app/src/utils/markdown.test.ts
@@ -53,6 +53,19 @@ describe('renderMarkdown', () => {
     expect(html).toContain('<a href="https://example.com">link</a>')
   })
 
+  it('should render task list items as checkbox inputs', () => {
+    const markdown = '- [ ] todo\n- [x] done'
+    const html = renderMarkdown(markdown)
+
+    expect(html).toContain('<ul class="contains-task-list">')
+    expect(html).toContain('<li class="task-list-item">')
+    expect(html).toContain(
+      '<input type="checkbox" class="task-list-item-checkbox" data-task-index="0"'
+    )
+    expect(html).toContain('data-task-index="1"')
+    expect(html).toContain('checked=""')
+  })
+
   it('should render supported safe html tags in markdown', () => {
     const markdown = '<details><summary>More</summary><kbd>Cmd</kbd> + <kbd>K</kbd></details>'
     const html = renderMarkdown(markdown)

--- a/packages/app/src/utils/markdown.ts
+++ b/packages/app/src/utils/markdown.ts
@@ -117,6 +117,58 @@ function renderGithubCallouts(html: string): string {
   return document.body.innerHTML
 }
 
+function renderTaskLists(html: string): string {
+  if (!html || typeof DOMParser === 'undefined') return html
+
+  const parser = new DOMParser()
+  const document = parser.parseFromString(`<body>${html}</body>`, 'text/html')
+  const listItems = Array.from(document.body.querySelectorAll('li'))
+  let taskIndex = 0
+
+  for (const listItem of listItems) {
+    const firstElement = listItem.firstElementChild
+    const container =
+      firstElement && firstElement.tagName.toLowerCase() === 'p' ? firstElement : listItem
+    const walker = document.createTreeWalker(container, NodeFilter.SHOW_TEXT)
+
+    let firstTextNode: Text | null = null
+    while (walker.nextNode()) {
+      const candidate = walker.currentNode as Text
+      const candidateText = candidate.textContent ?? ''
+      if (candidateText.trim().length === 0) continue
+      firstTextNode = candidate
+      break
+    }
+
+    if (!firstTextNode) continue
+
+    const initialText = firstTextNode.textContent ?? ''
+    const taskPrefixMatch = initialText.match(/^(\s*)\[([ xX])\](\s+|$)/)
+    if (!taskPrefixMatch) continue
+
+    const checked = taskPrefixMatch[2].toLowerCase() === 'x'
+    firstTextNode.textContent = initialText.slice(taskPrefixMatch[0].length)
+
+    const checkbox = document.createElement('input')
+    checkbox.setAttribute('type', 'checkbox')
+    checkbox.setAttribute('class', 'task-list-item-checkbox')
+    checkbox.setAttribute('data-task-index', String(taskIndex))
+    checkbox.setAttribute('aria-label', `Toggle task ${taskIndex + 1}`)
+    if (checked) checkbox.setAttribute('checked', '')
+
+    container.insertBefore(checkbox, firstTextNode)
+    container.insertBefore(document.createTextNode(' '), firstTextNode)
+
+    listItem.classList.add('task-list-item')
+    const parentList = listItem.closest('ul,ol')
+    if (parentList) parentList.classList.add('contains-task-list')
+
+    taskIndex += 1
+  }
+
+  return document.body.innerHTML
+}
+
 const defaultFenceRenderer = md.renderer.rules.fence?.bind(md.renderer.rules)
 
 md.renderer.rules.fence = (tokens, idx, options, env, self): string => {
@@ -148,7 +200,8 @@ export function renderMarkdown(markdown: string): string {
   if (!markdown) return ''
   const html = md.render(markdown)
   const withGithubCallouts = renderGithubCallouts(html)
-  return sanitizeGithubSafeHtml(withGithubCallouts)
+  const withTaskLists = renderTaskLists(withGithubCallouts)
+  return sanitizeGithubSafeHtml(withTaskLists)
 }
 
 /**


### PR DESCRIPTION
Implements interactive task list functionality with checkbox rendering and state management.

- Added `formatTaskList()` function to convert text to task list format or toggle existing task list markers.
- Added `toggleTaskListItem()` function to update task checkbox state by index in markdown source.
- Integrated task list checkbox rendering in preview pane with click handlers to update source markdown.
- Extended auto-continue editing to preserve task list checked state when pressing Enter on list items.
- Added task list formatting button to editor toolbar as a dropdown menu option alongside bullet and numbered lists.
- Updated markdown rendering to parse task list syntax (`- [ ]` / `- [x]`) and render as native HTML checkboxes with `data-task-index` attributes.
- Added styling for task list containers and checkboxes in print mode and standard preview.
- Extended GitHub-safe HTML sanitisation to allow checkbox input elements with task list attributes.
- Updated feature documentation to reflect task list support including bullet, numbered, and task list formatting.
