### PR TITLE
fix(emoji): Support GitHub-style shortcodes in headings and favicons

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -22,7 +22,7 @@ Poe includes standard Markdown editor functionality and a set of unique features
 | URL-based document persistence             | Content is compressed into the URL hash; no login or backend storage required.              |
 | Share links with readable metadata         | Shared URLs include a title/snippet path plus compressed hash payload.                      |
 | Share preview hero images                  | Social previews can use `?hero=<image-url>`; when multiple doc images exist, first is used. |
-| Dynamic title + emoji favicon from content | First heading drives page title; fallback prefers file name, then shared URL title.         |
+| Dynamic title + emoji favicon from content | First heading drives page title; supports Unicode emoji and GitHub-style shortcodes (e.g., `:smile:`) for favicon/title parsing; fallback prefers file name, then shared URL title. |
 | URL length safety + testing override       | Over-limit warnings are surfaced; `?limit=<n>` can override max length for testing.         |
 | Persisted editor preferences               | Vim mode, line numbers, word count, spell check, and start-empty preference persist.        |
 | App reset                                  | Reset app state is available (saved transformers are intentionally preserved).              |

--- a/packages/app/src/hooks/useUrlState.test.ts
+++ b/packages/app/src/hooks/useUrlState.test.ts
@@ -2,10 +2,15 @@ import { renderHook, act } from '@testing-library/react'
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { useUrlState } from './useUrlState'
 import * as compression from '../utils/compression'
