### PR TITLE
fix(editor): Exit vim visual mode on mouse click

### DIFF
--- a/packages/app/src/components/editor/hooks/useEditorVim.test.ts
+++ b/packages/app/src/components/editor/hooks/useEditorVim.test.ts
@@ -1,0 +1,174 @@
+import { act, renderHook } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { editor } from 'monaco-editor'
+import type { VimMode as VimAdapter } from 'monaco-vim'
+import { useEditorVim } from './useEditorVim'
+
+const { mockHandleKey } = vi.hoisted(() => ({
+  mockHandleKey: vi.fn(),
+}))
+
+vi.mock('monaco-vim', () => ({
+  initVimMode: vi.fn(),
+  VimMode: {
+    Vim: {
+      handleKey: mockHandleKey,
+    },
+  },
+}))
+
+vi.mock('@/hooks/useToast', () => ({
+  toast: vi.fn(),
+}))
+
+vi.mock('../vim', () => ({
+  setupVim: vi.fn(),
+  setVimDisplayLineOption: vi.fn(),
+}))
+
+vi.mock('../vimDisplayLine', () => ({
+  clearDisplayLineEnabledForEditor: vi.fn(),
+}))
+
+interface MockEditor {
+  editor: editor.IStandaloneCodeEditor
+  triggerMouseDown: (event: {
+    leftButton: boolean
+    position?: { lineNumber: number; column: number }
+  }) => void
+  triggerMouseUp: (event: { position?: { lineNumber: number; column: number } }) => void
+  setPosition: ReturnType<typeof vi.fn>
+  setSelection: ReturnType<typeof vi.fn>
+}
+
+const createDisposable = (): { dispose: ReturnType<typeof vi.fn> } => ({
+  dispose: vi.fn(),
+})
+
+const createEditorMock = (): MockEditor => {
+  let mouseDownHandler:
+    | ((event: {
+        event: { leftButton: boolean }
+        target: { position?: { lineNumber: number; column: number } }
+      }) => void)
+    | null = null
+  let mouseUpHandler:
+    | ((event: { target: { position?: { lineNumber: number; column: number } } }) => void)
+    | null = null
+
+  const setPosition = vi.fn()
+  const setSelection = vi.fn()
+
+  const editorMock = {
+    deltaDecorations: vi.fn(() => []),
+    getDomNode: vi.fn(() => document.createElement('div')),
+    getModel: vi.fn(() => null),
+    onDidChangeCursorSelection: vi.fn(() => createDisposable()),
+    onDidChangeModel: vi.fn(() => createDisposable()),
+    onMouseDown: vi.fn((handler) => {
+      mouseDownHandler = handler
+      return createDisposable()
+    }),
+    onMouseUp: vi.fn((handler) => {
+      mouseUpHandler = handler
+      return createDisposable()
+    }),
+    setPosition,
+    setSelection,
+  } as unknown as editor.IStandaloneCodeEditor
+
+  return {
+    editor: editorMock,
+    setPosition,
+    setSelection,
+    triggerMouseDown: ({ leftButton, position }) => {
+      mouseDownHandler?.({
+        event: { leftButton },
+        target: position ? { position } : {},
+      })
+    },
+    triggerMouseUp: ({ position }) => {
+      mouseUpHandler?.({
+        target: position ? { position } : {},
+      })
+    },
+  }
+}
+
+const createVimInstance = (visualMode: boolean): VimAdapter =>
+  ({
+    dispose: vi.fn(),
+    off: vi.fn(),
+    on: vi.fn(),
+    state: {
+      vim: {
+        visualMode,
+      },
+    },
+  }) as unknown as VimAdapter
+
+describe('useEditorVim', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('exits visual mode when clicking to move the cursor', () => {
+    const { editor, triggerMouseDown, triggerMouseUp, setPosition, setSelection } =
+      createEditorMock()
+    const vimInstance = createVimInstance(true)
+
+    renderHook(() =>
+      useEditorVim({
+        editorInstance: editor,
+        editorRef: { current: editor },
+        vimInstanceRef: { current: vimInstance },
+        statusBarRef: { current: document.createElement('div') },
+        vimMode: true,
+      })
+    )
+
+    act(() => {
+      triggerMouseDown({
+        leftButton: true,
+        position: { lineNumber: 3, column: 7 },
+      })
+      triggerMouseUp({
+        position: { lineNumber: 3, column: 7 },
+      })
+    })
+
+    expect(mockHandleKey).toHaveBeenCalledWith(vimInstance, '<Esc>')
+    expect(setPosition).toHaveBeenCalledWith({ lineNumber: 3, column: 7 })
+    expect(setSelection).toHaveBeenCalledOnce()
+  })
+
+  it('ignores clicks when visual mode is already inactive', () => {
+    const { editor, triggerMouseDown, triggerMouseUp, setPosition, setSelection } =
+      createEditorMock()
+    const vimInstance = createVimInstance(false)
+
+    renderHook(() =>
+      useEditorVim({
+        editorInstance: editor,
+        editorRef: { current: editor },
+        vimInstanceRef: { current: vimInstance },
+        statusBarRef: { current: document.createElement('div') },
+        vimMode: true,
+      })
+    )
+
+    act(() => {
+      triggerMouseDown({
+        leftButton: true,
+        position: { lineNumber: 1, column: 1 },
+      })
+      triggerMouseUp({
+        position: { lineNumber: 1, column: 1 },
+      })
+    })
+
+    expect(mockHandleKey).not.toHaveBeenCalled()
+    expect(setPosition).not.toHaveBeenCalled()
+    expect(setSelection).not.toHaveBeenCalled()
+  })
+})

