### PR TITLE
fix(vim): Mark end-of-line motions as inclusive

### DIFF
--- a/packages/app/src/components/editor/vim.test.ts
+++ b/packages/app/src/components/editor/vim.test.ts
@@ -73,7 +73,12 @@ describe('setupVim', () => {
       'motion',
       'moveToFirstNonWhitespaceConfigurableLine'
     )
-    expect(vimMocks.mapCommand).toHaveBeenCalledWith('$', 'motion', 'moveToEndOfConfigurableLine')
+    expect(vimMocks.mapCommand).toHaveBeenCalledWith('$', 'motion', 'moveToEndOfConfigurableLine', {
+      inclusive: true,
+    })
+    expect(vimMocks.mapCommand).toHaveBeenCalledWith('g$', 'motion', 'moveToEndOfDisplayLine', {
+      inclusive: true,
+    })
 
     const displayLineOptionCall = vimMocks.defineOption.mock.calls.find(
       ([name]) => name === 'displayline'

--- a/packages/app/src/components/editor/vim.ts
+++ b/packages/app/src/components/editor/vim.ts
@@ -167,9 +167,9 @@ export function setupVim(): void {
 
   Vim.mapCommand('0', 'motion', 'moveToStartOfConfigurableLine')
   Vim.mapCommand('^', 'motion', 'moveToFirstNonWhitespaceConfigurableLine')
-  Vim.mapCommand('$', 'motion', 'moveToEndOfConfigurableLine')
+  Vim.mapCommand('$', 'motion', 'moveToEndOfConfigurableLine', { inclusive: true })
 
-  Vim.mapCommand('g$', 'motion', 'moveToEndOfDisplayLine')
+  Vim.mapCommand('g$', 'motion', 'moveToEndOfDisplayLine', { inclusive: true })
   Vim.mapCommand('g^', 'motion', 'moveToStartOfDisplayLine')
   Vim.mapCommand('g0', 'motion', 'moveToStartOfDisplayLine')
 


### PR DESCRIPTION
Updates Vim motion mappings for end-of-line commands to include the `inclusive` option, which correctly includes the character at the cursor position in the motion selection.

- Added `inclusive: true` option to the `$` motion mapping for `moveToEndOfConfigurableLine`.
- Added `inclusive: true` option to the `g$` motion mapping for `moveToEndOfDisplayLine`.
- Updated corresponding test expectations to verify the new option is passed correctly.
