### PR TITLE
fix(formatting): Quote blank lines in multi-line selection

### DIFF
--- a/packages/app/src/utils/formatting.test.ts
+++ b/packages/app/src/utils/formatting.test.ts
@@ -217,6 +217,14 @@ describe('formatting utils', () => {
       expect(replaceSelectionMock).toHaveBeenCalledWith('> line 1\n> line 2')
     })
 
+    it('quotes blank lines between content lines', () => {
+      setMultilineInput('line 1\n\nline 2')
+
+      formatQuote(mockEditor)
+
+      expect(replaceSelectionMock).toHaveBeenCalledWith('> line 1\n> \n> line 2')
+    })
+
     it('inserts quote marker on empty line', () => {
       setSingleLine('')
 

--- a/packages/app/src/utils/formatting.ts
+++ b/packages/app/src/utils/formatting.ts
@@ -202,9 +202,9 @@ export function formatQuote(editor: EditorPaneHandle | null): void {
     editor,
     placeholder: '> ',
     transform: (lines) =>
-      lines.map((line) => {
-        // Skip empty lines to avoid trailing > on selection end
-        if (line.trim().length === 0) return line
+      lines.map((line, i) => {
+        // Skip trailing empty line to avoid extra > at selection end
+        if (i === lines.length - 1 && line.trim().length === 0) return line
         // We could strip existing quotes here if we wanted toggle behavior,
         // but preserving existing behavior of just adding > for now,
         // unless it's just a raw add.


### PR DESCRIPTION
Selecting multiple lines and applying quote formatting now correctly quotes blank lines between content.

Previously, `formatQuote` skipped all empty lines, leaving them without the `>` prefix. This meant a selection like:

```
line 1

line 2
```

Would produce:

```
> line 1

> line 2
```

Instead of the correct:

```
> line 1
> 
> line 2
```

- Update `formatQuote` to only skip the trailing empty line (which represents a cursor at the start of a new line after selection) instead of all empty lines
- Add unit test covering blank lines between content lines

**Risk:** Low — scoped change to a single formatting utility function with no side effects.