--- a/packages/app/src/components/editor/hooks/useEditorVim.ts
+++ b/packages/app/src/components/editor/hooks/useEditorVim.ts
@@ -1,8 +1,8 @@
 import { useEffect, useRef } from 'react'
-import type { editor } from 'monaco-editor'
-import { initVimMode, type VimMode as VimAdapter } from 'monaco-vim'
+import { Selection, type editor, type IPosition } from 'monaco-editor'
+import { initVimMode, VimMode, type VimMode as VimAdapter } from 'monaco-vim'
 import { toast } from '@/hooks/useToast'
-import type { CodeMirrorAdapter } from '../vimTypes'
+import type { CodeMirrorAdapter, VimModeModule } from '../vimTypes'
 import { setVimDisplayLineOption, setupVim } from '../vim'
 import { clearDisplayLineEnabledForEditor } from '../vimDisplayLine'
 
@@ -22,6 +22,7 @@ interface VimModeChangeEvent {
 interface VimStateWithSelection {
   state?: {
     vim?: {
+      visualMode?: boolean
       sel?: {
         head?: VimCursor
       }
@@ -58,8 +59,26 @@ const getVisualHead = (vim: VimAdapter): VimCursor | null => {
   return isVimCursor(head) ? head : null
 }
 
+const resolveVimApi = (): VimModeModule['Vim'] | null => {
+  if (!VimMode) {
+    return null
+  }
+
+  const { Vim } = VimMode as unknown as VimModeModule
+  return Vim || null
+}
+
 const toCodeMirrorAdapter = (vim: VimAdapter): CodeMirrorAdapter =>
   vim as unknown as CodeMirrorAdapter
+
+const exitVisualModeOnMouseDown = (vim: VimAdapter): void => {
+  const cm = toCodeMirrorAdapter(vim)
+  if (!cm.state.vim.visualMode) {
+    return
+  }
+
+  resolveVimApi()?.handleKey(cm, '<Esc>')
+}
 
 const attachVisualCursorSync = (
   editor: editor.IStandaloneCodeEditor,
@@ -67,6 +86,7 @@ const attachVisualCursorSync = (
 ): (() => void) => {
   let decorationIds: string[] = []
   let isVisualCharMode = false
+  let pendingMouseExitPosition: IPosition | null = null
   const domNode = editor.getDomNode()
 
   const clearDecoration = (): void => {
@@ -147,10 +167,39 @@ const attachVisualCursorSync = (
     }
   })
 
+  const mouseDownDisposable = editor.onMouseDown((event) => {
+    if (!event.event.leftButton || !event.target.position) {
+      return
+    }
+
+    if (!toCodeMirrorAdapter(vim).state.vim.visualMode) {
+      return
+    }
+
+    pendingMouseExitPosition = event.target.position
+    exitVisualModeOnMouseDown(vim)
+  })
+
+  const mouseUpDisposable = editor.onMouseUp((event) => {
+    if (!pendingMouseExitPosition) {
+      return
+    }
+
+    const position = event.target.position ?? pendingMouseExitPosition
+    pendingMouseExitPosition = null
+
+    editor.setPosition(position)
+    editor.setSelection(
+      new Selection(position.lineNumber, position.column, position.lineNumber, position.column)
+    )
+  })
+
   return () => {
     vim.off('vim-mode-change', onModeChange)
     cursorSelectionDisposable.dispose()
     modelChangeDisposable.dispose()
+    mouseDownDisposable.dispose()
+    mouseUpDisposable.dispose()
     clearDecoration()
   }
 }

--- a/packages/app/src/utils/markdown.ts
+++ b/packages/app/src/utils/markdown.ts
@@ -14,16 +14,23 @@ import {
 export type { TocHeading } from '@/utils/markdownHeadings'
 
 type MarkdownItPlugin = (markdown: MarkdownIt) => void
+type EmojiMarkdownModule = {
+  full: MarkdownItPlugin
+}
+type EmojiMarkdownModuleLoader = () => Promise<EmojiMarkdownModule>
 
 const baseMarkdown = createMarkdownIt(false)
 const markdownRenderer = createMarkdownIt(true)
 
 let emojiMarkdownRendererPromise: Promise<MarkdownIt> | null = null
+const defaultEmojiMarkdownModuleLoader: EmojiMarkdownModuleLoader = async () =>
+  (await import('markdown-it-emoji')) as EmojiMarkdownModule
+let emojiMarkdownModuleLoader: EmojiMarkdownModuleLoader = defaultEmojiMarkdownModuleLoader
 
 async function getEmojiMarkdownRenderer(): Promise<MarkdownIt> {
   if (!emojiMarkdownRendererPromise) {
     emojiMarkdownRendererPromise = (async () => {
-      const { full } = await import('markdown-it-emoji')
+      const { full } = await emojiMarkdownModuleLoader()
       const parser = createMarkdownIt(true)
       parser.use(full as MarkdownItPlugin)
       return parser
@@ -98,4 +105,25 @@ export async function renderMarkdownForPreview(markdown: string): Promise<string
  */
 export function getFirstHeading(markdown: string): string | null {
   return getFirstHeadingFromMarkdown(markdown, baseMarkdown)
+}
+
+/**
+ * Overrides the lazy emoji module loader for isolated tests.
+ * @param loader - Test loader to use, or `null` to restore the default loader.
+ * @returns void
+ */
+export function setEmojiMarkdownModuleLoaderForTests(
+  loader: EmojiMarkdownModuleLoader | null
+): void {
+  emojiMarkdownRendererPromise = null
+  emojiMarkdownModuleLoader = loader ?? defaultEmojiMarkdownModuleLoader
+}
+
+/**
+ * Resets the lazy emoji renderer cache and restores the default emoji loader for tests.
+ * @returns void
+ */
+export function resetEmojiMarkdownRendererForTests(): void {
+  emojiMarkdownRendererPromise = null
+  emojiMarkdownModuleLoader = defaultEmojiMarkdownModuleLoader
 }

--- a/packages/app/src/utils/markdownPreviewEmoji.test.ts
+++ b/packages/app/src/utils/markdownPreviewEmoji.test.ts
@@ -34,19 +34,21 @@ describe('renderMarkdownForPreview emoji shortcodes', () => {
 })
 
 describe('renderMarkdownForPreview lazy emoji loading', () => {
-  beforeEach(() => {
-    vi.resetModules()
+  beforeEach(async () => {
+    const { resetEmojiMarkdownRendererForTests } = await import('./markdown')
+    resetEmojiMarkdownRendererForTests()
   })
 
-  afterEach(() => {
-    vi.doUnmock('markdown-it-emoji')
-    vi.resetModules()
+  afterEach(async () => {
+    const { resetEmojiMarkdownRendererForTests } = await import('./markdown')
+    resetEmojiMarkdownRendererForTests()
   })
 
   it('does not import the emoji module when no shortcode pattern exists', async () => {
-    const emojiFactory = vi.fn(() => ({ full: vi.fn() }))
-    vi.doMock('markdown-it-emoji', emojiFactory)
-    const { renderMarkdownForPreview } = await import('./markdown')
+    const emojiFactory = vi.fn(async () => ({ full: vi.fn() }))
+    const { renderMarkdownForPreview, setEmojiMarkdownModuleLoaderForTests } =
+      await import('./markdown')
+    setEmojiMarkdownModuleLoaderForTests(emojiFactory)
 
     await renderMarkdownForPreview('No shortcode candidates in this markdown content.')
 
@@ -55,9 +57,10 @@ describe('renderMarkdownForPreview lazy emoji loading', () => {
 
   it('imports the emoji module when shortcode pattern exists', async () => {
     const emojiPlugin = vi.fn()
-    const emojiFactory = vi.fn(() => ({ full: emojiPlugin }))
-    vi.doMock('markdown-it-emoji', emojiFactory)
-    const { renderMarkdownForPreview } = await import('./markdown')
+    const emojiFactory = vi.fn(async () => ({ full: emojiPlugin }))
+    const { renderMarkdownForPreview, setEmojiMarkdownModuleLoaderForTests } =
+      await import('./markdown')
+    setEmojiMarkdownModuleLoaderForTests(emojiFactory)
 
     await renderMarkdownForPreview('Has :smile: shortcode candidate.')
 


### PR DESCRIPTION
Adds functionality to exit Vim visual mode when the user clicks to reposition the cursor in the editor.

- Implemented mouse down and mouse up event handlers to detect clicks during visual mode.
- When a left mouse button click occurs in visual mode, the escape key is triggered to exit visual mode.
- The cursor is then positioned at the clicked location with proper selection handling.
- Added comprehensive unit tests covering visual mode exit and inactive mode scenarios.
- Extracted Vim API resolution into a dedicated function for improved code organisation.