+import * as emojiShortcodes from '@/utils/emojiShortcodes'
 
 vi.mock('../utils/compression', () => ({
   compressDocumentToHash: vi.fn(),
   decompressDocumentFromHash: vi.fn(),
+}))
+
+vi.mock('@/utils/emojiShortcodes', () => ({
+  getEmojiForShortcode: vi.fn(),
 }))
 
 describe('useUrlState', () => {
@@ -16,6 +21,7 @@ describe('useUrlState', () => {
 
     // Mock window.scrollTo to avoid jsdom errors if any
     window.scrollTo = vi.fn()
+    vi.mocked(emojiShortcodes.getEmojiForShortcode).mockResolvedValue(null)
   })
 
   it('should initialize with default content', () => {
@@ -204,6 +210,62 @@ describe('useUrlState', () => {
     // originalFavicons stores sizes: ''
     // if (sizes) check fails for empty string, so removeAttribute called
     expect(mockLinks[1].removeAttribute).toHaveBeenCalledWith('sizes')
+
+    vi.useRealTimers()
+    querySelectorAllSpy.mockRestore()
+  })
+
+  it('should resolve heading emoji shortcodes for favicon updates', async () => {
+    vi.useFakeTimers()
+    vi.mocked(emojiShortcodes.getEmojiForShortcode).mockResolvedValue('😄')
+
+    const mockLinks = [
+      {
+        href: '/favicon-32x32.png',
+        rel: 'icon',
+        type: 'image/png',
+        sizes: { value: '32x32' },
+        setAttribute: vi.fn(),
+        removeAttribute: vi.fn(),
+      },
+      {
+        href: '/favicon.ico',
+        rel: 'icon',
+        type: 'image/x-icon',
+        sizes: { value: '' },
+        setAttribute: vi.fn(),
+        removeAttribute: vi.fn(),
+      },
+    ] as unknown as HTMLLinkElement[]
+
+    const querySelectorAllSpy = vi
+      .spyOn(document, 'querySelectorAll')
+      .mockReturnValue(mockLinks as unknown as NodeListOf<HTMLLinkElement>)
+
+    const { result } = renderHook(() => useUrlState())
+    vi.mocked(compression.compressDocumentToHash).mockReturnValue('hash')
+
+    act(() => {
+      result.current.setContent('# :smile: foo\nContent')
+    })
+
+    act(() => {
+      vi.advanceTimersByTime(500)
+    })
+
+    await act(async () => {
+      await Promise.resolve()
+    })
+
+    expect(emojiShortcodes.getEmojiForShortcode).toHaveBeenCalledWith(':smile:')
+    expect(document.title).toBe('foo')
+
+    mockLinks.forEach((link) => {
+      expect(link.href).toMatch(/^data:image\/svg\+xml/)
+      expect(decodeURIComponent(link.href)).toContain('😄')
+      expect(link.type).toBe('image/svg+xml')
+      expect(link.removeAttribute).toHaveBeenCalledWith('sizes')
+    })
 
     vi.useRealTimers()
     querySelectorAllSpy.mockRestore()

--- a/packages/app/src/hooks/useUrlState.ts
+++ b/packages/app/src/hooks/useUrlState.ts
@@ -1,6 +1,7 @@
 import { useState, useEffect, useCallback, useRef } from 'react'
 import { getFirstHeading } from '@/utils/markdown'
-import { extractFirstEmoji } from '@/utils/emoji'
+import { extractFirstEmojiToken, isEmojiShortcodeToken } from '@/utils/emoji'
+import { getEmojiForShortcode } from '@/utils/emojiShortcodes'
 import {
   compressDocumentToHash,
   decompressDocumentFromHash,
@@ -34,7 +35,7 @@ interface FaviconState {
 
 interface ResolvedTitleState {
   title: string
-  emoji: string | null
+  emojiToken: string | null
 }
 
 /**
@@ -109,22 +110,22 @@ function resolveDocumentTitle(
   const heading = getFirstHeading(content)
 
   if (heading) {
-    const emoji = extractFirstEmoji(heading)
-    const headingTitle = emoji ? heading.replace(emoji, '').trim() : heading
+    const emojiToken = extractFirstEmojiToken(heading)
+    const headingTitle = emojiToken ? heading.replace(emojiToken, '').trim() : heading
 
     if (headingTitle) {
-      return { title: headingTitle, emoji }
+      return { title: headingTitle, emojiToken }
     }
 
     return {
       title: resolveFallbackTitle(documentName, defaultName, pathname),
-      emoji,
+      emojiToken,
     }
   }
 
   return {
     title: resolveFallbackTitle(documentName, defaultName, pathname),
-    emoji: null,
+    emojiToken: null,
   }
 }
 
@@ -202,24 +203,56 @@ export function useUrlState(options?: UseUrlStateOptions): UseUrlStateReturn {
   const contentRef = useRef(content)
   const documentNameRef = useRef(documentName)
   const originalFaviconsRef = useRef<FaviconState[] | null>(null)
+  const faviconUpdateRequestRef = useRef(0)
+
+  const applyDocumentChrome = useCallback(
+    (nextContent: string, nextDocumentName: string): void => {
+      const { title, emojiToken } = resolveDocumentTitle(
+        nextContent,
+        nextDocumentName,
+        defaultName,
+        window.location.pathname
+      )
+      document.title = title
+
+      const requestId = faviconUpdateRequestRef.current + 1
+      faviconUpdateRequestRef.current = requestId
+
+      const applyFaviconIfLatest = (emoji: string | null): void => {
+        if (faviconUpdateRequestRef.current !== requestId) return
+        updateFavicon(emoji, originalFaviconsRef)
+      }
+
+      if (!emojiToken) {
+        applyFaviconIfLatest(null)
+        return
+      }
+
+      if (!isEmojiShortcodeToken(emojiToken)) {
+        applyFaviconIfLatest(emojiToken)
+        return
+      }
+
+      void getEmojiForShortcode(emojiToken)
+        .then((emoji) => {
+          applyFaviconIfLatest(emoji)
+        })
+        .catch(() => {
+          applyFaviconIfLatest(null)
+        })
+    },
+    [defaultName]
+  )
 
   // Initialize title and favicon on mount
   const initializedRef = useRef(false)
   useEffect(() => {
     if (!initializedRef.current) {
-      const { title, emoji } = resolveDocumentTitle(
-        content,
-        documentName,
-        defaultName,
-        window.location.pathname
-      )
-
-      updateFavicon(emoji, originalFaviconsRef)
-      document.title = title
+      applyDocumentChrome(content, documentName)
 
       initializedRef.current = true
     }
-  }, [content, defaultName, documentName])
+  }, [applyDocumentChrome, content, documentName])
 
   // Keep refs in sync with state
   useEffect(() => {
@@ -243,14 +276,7 @@ export function useUrlState(options?: UseUrlStateOptions): UseUrlStateReturn {
       }
 
       // Update document title and favicon from first heading
-      const { title, emoji } = resolveDocumentTitle(
-        contentRef.current,
-        documentNameRef.current,
-        defaultName,
-        window.location.pathname
-      )
-      updateFavicon(emoji, originalFaviconsRef)
-      document.title = title
+      applyDocumentChrome(contentRef.current, documentNameRef.current)
 
       const compressed = compressDocumentToHash(docData)
       const overLimit = compressed.length > maxLength
@@ -284,7 +310,7 @@ export function useUrlState(options?: UseUrlStateOptions): UseUrlStateReturn {
       // We use replaceState to update the URL without adding a new history entry for every keystroke
       window.history.replaceState(null, '', newUrl.toString())
     }, debounceMs)
-  }, [debounceMs, defaultName, maxLength, onLengthWarning])
+  }, [applyDocumentChrome, debounceMs, maxLength, onLengthWarning])
 
   // Handle external hash changes (e.g., back/forward navigation)
   useEffect(() => {
@@ -294,14 +320,7 @@ export function useUrlState(options?: UseUrlStateOptions): UseUrlStateReturn {
       const updateStateAndTitle = (newContent: string, newName: string) => {
         setContentState(newContent)
         setDocumentNameState(newName)
-        const { title, emoji } = resolveDocumentTitle(
-          newContent,
-          newName,
-          defaultName,
-          window.location.pathname
-        )
-        updateFavicon(emoji, originalFaviconsRef)
-        document.title = title
+        applyDocumentChrome(newContent, newName)
       }
 
       if (!hash) {
@@ -330,7 +349,7 @@ export function useUrlState(options?: UseUrlStateOptions): UseUrlStateReturn {
         clearTimeout(timeoutRef.current)
       }
     }
-  }, [defaultContent, defaultName, onError])
+  }, [applyDocumentChrome, defaultContent, defaultName, onError])
 
   const setContent = useCallback(
     (newContent: string) => {

--- a/packages/app/src/utils/emoji.test.ts
+++ b/packages/app/src/utils/emoji.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { extractFirstEmoji } from './emoji'
+import { extractFirstEmoji, extractFirstEmojiToken, isEmojiShortcodeToken } from './emoji'
 
 describe('extractFirstEmoji', () => {
   it('should return null for empty string/null/undefined', () => {
@@ -47,5 +47,37 @@ describe('extractFirstEmoji', () => {
 
     // Test base emoji
     expect(extractFirstEmoji('👍')).toBe('👍')
+  })
+})
+
+describe('extractFirstEmojiToken', () => {
+  it('returns first unicode emoji token', () => {
+    expect(extractFirstEmojiToken('Hello 🚀 world')).toBe('🚀')
+  })
+
+  it('returns first shortcode token', () => {
+    expect(extractFirstEmojiToken('Hello :smile: world')).toBe(':smile:')
+  })
+
+  it('returns whichever token appears first', () => {
+    expect(extractFirstEmojiToken(':smile: and 🚀')).toBe(':smile:')
+    expect(extractFirstEmojiToken('🚀 and :smile:')).toBe('🚀')
+  })
+
+  it('returns null when no token exists', () => {
+    expect(extractFirstEmojiToken('plain heading')).toBeNull()
+  })
+})
+
+describe('isEmojiShortcodeToken', () => {
+  it('detects valid shortcode tokens', () => {
+    expect(isEmojiShortcodeToken(':smile:')).toBe(true)
+    expect(isEmojiShortcodeToken(':+1:')).toBe(true)
+  })
+
+  it('rejects invalid shortcode tokens', () => {
+    expect(isEmojiShortcodeToken('smile')).toBe(false)
+    expect(isEmojiShortcodeToken(':smile')).toBe(false)
+    expect(isEmojiShortcodeToken('smile:')).toBe(false)
   })
 })

--- a/packages/app/src/utils/emoji.ts
+++ b/packages/app/src/utils/emoji.ts
@@ -1,3 +1,6 @@
+const UNICODE_EMOJI_PATTERN = /\p{Extended_Pictographic}/u
+const SHORTCODE_EMOJI_PATTERN = /:[a-zA-Z0-9_+-]+:/
+
 /**
  * Extracts the first emoji from the given text.
  * Uses Unicode property escapes to detect extended pictographics.
@@ -17,8 +20,42 @@ export function extractFirstEmoji(text: string): string | null {
   // but for a favicon extractor, this is usually sufficient.
   //
   // Capturing the first match.
-  const regex = /\p{Extended_Pictographic}/u
-  const match = text.match(regex)
+  const match = text.match(UNICODE_EMOJI_PATTERN)
 
   return match ? match[0] : null
+}
+
+/**
+ * Checks whether the provided token is an emoji shortcode token like `:smile:`.
+ * @param token - Candidate emoji token.
+ * @returns `true` when the token is a shortcode token.
+ */
+export function isEmojiShortcodeToken(token: string): boolean {
+  return /^:[a-zA-Z0-9_+-]+:$/.test(token)
+}
+
+/**
+ * Extracts the first emoji token from text, supporting Unicode emoji and shortcode tokens.
+ * @param text - The text to search.
+ * @returns First emoji token in document order, or null when none exists.
+ */
+export function extractFirstEmojiToken(text: string): string | null {
+  if (!text) return null
+
+  const unicodeMatch = UNICODE_EMOJI_PATTERN.exec(text)
+  const shortcodeMatch = SHORTCODE_EMOJI_PATTERN.exec(text)
+
+  if (!unicodeMatch && !shortcodeMatch) {
+    return null
+  }
+
+  if (!unicodeMatch) {
+    return shortcodeMatch?.[0] ?? null
+  }
+
+  if (!shortcodeMatch) {
+    return unicodeMatch[0]
+  }
+
+  return unicodeMatch.index <= shortcodeMatch.index ? unicodeMatch[0] : shortcodeMatch[0]
 }

--- a/packages/app/src/utils/emojiShortcodes.test.ts
+++ b/packages/app/src/utils/emojiShortcodes.test.ts
@@ -60,4 +60,21 @@ describe('getEmojiShortcodeEntries', () => {
     expect(first).toEqual(second)
     expect(first.map((entry) => entry.shortcode)).toEqual(['+1', 'smile'])
   })
+
+  it('resolves shortcode tokens to emoji', async () => {
+    const emojiDataFactory = vi.fn(() => ({
+      default: {
+        smile: '😄',
+      },
+    }))
+
+    vi.doMock('markdown-it-emoji/lib/data/full.mjs', emojiDataFactory)
+    const { getEmojiForShortcode, resetEmojiShortcodeCacheForTests } =
+      await import('./emojiShortcodes')
+    resetEmojiShortcodeCacheForTests()
+
+    await expect(getEmojiForShortcode(':smile:')).resolves.toBe('😄')
+    await expect(getEmojiForShortcode(':missing:')).resolves.toBeNull()
+    expect(emojiDataFactory).toHaveBeenCalledTimes(1)
+  })
 })

--- a/packages/app/src/utils/emojiShortcodes.ts
+++ b/packages/app/src/utils/emojiShortcodes.ts
@@ -11,6 +11,23 @@ export interface EmojiShortcodeEntry {
 }
 
 let emojiShortcodeEntriesPromise: Promise<EmojiShortcodeEntry[]> | null = null
+let emojiShortcodeMapPromise: Promise<EmojiShortcodeMap> | null = null
+
+async function getEmojiShortcodeMap(): Promise<EmojiShortcodeMap> {
+  if (!emojiShortcodeMapPromise) {
+    emojiShortcodeMapPromise = (async () => {
+      const module = await import('markdown-it-emoji/lib/data/full.mjs')
+      return module.default as EmojiShortcodeMap
+    })()
+  }
+
+  try {
+    return await emojiShortcodeMapPromise
+  } catch (error) {
+    emojiShortcodeMapPromise = null
+    throw error
+  }
+}
 
 /**
  * Lazily loads emoji shortcodes from the markdown-it emoji dataset.
@@ -19,8 +36,7 @@ let emojiShortcodeEntriesPromise: Promise<EmojiShortcodeEntry[]> | null = null
 export async function getEmojiShortcodeEntries(): Promise<EmojiShortcodeEntry[]> {
   if (!emojiShortcodeEntriesPromise) {
     emojiShortcodeEntriesPromise = (async () => {
-      const module = await import('markdown-it-emoji/lib/data/full.mjs')
-      const shortcodeMap = module.default as EmojiShortcodeMap
+      const shortcodeMap = await getEmojiShortcodeMap()
 
       return Object.entries(shortcodeMap)
         .map(([shortcode, emoji]) => ({ shortcode, emoji }))
@@ -34,6 +50,21 @@ export async function getEmojiShortcodeEntries(): Promise<EmojiShortcodeEntry[]>
     emojiShortcodeEntriesPromise = null
     throw error
   }
+}
+
+/**
+ * Resolves a GitHub-style shortcode token to its unicode emoji.
+ * @param shortcodeToken - Shortcode token (for example `:smile:`).
+ * @returns Unicode emoji when found, otherwise `null`.
+ */
+export async function getEmojiForShortcode(shortcodeToken: string): Promise<string | null> {
+  const normalized = shortcodeToken.trim().replace(/^:/, '').replace(/:$/, '')
+  if (!normalized) {
+    return null
+  }
+
+  const shortcodeMap = await getEmojiShortcodeMap()
+  return shortcodeMap[normalized] ?? null
 }
 
 /**
@@ -77,4 +108,5 @@ export function filterEmojiShortcodeEntries(
  */
 export function resetEmojiShortcodeCacheForTests(): void {
   emojiShortcodeEntriesPromise = null
+  emojiShortcodeMapPromise = null
 }


### PR DESCRIPTION
Added support for GitHub-style emoji shortcodes (e.g., `:smile:`) in document headings. The system now detects both Unicode emoji and shortcode tokens, resolves shortcodes asynchronously, and applies the resolved emoji to the document favicon.

- Introduced `extractFirstEmojiToken()` to detect both Unicode and shortcode emoji tokens in order of appearance.
- Added `isEmojiShortcodeToken()` to identify valid shortcode format (`:word:`).
- Implemented `getEmojiForShortcode()` to resolve shortcode tokens to Unicode emoji via the markdown-it emoji dataset.
- Refactored favicon update logic into `applyDocumentChrome()` callback to centralise title and favicon updates with proper async handling.
- Added favicon update request tracking to prevent stale async resolutions from overwriting newer requests.
- Updated FEATURES.md to document shortcode support.
- Added comprehensive test coverage for shortcode detection, validation, and resolution.
