### PR TITLE
fix(build): Make husky prepare script fail gracefully in CI

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "test:e2e": "npm run test:e2e -w packages/app",
     "deploy:app": "npm run deploy -w packages/app",
     "deploy:proxy": "npm run deploy -w packages/proxy",
-    "prepare": "husky"
+    "prepare": "husky || true"
   },
   "lint-staged": {
     "*.{ts,tsx}": [


### PR DESCRIPTION
Fix Cloudflare Pages build failures caused by `npm clean-install` [^1]. 

- The `prepare` script now falls back gracefully when `husky` is not found, allowing CI builds to complete.
- Local development is unaffected as husky installs and runs normally.

[^1]: Failed because the `prepare` script runs `husky`, which is not available in the CI environment.