### PR TITLE
chore(wrangler): Configure assets directory for distribution

### DIFF
--- a/packages/app/wrangler.jsonc
+++ b/packages/app/wrangler.jsonc
@@ -3,6 +3,7 @@
   "name": "poe-editor",
   "compatibility_date": "2025-01-30",
   "assets": {
+    "directory": "./dist",
     "not_found_handling": "single-page-application",
   },
   "routes": [


### PR DESCRIPTION
Specifies the `./dist` directory as the assets source for Cloudflare Workers, ensuring static files are properly bundled and served.

- Added missing `directory` property to the assets configuration.
- Resolves asset loading issues in the deployed application.
