### PR TITLE
feat(fake-shell): Add vim :q easter egg fake terminal

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -1,0 +1,427 @@
+# Vim :q Easter Egg — Fake Shell Implementation Plan
+
+## Overview
+
+When a user types `:q`, `:wq`, `:x` (or `!` variants) in vim mode, the entire page is replaced with a full-screen fake Linux terminal (green-on-black Matrix style). The terminal supports a small set of commands, tab completion, command history, and a fake filesystem with easter egg files. Typing `exit` returns to the editor. Shutdown commands trigger a systemd-style shutdown animation ending in a permanent black screen (reload required).
+
+**No external dependencies.** Everything is built with plain React + CSS on top of the existing `monaco-vim` `defineEx` API.
+
+---
+
+## File Structure
+
+```
+packages/app/src/components/fake-shell/
+├── FakeShell.tsx           # Main component (input, output, history, tab completion)
+├── ShutdownOverlay.tsx     # Shutdown animation sequence
+├── commands.ts             # Command interpreter (pure functions)
+├── filesystem.ts           # Fake filesystem tree + utilities
+└── neofetch.ts             # ASCII art + system info generator
+```
+
+Modified files:
+
+- `packages/app/src/components/editor/vimTypes.ts` — add `defineEx` to `VimAPI`
+- `packages/app/src/components/editor/vim.ts` — add `defineEx` hooks + subscriber
+- `packages/app/src/components/PoeEditor.tsx` — wire up shell state + render `<FakeShell>`
+
+---
+
+## Phase 1: Foundation (can be parallelized as 3 independent subagents)
+
+### Task 1A: Fake Filesystem
+
+**File:** `packages/app/src/components/fake-shell/filesystem.ts`
+
+Create a static in-memory filesystem tree and utility functions.
+
+**Type:**
+
+```ts
+interface FSNode {
+  type: "file" | "directory";
+  content?: string; // file content
+  children?: Record<string, FSNode>; // directory entries
+  permissions?: string; // e.g. "-rwxr-xr-x", "drwxr-xr-x"
+  size?: number; // byte count for ls -la
+}
+```
+
+**Filesystem tree:**
+
+```
+/
+├── home/
+│   └── edgar/               ← this is ~ (home dir)
+│       ├── documents/
+│       │   └── definitely-not-a-virus.sh  → "#!/bin/bash\necho 'You have been hacked!'\necho 'Just kidding.'"
+│       ├── .bashrc                        → "# ~/.bashrc\nalias vim='echo just use poe-editor'"
+│       ├── .vimrc                         → "\" finally escaped vim\n\" or did I?"
+│       ├── todo.txt                       → "1. finish this editor\n2. touch grass\n3. figure out how to exit vim"
+│       ├── README.md                      → "You found the secret terminal!\n\nThere is nothing useful here. Go back to writing."
+│       └── poems/
+│           └── the-raven.md              → First stanza of The Raven by Edgar Allan Poe
+├── bin/    (empty directory)
+├── etc/    (empty directory)
+├── tmp/    (empty directory)
+└── var/    (empty directory)
+```
+
+**Utility functions to export:**
+
+- `resolve(cwd: string, path: string): string` — resolve relative/absolute/~ paths to absolute
+- `getNode(absolutePath: string): FSNode | null` — traverse tree to find node
+- `listDir(cwd: string, path?: string): { name: string; node: FSNode }[] | null` — list directory contents
+- `readFile(cwd: string, path: string): string | null` — get file content
+- `isDir(cwd: string, path: string): boolean` — check if path is a directory
+- `completePath(cwd: string, partial: string): string[]` — return matching filenames for tab completion
+
+**Notes:**
+
+- `ls -la` needs permissions, size, and fake dates (use a fixed date like `Mar 15 13:37`)
+- `ls` without `-la` should show just names, with directories colored blue and `.sh` files green
+- Hidden files (`.bashrc`, `.vimrc`) only shown with `-a`/`-la` flags
+
+---
+
+### Task 1B: Command Interpreter
+
+**File:** `packages/app/src/components/fake-shell/commands.ts`
+
+Pure functions with no React dependency. Each command receives parsed args and returns output.
+
+**Types:**
+
+```ts
+interface ShellState {
+  cwd: string; // absolute path, starts at /home/edgar
+}
+
+interface CommandResult {
+  output: string; // text to display (may contain color tokens)
+  exit?: boolean; // true = return to editor
+  shutdown?: boolean; // true = trigger shutdown sequence
+  clear?: boolean; // true = clear scrollback
+  newCwd?: string; // if command changed directory
+}
+
+type CommandFn = (args: string[], state: ShellState) => CommandResult;
+```
+
+**Command table:**
+
+| Command                          | Behavior                                                                                  |
+| -------------------------------- | ----------------------------------------------------------------------------------------- |
+| `ls`                             | List current dir. Flags: `-l`, `-a`, `-la`/`-al`. Color dirs blue, `.sh` green.           |
+| `cd <dir>`                       | Change cwd. Support `..`, `.`, `~`, absolute paths. Error if not a directory.             |
+| `cat <file>`                     | Print file content. Error if not found or is directory.                                   |
+| `pwd`                            | Print `state.cwd`                                                                         |
+| `echo <...>`                     | Join remaining args with spaces, print                                                    |
+| `whoami`                         | `edgar`                                                                                   |
+| `uname` / `uname -a` / any flags | `PoeOS 6.6.6-poe #1 SMP PREEMPT_DYNAMIC Edgar x86_64 GNU/Linux`                           |
+| `date`                           | Real current date in Linux format (e.g. `Thu Apr  3 12:00:00 UTC 2026`)                   |
+| `clear`                          | Return `{ clear: true }`                                                                  |
+| `exit`                           | Return `{ exit: true }`                                                                   |
+| `vim` / `vi`                     | Print `You just left vim. Are you sure you want to go back?` then return `{ exit: true }` |
+| `neofetch`                       | Delegate to neofetch module (Task 1C)                                                     |
+| `help`                           | Print list of available commands with one-line descriptions                               |
+| `sudo <cmd>`                     | Strip `sudo` prefix, re-parse and execute inner command (no password prompt)              |
+| `shutdown` / `poweroff` / `halt` | Return `{ shutdown: true }`                                                               |
+| `<empty>`                        | No output, just new prompt                                                                |
+| `<anything else>`                | `bash: <cmd>: command not found`                                                          |
+
+**Main entry point:**
+
+```ts
+export function executeCommand(input: string, state: ShellState): CommandResult;
+```
+
+This function should:
+
+1. Trim and split input on whitespace
+2. Handle `sudo` prefix by stripping it and recursing
+3. Look up command name in a map
+4. Call the handler with remaining args + state
+5. Return result
+
+---
+
+### Task 1C: Neofetch ASCII Art
+
+**File:** `packages/app/src/components/fake-shell/neofetch.ts`
+
+**Export:** `function neofetch(): string`
+
+Returns a pre-formatted string with ASCII art and system info side by side.
+
+```
+         ___         edgar@poe-editor
+        (o o)        ----------------
+       (  V  )       OS: PoeOS 6.6.6
+       /|   |\       Host: poe-editor
+      / |   | \      Kernel: 6.6.6-poe
+         m m         Shell: bash 5.2
+                     Editor: vim (escaped)
+                     Theme: Matrix Green
+                     Uptime: since you typed :q
+                     Packages: 0 (npm)
+                     Memory: 640K (ought to be enough)
+```
+
+Use color tokens (same format as the shell output renderer) so the raven art is in green and the labels are bold/colored.
+
+---
+
+## Phase 2: Shell UI Component (depends on Phase 1)
+
+### Task 2A: FakeShell Component
+
+**File:** `packages/app/src/components/fake-shell/FakeShell.tsx`
+
+**Props:**
+
+```ts
+interface FakeShellProps {
+  onExit: () => void; // called when user types `exit` or `vim`/`vi`
+}
+```
+
+**Rendering:**
+
+- `position: fixed; inset: 0; z-index: 9999`
+- Background: `#000000`
+- Text color: `#00ff00` (Matrix green)
+- Font: `'Courier New', 'Consolas', monospace`, ~14px
+- Slight text-shadow glow: `0 0 5px rgba(0, 255, 0, 0.5)` for CRT feel
+
+**Structure:**
+
+```
+<div class="fake-shell">           ← fixed fullscreen, black bg
+  <div class="shell-output">       ← scrollable area, grows upward
+    {lines.map(line => <Line />)}   ← rendered output lines
+  </div>
+  <div class="shell-input-line">   ← prompt + input at bottom
+    <span>edgar@poe-editor:~$</span>
+    <input />                       ← hidden/styled input
+  </div>
+</div>
+```
+
+**State:**
+
+```ts
+const [lines, setLines] = useState<OutputLine[]>([motdBanner]);
+const [input, setInput] = useState("");
+const [shellState, setShellState] = useState<ShellState>({
+  cwd: "/home/edgar",
+});
+const [history, setHistory] = useState<string[]>([]);
+const [historyIndex, setHistoryIndex] = useState(-1);
+const [isShutdown, setIsShutdown] = useState(false);
+```
+
+**Input handling (onKeyDown):**
+
+- `Enter` → execute command, append input line + output to `lines`, clear input, reset history index, auto-scroll to bottom
+- `Tab` → prevent default, run tab completion:
+  - First token: complete against command names
+  - Subsequent tokens: complete against filenames via `completePath()`
+  - Single match: replace token inline
+  - Multiple matches: append line showing all matches
+- `ArrowUp` → go back in history (decrement index, set input)
+- `ArrowDown` → go forward in history (increment index, set input or clear)
+- `Ctrl+C` → clear current input, append `^C` line, new prompt
+- `Ctrl+L` → clear scrollback
+
+**MOTD banner on mount:**
+
+```
+PoeOS 6.6.6-poe (tty1)
+
+poe-editor login: edgar
+Last login: [current date] on tty1
+
+edgar@poe-editor:~$
+```
+
+**Prompt format:**
+
+The prompt should reflect `cwd`. When in home dir show `~`, otherwise show path:
+
+- `/home/edgar` → `edgar@poe-editor:~$`
+- `/home/edgar/poems` → `edgar@poe-editor:~/poems$`
+- `/tmp` → `edgar@poe-editor:/tmp$`
+
+**Special handling:**
+
+- When `executeCommand` returns `{ exit: true }` → call `onExit()`
+- When it returns `{ shutdown: true }` → set `isShutdown = true`
+- When it returns `{ clear: true }` → clear lines array
+- When it returns `{ newCwd }` → update `shellState.cwd`
+- `vim`/`vi` command: show the joke message, then after a ~1s timeout call `onExit()`
+
+**Focus management:**
+
+- Auto-focus input on mount
+- Re-focus input on any click within the shell div
+- Prevent tab from moving focus out
+
+**If `isShutdown` is true:** render `<ShutdownOverlay />` instead of the shell
+
+---
+
+### Task 2B: Shutdown Overlay
+
+**File:** `packages/app/src/components/fake-shell/ShutdownOverlay.tsx`
+
+**Props:** none (this is a terminal state — no escape)
+
+**Sequence** (staggered ~400ms per line):
+
+```
+Broadcast message from edgar@poe-editor:
+  The system is going down for poweroff NOW!
+
+[  OK  ] Stopped Poe Markdown Daemon
+[  OK  ] Stopped Session Manager for edgar
+[  OK  ] Unmounted /dev/inspiration
+[  OK  ] Deactivated swap: /dev/writers-block
+[  OK  ] Stopped Creative Writing Service
+[  OK  ] Stopped NetworkManager
+[  OK  ] Reached target Shutdown
+[  OK  ] Reached target Final Step
+         Powering off...
+```
+
+**Implementation:**
+
+- Array of message strings
+- `useEffect` with `setInterval` or chained `setTimeout`, adding one message at a time to state
+- `[  OK  ]` prefix rendered in green, rest in white
+- After all messages displayed, wait ~800ms then clear everything to pure black
+- Final state: completely black div, no text, no cursor, `position: fixed; inset: 0; z-index: 10000`
+- No event handlers, no way out except browser reload
+
+**Styling:** Same monospace green-on-black as the shell.
+
+---
+
+## Phase 3: Wiring (depends on Phase 1 + 2)
+
+### Task 3A: Vim Ex-Command Registration
+
+**Files:**
+
+- `packages/app/src/components/editor/vimTypes.ts`
+- `packages/app/src/components/editor/vim.ts`
+
+**Step 1 — Update `VimAPI` type in `vimTypes.ts`:**
+
+Add to the `VimAPI` interface:
+
+```ts
+defineEx: (name: string, prefix: string, fn: (cm: CodeMirrorAdapter) => void) => void
+```
+
+**Step 2 — Add subscriber + defineEx calls in `vim.ts`:**
+
+Follow the exact same pattern as the existing `onVimSpellCheckChange`:
+
+```ts
+// Shell activation subscriber
+type ShellActivationCallback = () => void;
+const shellActivationSubscribers: ShellActivationCallback[] = [];
+
+export function onShellActivation(
+  callback: ShellActivationCallback,
+): () => void {
+  shellActivationSubscribers.push(callback);
+  return () => {
+    const index = shellActivationSubscribers.indexOf(callback);
+    if (index > -1) shellActivationSubscribers.splice(index, 1);
+  };
+}
+```
+
+Inside `setupVim()`, after existing setup, add:
+
+```ts
+const triggerShell = () => {
+  shellActivationSubscribers.forEach((cb) => cb());
+};
+
+Vim.defineEx("q", "q", triggerShell);
+Vim.defineEx("q!", "q!", triggerShell);
+Vim.defineEx("wq", "wq", triggerShell);
+Vim.defineEx("wq!", "wq!", triggerShell);
+Vim.defineEx("x", "x", triggerShell);
+```
+
+---
+
+### Task 3B: PoeEditor Integration
+
+**File:** `packages/app/src/components/PoeEditor.tsx`
+
+**Changes:**
+
+1. Import `onShellActivation` from `../components/editor/vim`
+2. Import `FakeShell` from `./fake-shell/FakeShell`
+3. Add state: `const [shellActive, setShellActive] = useState(false)`
+4. Add effect to subscribe:
+
+```ts
+useEffect(() => {
+  return onShellActivation(() => setShellActive(true));
+}, []);
+```
+
+5. Conditional render — when `shellActive` is true, render **only** `<FakeShell onExit={() => setShellActive(false)} />` and skip the entire editor UI. This gives full page takeover without unmounting the editor (it's just hidden behind the fixed overlay... actually since we want realism, we should conditionally render to replace, not overlay).
+
+**Decision:** Use conditional rendering. When `shellActive = true`, return `<FakeShell />` instead of the normal JSX. This means the editor unmounts. When the user exits, `shellActive` becomes false, the editor remounts. Since all state is in the URL hash, the document content is fully preserved — the editor restores seamlessly.
+
+---
+
+## Phase 4: Polish & Testing
+
+### Task 4A: Edge Cases & UX Polish
+
+- Ensure hidden files only show with `-a` flag in `ls`
+- Verify `cd ..` from `/` stays at `/`
+- Test long output scrolling
+- Test rapid command entry
+- Verify editor state restores correctly after exit
+- Verify shell only activates when vim mode is enabled
+- Mobile: ensure input works with virtual keyboard (`inputMode="text"`)
+
+### Task 4B: Tests
+
+- Unit tests for `commands.ts` — each command with various args
+- Unit tests for `filesystem.ts` — path resolution, listing, reading
+- Unit tests for `neofetch.ts` — snapshot test
+- Component test for `FakeShell.tsx` — mount, type command, verify output
+- Component test for `ShutdownOverlay.tsx` — verify message sequence
+- Integration test: verify `:q` in vim mode triggers shell activation callback
+
+---
+
+## Subagent Parallelization Guide
+
+```
+Phase 1 (parallel):
+  ├── Subagent A: Task 1A (filesystem.ts)
+  ├── Subagent B: Task 1B (commands.ts) — can stub filesystem imports
+  └── Subagent C: Task 1C (neofetch.ts)
+
+Phase 2 (parallel, after Phase 1):
+  ├── Subagent D: Task 2A (FakeShell.tsx)
+  └── Subagent E: Task 2B (ShutdownOverlay.tsx)
+
+Phase 3 (parallel, after Phase 2):
+  ├── Subagent F: Task 3A (vim.ts + vimTypes.ts)
+  └── Subagent G: Task 3B (PoeEditor.tsx)
+
+Phase 4 (sequential, after Phase 3):
+  └── Subagent H: Tasks 4A + 4B (polish + tests)
+```

--- a/packages/app/src/components/PoeEditor.tsx
+++ b/packages/app/src/components/PoeEditor.tsx
@@ -11,6 +11,8 @@ import { useTransformers } from '@/hooks/useTransformers'
 import { useUrlState } from '@/hooks/useUrlState'
 import { useViewMode } from '@/hooks/useViewMode'
 import { useVimMode } from '@/hooks/useVimMode'
+import { onShellActivation } from '@/components/editor/vim'
+import { FakeShell } from '@/components/fake-shell/FakeShell'
 import { useWordCount } from '@/hooks/useWordCount'
 import { type EditorPaneHandle } from '@/components/editor'
 import { PoeEditorDialogs } from '@/components/poe-editor/PoeEditorDialogs'
@@ -84,6 +86,7 @@ export function PoeEditor({ onReady }: PoeEditorProps): ReactElement {
   })
 
   const { vimMode: vimModeEnabled, toggleVimMode } = useVimMode()
+  const [shellActive, setShellActive] = useState(false)
   const { displayLineMotion, toggleDisplayLineMotion } = useDisplayLineMotion()
   const { showWordCount, toggleWordCount } = useWordCount()
   const { showLineNumbers, toggleLineNumbers } = useLineNumbers()
@@ -330,6 +333,10 @@ export function PoeEditor({ onReady }: PoeEditorProps): ReactElement {
   })
 
   useEffect(() => {
+    return onShellActivation(() => setShellActive(true))
+  }, [])
+
+  useEffect(() => {
     const timeoutId = setTimeout(() => {
       setMounted(true)
     }, 0)
@@ -406,6 +413,10 @@ export function PoeEditor({ onReady }: PoeEditorProps): ReactElement {
     toggleSpellCheck,
     displayLineMotion,
     toggleDisplayLineMotion,
+  }
+
+  if (shellActive) {
+    return <FakeShell onExit={() => setShellActive(false)} />
   }
 
   return (

--- a/packages/app/src/components/editor/vim.test.ts
+++ b/packages/app/src/components/editor/vim.test.ts
@@ -6,6 +6,7 @@ interface VimMocks {
   mapCommand: ReturnType<typeof vi.fn>
   defineMotion: ReturnType<typeof vi.fn>
   defineOption: ReturnType<typeof vi.fn>
+  defineEx: ReturnType<typeof vi.fn>
 }
 
 const setupModule = async (): Promise<{
@@ -20,6 +21,7 @@ const setupModule = async (): Promise<{
     mapCommand: vi.fn(),
     defineMotion: vi.fn(),
     defineOption: vi.fn(),
+    defineEx: vi.fn(),
   }
 
   vi.doMock('monaco-vim', () => ({

--- a/packages/app/src/components/editor/vim.ts
+++ b/packages/app/src/components/editor/vim.ts
@@ -196,6 +196,16 @@ export function setupVim(): void {
   Vim.mapCommand('M', 'motion', 'moveToMiddleDocumentPosition')
   Vim.mapCommand('L', 'motion', 'moveToLowDocumentPosition')
 
+  // Register :q/:wq/:x commands to trigger the fake shell easter egg
+  const triggerShell = () => {
+    shellActivationSubscribers.forEach((cb) => cb())
+  }
+  Vim.defineEx('q', 'q', triggerShell)
+  Vim.defineEx('q!', 'q!', triggerShell)
+  Vim.defineEx('wq', 'wq', triggerShell)
+  Vim.defineEx('wq!', 'wq!', triggerShell)
+  Vim.defineEx('x', 'x', triggerShell)
+
   // Register spell check option
   // We use a custom event to notify React when Vim changes this option
   Vim.defineOption(
@@ -210,6 +220,25 @@ export function setupVim(): void {
       }
     }
   )
+}
+
+// Subscription mechanism for shell activation from Vim :q/:wq/:x
+type ShellActivationCallback = () => void
+const shellActivationSubscribers: ShellActivationCallback[] = []
+
+/**
+ * Subscribes to Vim :q, :wq, :x command activations.
+ * @param callback - Callback invoked when a quit command is issued.
+ * @returns Unsubscribe function.
+ */
+export function onShellActivation(callback: ShellActivationCallback): () => void {
+  shellActivationSubscribers.push(callback)
+  return () => {
+    const index = shellActivationSubscribers.indexOf(callback)
+    if (index > -1) {
+      shellActivationSubscribers.splice(index, 1)
+    }
+  }
 }
 
 // Subscription mechanism for spell check changes from Vim

--- a/packages/app/src/components/editor/vimTypes.ts
+++ b/packages/app/src/components/editor/vimTypes.ts
@@ -84,11 +84,7 @@ export interface VimAPI {
     cm?: CodeMirrorAdapter,
     cfg?: Record<string, unknown>
   ) => void
-  defineEx: (
-    name: string,
-    prefix: string,
-    fn: (cm: CodeMirrorAdapter) => void
-  ) => void
+  defineEx: (name: string, prefix: string, fn: (cm: CodeMirrorAdapter) => void) => void
 }
 
 export interface VimModeModule {

--- a/packages/app/src/components/editor/vimTypes.ts
+++ b/packages/app/src/components/editor/vimTypes.ts
@@ -84,6 +84,11 @@ export interface VimAPI {
     cm?: CodeMirrorAdapter,
     cfg?: Record<string, unknown>
   ) => void
+  defineEx: (
+    name: string,
+    prefix: string,
+    fn: (cm: CodeMirrorAdapter) => void
+  ) => void
 }
 
 export interface VimModeModule {

--- a/packages/app/src/components/fake-shell/FakeShell.tsx
+++ b/packages/app/src/components/fake-shell/FakeShell.tsx
@@ -1,0 +1,361 @@
+import { useState, useRef, useCallback, useEffect, type ReactNode, type CSSProperties } from 'react'
+import { executeCommand, getCommandNames, type ShellState, type CommandResult } from './commands'
+import { completePath, HOME } from './filesystem'
+import { ShutdownOverlay } from './ShutdownOverlay'
+
+// -- Types --
+
+interface FakeShellProps {
+  onExit: () => void
+}
+
+// -- ANSI color map --
+
+const ANSI_COLOR_MAP: Record<string, CSSProperties> = {
+  '1;34': { color: '#5555ff', fontWeight: 'bold' },
+  '1;32': { color: '#00ff00', fontWeight: 'bold' },
+  '1;37': { color: '#ffffff', fontWeight: 'bold' },
+  '0': {},
+}
+
+const DEFAULT_STYLE: CSSProperties = { color: '#00ff00' }
+
+// -- ANSI rendering helper --
+
+function renderAnsi(text: string): ReactNode {
+  const regex = /\x1b\[([0-9;]*)m/g
+  const parts: ReactNode[] = []
+  let lastIndex = 0
+  let currentStyle: CSSProperties = { ...DEFAULT_STYLE }
+  let match: RegExpExecArray | null
+  let key = 0
+
+  match = regex.exec(text)
+  while (match !== null) {
+    // Push the text segment before this escape sequence
+    if (match.index > lastIndex) {
+      const segment = text.slice(lastIndex, match.index)
+      parts.push(
+        <span key={key++} style={currentStyle}>
+          {segment}
+        </span>
+      )
+    }
+
+    // Update the current style
+    const code = match[1]
+    if (code === '0' || code === '') {
+      currentStyle = { ...DEFAULT_STYLE }
+    } else if (ANSI_COLOR_MAP[code]) {
+      currentStyle = { ...ANSI_COLOR_MAP[code] }
+    }
+
+    lastIndex = match.index + match[0].length
+    match = regex.exec(text)
+  }
+
+  // Push any remaining text after the last escape sequence
+  if (lastIndex < text.length) {
+    const segment = text.slice(lastIndex)
+    parts.push(
+      <span key={key++} style={currentStyle}>
+        {segment}
+      </span>
+    )
+  }
+
+  // If there were no ANSI codes at all, return the plain text
+  if (parts.length === 0) {
+    return <span style={DEFAULT_STYLE}>{text}</span>
+  }
+
+  return parts
+}
+
+// -- Prompt helper --
+
+function getPrompt(cwd: string): string {
+  const display = cwd.startsWith(HOME)
+    ? '~' + cwd.slice(HOME.length)
+    : cwd
+  return `edgar@poe-editor:${display || '~'}$ `
+}
+
+// -- MOTD banner --
+
+function buildMotd(): string {
+  const now = new Date()
+  const days = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat']
+  const months = [
+    'Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun',
+    'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec',
+  ]
+
+  const dayName = days[now.getDay()]
+  const monthName = months[now.getMonth()]
+  const date = String(now.getDate()).padStart(2, ' ')
+  const hours = String(now.getHours()).padStart(2, '0')
+  const minutes = String(now.getMinutes()).padStart(2, '0')
+  const seconds = String(now.getSeconds()).padStart(2, '0')
+  const year = now.getFullYear()
+
+  const dateStr = `${dayName} ${monthName} ${date} ${hours}:${minutes}:${seconds} ${year}`
+
+  return [
+    'PoeOS 6.6.6-poe (tty1)',
+    '',
+    'poe-editor login: edgar',
+    `Last login: ${dateStr} on tty1`,
+    '',
+  ].join('\n')
+}
+
+// -- Static inline styles --
+
+const shellStyles: CSSProperties = {
+  position: 'fixed',
+  inset: 0,
+  zIndex: 9999,
+  backgroundColor: '#000000',
+  color: '#00ff00',
+  fontFamily: "'Courier New', 'Consolas', monospace",
+  fontSize: '14px',
+  textShadow: '0 0 5px rgba(0, 255, 0, 0.5)',
+  display: 'flex',
+  flexDirection: 'column',
+}
+
+const outputStyles: CSSProperties = {
+  flexGrow: 1,
+  overflowY: 'auto',
+  padding: '8px',
+  whiteSpace: 'pre-wrap',
+  wordBreak: 'break-word',
+}
+
+const inputLineStyles: CSSProperties = {
+  display: 'flex',
+  alignItems: 'center',
+  padding: '0 8px 8px 8px',
+  whiteSpace: 'pre',
+}
+
+const inputStyles: CSSProperties = {
+  backgroundColor: 'transparent',
+  border: 'none',
+  outline: 'none',
+  color: '#00ff00',
+  fontFamily: "'Courier New', 'Consolas', monospace",
+  fontSize: '14px',
+  textShadow: '0 0 5px rgba(0, 255, 0, 0.5)',
+  flexGrow: 1,
+  caretColor: '#00ff00',
+}
+
+// -- Component --
+
+export function FakeShell({ onExit }: FakeShellProps) {
+  const [lines, setLines] = useState<string[]>(() => buildMotd().split('\n'))
+  const [input, setInput] = useState('')
+  const [shellState, setShellState] = useState<ShellState>({ cwd: HOME })
+  const [history, setHistory] = useState<string[]>([])
+  const [historyIndex, setHistoryIndex] = useState(-1)
+  const [isShutdown, setIsShutdown] = useState(false)
+
+  const inputRef = useRef<HTMLInputElement>(null)
+  const outputRef = useRef<HTMLDivElement>(null)
+
+  // Auto-focus input on mount
+  useEffect(() => {
+    inputRef.current?.focus()
+  }, [])
+
+  // Auto-scroll to bottom whenever lines change
+  useEffect(() => {
+    if (outputRef.current) {
+      outputRef.current.scrollTop = outputRef.current.scrollHeight
+    }
+  }, [lines])
+
+  const scrollToBottom = useCallback(() => {
+    if (outputRef.current) {
+      outputRef.current.scrollTop = outputRef.current.scrollHeight
+    }
+  }, [])
+
+  const prompt = getPrompt(shellState.cwd)
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent<HTMLInputElement>) => {
+      if (e.key === 'Enter') {
+        const currentInput = input
+        const currentPrompt = prompt
+
+        // Add the prompt + input line to output
+        const newLines = [...lines, currentPrompt + currentInput]
+
+        // Execute the command
+        const result: CommandResult = executeCommand(currentInput, shellState)
+
+        // Update shell state if cwd changed
+        if (result.newCwd) {
+          setShellState({ cwd: result.newCwd })
+        }
+
+        // Handle clear
+        if (result.clear) {
+          setLines([])
+          setInput('')
+          if (currentInput.trim()) {
+            setHistory((prev) => [...prev, currentInput])
+          }
+          setHistoryIndex(-1)
+          return
+        }
+
+        // Append output lines
+        let updatedLines = newLines
+        if (result.output) {
+          const outputLines = result.output.split('\n')
+          updatedLines = [...newLines, ...outputLines]
+        }
+        setLines(updatedLines)
+
+        // Clear input
+        setInput('')
+
+        // Update history
+        if (currentInput.trim()) {
+          setHistory((prev) => [...prev, currentInput])
+        }
+        setHistoryIndex(-1)
+
+        // Handle shutdown
+        if (result.shutdown) {
+          setIsShutdown(true)
+          return
+        }
+
+        // Handle exit
+        if (result.exit) {
+          if (result.output) {
+            setTimeout(() => {
+              onExit()
+            }, 1000)
+          } else {
+            onExit()
+          }
+          return
+        }
+
+        // Schedule a scroll after state updates
+        setTimeout(scrollToBottom, 0)
+        return
+      }
+
+      if (e.key === 'Tab') {
+        e.preventDefault()
+
+        const tokens = input.split(/\s+/)
+        const isFirstToken = tokens.length <= 1
+
+        if (isFirstToken) {
+          // Complete against command names
+          const partial = tokens[0] ?? ''
+          const commandNames = getCommandNames()
+          const matches = commandNames.filter((name) => name.startsWith(partial))
+
+          if (matches.length === 1) {
+            setInput(matches[0] + ' ')
+          } else if (matches.length > 1) {
+            setLines((prev) => [...prev, prompt + input, matches.join('  ')])
+          }
+        } else {
+          // Complete against filesystem paths
+          const partial = tokens[tokens.length - 1] ?? ''
+          const matches = completePath(shellState.cwd, partial)
+
+          if (matches.length === 1) {
+            const completed = [...tokens.slice(0, -1), matches[0]].join(' ')
+            setInput(completed)
+          } else if (matches.length > 1) {
+            setLines((prev) => [...prev, prompt + input, matches.join('  ')])
+          }
+        }
+        return
+      }
+
+      if (e.key === 'ArrowUp') {
+        e.preventDefault()
+        if (history.length === 0) return
+
+        const newIndex = historyIndex === -1 ? history.length - 1 : Math.max(0, historyIndex - 1)
+        setHistoryIndex(newIndex)
+        setInput(history[newIndex])
+        return
+      }
+
+      if (e.key === 'ArrowDown') {
+        e.preventDefault()
+        if (historyIndex === -1) return
+
+        const newIndex = historyIndex + 1
+        if (newIndex >= history.length) {
+          setHistoryIndex(-1)
+          setInput('')
+        } else {
+          setHistoryIndex(newIndex)
+          setInput(history[newIndex])
+        }
+        return
+      }
+
+      // Ctrl+C: cancel current input
+      if (e.key === 'c' && e.ctrlKey) {
+        e.preventDefault()
+        setLines((prev) => [...prev, prompt + input + '^C'])
+        setInput('')
+        setHistoryIndex(-1)
+        return
+      }
+
+      // Ctrl+L: clear screen
+      if (e.key === 'l' && e.ctrlKey) {
+        e.preventDefault()
+        setLines([])
+        return
+      }
+    },
+    [input, lines, prompt, shellState, history, historyIndex, onExit, scrollToBottom]
+  )
+
+  const handleShellClick = useCallback(() => {
+    inputRef.current?.focus()
+  }, [])
+
+  if (isShutdown) {
+    return <ShutdownOverlay />
+  }
+
+  return (
+    <div style={shellStyles} onClick={handleShellClick}>
+      <div ref={outputRef} style={outputStyles}>
+        {lines.map((line, i) => (
+          <div key={i}>{renderAnsi(line)}</div>
+        ))}
+      </div>
+      <div style={inputLineStyles}>
+        <span>{prompt}</span>
+        <input
+          ref={inputRef}
+          style={inputStyles}
+          value={input}
+          onChange={(e) => setInput(e.target.value)}
+          onKeyDown={handleKeyDown}
+          spellCheck={false}
+          autoComplete="off"
+        />
+      </div>
+    </div>
+  )
+}

--- a/packages/app/src/components/fake-shell/FakeShell.tsx
+++ b/packages/app/src/components/fake-shell/FakeShell.tsx
@@ -23,6 +23,7 @@ const DEFAULT_STYLE: CSSProperties = { color: '#00ff00' }
 // -- ANSI rendering helper --
 
 function renderAnsi(text: string): ReactNode {
+  // eslint-disable-next-line no-control-regex
   const regex = /\x1b\[([0-9;]*)m/g
   const parts: ReactNode[] = []
   let lastIndex = 0
@@ -75,9 +76,7 @@ function renderAnsi(text: string): ReactNode {
 // -- Prompt helper --
 
 function getPrompt(cwd: string): string {
-  const display = cwd.startsWith(HOME)
-    ? '~' + cwd.slice(HOME.length)
-    : cwd
+  const display = cwd.startsWith(HOME) ? '~' + cwd.slice(HOME.length) : cwd
   return `edgar@poe-editor:${display || '~'}$ `
 }
 
@@ -87,8 +86,18 @@ function buildMotd(): string {
   const now = new Date()
   const days = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat']
   const months = [
-    'Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun',
-    'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec',
+    'Jan',
+    'Feb',
+    'Mar',
+    'Apr',
+    'May',
+    'Jun',
+    'Jul',
+    'Aug',
+    'Sep',
+    'Oct',
+    'Nov',
+    'Dec',
   ]
 
   const dayName = days[now.getDay()]
@@ -121,12 +130,6 @@ const shellStyles: CSSProperties = {
   fontFamily: "'Courier New', 'Consolas', monospace",
   fontSize: '14px',
   textShadow: '0 0 5px rgba(0, 255, 0, 0.5)',
-  display: 'flex',
-  flexDirection: 'column',
-}
-
-const outputStyles: CSSProperties = {
-  flexGrow: 1,
   overflowY: 'auto',
   padding: '8px',
   whiteSpace: 'pre-wrap',
@@ -136,7 +139,6 @@ const outputStyles: CSSProperties = {
 const inputLineStyles: CSSProperties = {
   display: 'flex',
   alignItems: 'center',
-  padding: '0 8px 8px 8px',
   whiteSpace: 'pre',
 }
 
@@ -338,12 +340,10 @@ export function FakeShell({ onExit }: FakeShellProps) {
   }
 
   return (
-    <div style={shellStyles} onClick={handleShellClick}>
-      <div ref={outputRef} style={outputStyles}>
-        {lines.map((line, i) => (
-          <div key={i}>{renderAnsi(line)}</div>
-        ))}
-      </div>
+    <div ref={outputRef} style={shellStyles} onClick={handleShellClick}>
+      {lines.map((line, i) => (
+        <div key={i}>{renderAnsi(line)}</div>
+      ))}
       <div style={inputLineStyles}>
         <span>{prompt}</span>
         <input

--- a/packages/app/src/components/fake-shell/FakeShell.tsx
+++ b/packages/app/src/components/fake-shell/FakeShell.tsx
@@ -341,7 +341,9 @@ export function FakeShell({ onExit }: FakeShellProps) {
 
   return (
     <div ref={outputRef} style={shellStyles} onClick={handleShellClick}>
+      {/* Lines are append-only terminal output; index keys are stable */}
       {lines.map((line, i) => (
+        // eslint-disable-next-line react-x/no-array-index-key
         <div key={i}>{renderAnsi(line)}</div>
       ))}
       <div style={inputLineStyles}>

--- a/packages/app/src/components/fake-shell/ShutdownOverlay.tsx
+++ b/packages/app/src/components/fake-shell/ShutdownOverlay.tsx
@@ -1,0 +1,91 @@
+import { useEffect, useState } from 'react'
+
+const MESSAGES = [
+  'Broadcast message from edgar@poe-editor:',
+  '  The system is going down for poweroff NOW!',
+  '',
+  '[  OK  ] Stopped Poe Markdown Daemon',
+  '[  OK  ] Stopped Session Manager for edgar',
+  '[  OK  ] Unmounted /dev/inspiration',
+  '[  OK  ] Deactivated swap: /dev/writers-block',
+  '[  OK  ] Stopped Creative Writing Service',
+  '[  OK  ] Stopped NetworkManager',
+  '[  OK  ] Reached target Shutdown',
+  '[  OK  ] Reached target Final Step',
+  '         Powering off...',
+]
+
+const OK_PREFIX = '[  OK  ] '
+
+const baseStyle: React.CSSProperties = {
+  position: 'fixed',
+  inset: 0,
+  zIndex: 10000,
+  background: '#000000',
+}
+
+const containerStyle: React.CSSProperties = {
+  ...baseStyle,
+  fontFamily: "'Courier New', 'Consolas', monospace",
+  fontSize: 14,
+  color: '#00ff00',
+  padding: 20,
+}
+
+const poweredOffStyle: React.CSSProperties = {
+  ...baseStyle,
+}
+
+export function ShutdownOverlay() {
+  const [visibleCount, setVisibleCount] = useState(0)
+  const [poweredOff, setPoweredOff] = useState(false)
+
+  useEffect(() => {
+    if (visibleCount >= MESSAGES.length) return
+
+    const interval = setInterval(() => {
+      setVisibleCount((prev) => {
+        const next = prev + 1
+        if (next >= MESSAGES.length) {
+          clearInterval(interval)
+        }
+        return next
+      })
+    }, 400)
+
+    return () => clearInterval(interval)
+  }, [visibleCount])
+
+  useEffect(() => {
+    if (visibleCount < MESSAGES.length) return
+
+    const timeout = setTimeout(() => {
+      setPoweredOff(true)
+    }, 800)
+
+    return () => clearTimeout(timeout)
+  }, [visibleCount])
+
+  if (poweredOff) {
+    return <div style={poweredOffStyle} />
+  }
+
+  return (
+    <div style={containerStyle}>
+      {MESSAGES.slice(0, visibleCount).map((msg, i) => (
+        <div key={i}>
+          {msg.startsWith(OK_PREFIX) ? (
+            <>
+              <span style={{ color: '#00ff00' }}>{OK_PREFIX}</span>
+              <span style={{ color: '#cccccc' }}>
+                {msg.slice(OK_PREFIX.length)}
+              </span>
+            </>
+          ) : (
+            <span style={{ color: '#00ff00' }}>{msg}</span>
+          )}
+        </div>
+      ))}
+    </div>
+  )
+}

--- a/packages/app/src/components/fake-shell/ShutdownOverlay.tsx
+++ b/packages/app/src/components/fake-shell/ShutdownOverlay.tsx
@@ -73,13 +73,12 @@ export function ShutdownOverlay() {
   return (
     <div style={containerStyle}>
       {MESSAGES.slice(0, visibleCount).map((msg, i) => (
+        // eslint-disable-next-line react-x/no-array-index-key
         <div key={i}>
           {msg.startsWith(OK_PREFIX) ? (
             <>
               <span style={{ color: '#00ff00' }}>{OK_PREFIX}</span>
-              <span style={{ color: '#cccccc' }}>
-                {msg.slice(OK_PREFIX.length)}
-              </span>
+              <span style={{ color: '#cccccc' }}>{msg.slice(OK_PREFIX.length)}</span>
             </>
           ) : (
             <span style={{ color: '#00ff00' }}>{msg}</span>

--- a/packages/app/src/components/fake-shell/commands.test.ts
+++ b/packages/app/src/components/fake-shell/commands.test.ts
@@ -1,0 +1,276 @@
+import { describe, it, expect } from 'vitest'
+import { executeCommand, getCommandNames } from './commands'
+import type { ShellState } from './commands'
+
+const defaultState: ShellState = { cwd: '/home/edgar' }
+
+describe('executeCommand', () => {
+  it('returns empty output for empty input', () => {
+    const result = executeCommand('', defaultState)
+    expect(result.output).toBe('')
+  })
+
+  it('returns empty output for whitespace-only input', () => {
+    const result = executeCommand('   ', defaultState)
+    expect(result.output).toBe('')
+  })
+
+  it('returns "command not found" for unknown commands', () => {
+    const result = executeCommand('nonexistent', defaultState)
+    expect(result.output).toContain('command not found')
+    expect(result.output).toContain('nonexistent')
+  })
+})
+
+describe('ls', () => {
+  it('lists directory entries for the current directory', () => {
+    const result = executeCommand('ls', defaultState)
+    expect(result.output).toContain('documents')
+    expect(result.output).toContain('todo.txt')
+    expect(result.output).toContain('README.md')
+    expect(result.output).toContain('poems')
+  })
+
+  it('excludes hidden files by default', () => {
+    const result = executeCommand('ls', defaultState)
+    expect(result.output).not.toContain('.bashrc')
+    expect(result.output).not.toContain('.vimrc')
+  })
+
+  it('shows hidden files with -a flag', () => {
+    const result = executeCommand('ls -a', defaultState)
+    expect(result.output).toContain('.bashrc')
+    expect(result.output).toContain('.vimrc')
+  })
+
+  it('errors for non-existent directory', () => {
+    const result = executeCommand('ls fakedir', defaultState)
+    expect(result.output).toContain('No such file or directory')
+  })
+
+  it('supports long format with -l', () => {
+    const result = executeCommand('ls -l', defaultState)
+    expect(result.output).toContain('edgar')
+    expect(result.output).toContain('drwxr-xr-x')
+  })
+
+  it('supports combined -la flag', () => {
+    const result = executeCommand('ls -la', defaultState)
+    expect(result.output).toContain('.bashrc')
+    expect(result.output).toContain('edgar')
+  })
+})
+
+describe('cd', () => {
+  it('changes the working directory', () => {
+    const result = executeCommand('cd documents', defaultState)
+    expect(result.newCwd).toBe('/home/edgar/documents')
+    expect(result.output).toBe('')
+  })
+
+  it('navigates to home with ~ shorthand', () => {
+    const state: ShellState = { cwd: '/tmp' }
+    const result = executeCommand('cd ~', state)
+    expect(result.newCwd).toBe('/home/edgar')
+  })
+
+  it('defaults to home when no argument is given', () => {
+    const state: ShellState = { cwd: '/tmp' }
+    const result = executeCommand('cd', state)
+    expect(result.newCwd).toBe('/home/edgar')
+  })
+
+  it('navigates up with ..', () => {
+    const result = executeCommand('cd ..', defaultState)
+    expect(result.newCwd).toBe('/home')
+  })
+
+  it('errors for non-existent directory', () => {
+    const result = executeCommand('cd nope', defaultState)
+    expect(result.output).toContain('No such file or directory')
+  })
+
+  it('errors when target is a file, not a directory', () => {
+    const result = executeCommand('cd todo.txt', defaultState)
+    expect(result.output).toContain('Not a directory')
+  })
+})
+
+describe('cat', () => {
+  it('returns file content', () => {
+    const result = executeCommand('cat todo.txt', defaultState)
+    expect(result.output).toContain('finish this editor')
+    expect(result.output).toContain('exit vim')
+  })
+
+  it('errors for a directory', () => {
+    const result = executeCommand('cat documents', defaultState)
+    expect(result.output).toContain('Is a directory')
+  })
+
+  it('errors for a non-existent file', () => {
+    const result = executeCommand('cat ghost.txt', defaultState)
+    expect(result.output).toContain('No such file or directory')
+  })
+
+  it('returns empty output when called with no arguments', () => {
+    const result = executeCommand('cat', defaultState)
+    expect(result.output).toBe('')
+  })
+})
+
+describe('pwd', () => {
+  it('returns the current working directory', () => {
+    const result = executeCommand('pwd', defaultState)
+    expect(result.output).toBe('/home/edgar')
+  })
+
+  it('reflects a different cwd', () => {
+    const result = executeCommand('pwd', { cwd: '/tmp' })
+    expect(result.output).toBe('/tmp')
+  })
+})
+
+describe('echo', () => {
+  it('joins arguments into a single string', () => {
+    const result = executeCommand('echo hello world', defaultState)
+    expect(result.output).toBe('hello world')
+  })
+
+  it('returns empty string with no arguments', () => {
+    const result = executeCommand('echo', defaultState)
+    expect(result.output).toBe('')
+  })
+})
+
+describe('whoami', () => {
+  it('returns "edgar"', () => {
+    const result = executeCommand('whoami', defaultState)
+    expect(result.output).toBe('edgar')
+  })
+})
+
+describe('uname', () => {
+  it('returns the PoeOS system string', () => {
+    const result = executeCommand('uname', defaultState)
+    expect(result.output).toContain('PoeOS')
+    expect(result.output).toContain('GNU/Linux')
+  })
+})
+
+describe('date', () => {
+  it('returns a non-empty date string', () => {
+    const result = executeCommand('date', defaultState)
+    expect(result.output.length).toBeGreaterThan(0)
+    expect(result.output).toContain('UTC')
+  })
+})
+
+describe('clear', () => {
+  it('returns clear flag set to true', () => {
+    const result = executeCommand('clear', defaultState)
+    expect(result.clear).toBe(true)
+  })
+})
+
+describe('exit', () => {
+  it('returns exit flag set to true', () => {
+    const result = executeCommand('exit', defaultState)
+    expect(result.exit).toBe(true)
+  })
+})
+
+describe('vim / vi', () => {
+  it('vim returns exit with a message', () => {
+    const result = executeCommand('vim', defaultState)
+    expect(result.exit).toBe(true)
+    expect(result.output).toContain('vim')
+  })
+
+  it('vi returns exit with a message', () => {
+    const result = executeCommand('vi', defaultState)
+    expect(result.exit).toBe(true)
+    expect(result.output).toContain('vim')
+  })
+})
+
+describe('help', () => {
+  it('returns help text listing available commands', () => {
+    const result = executeCommand('help', defaultState)
+    expect(result.output).toContain('Available commands')
+    expect(result.output).toContain('ls')
+    expect(result.output).toContain('cd')
+    expect(result.output).toContain('cat')
+    expect(result.output).toContain('exit')
+  })
+})
+
+describe('sudo', () => {
+  it('strips the sudo prefix and executes the inner command', () => {
+    const result = executeCommand('sudo whoami', defaultState)
+    expect(result.output).toBe('edgar')
+  })
+
+  it('returns usage message when called with no arguments', () => {
+    const result = executeCommand('sudo', defaultState)
+    expect(result.output).toContain('usage')
+  })
+
+  it('passes through arguments to the inner command', () => {
+    const result = executeCommand('sudo echo hello', defaultState)
+    expect(result.output).toBe('hello')
+  })
+})
+
+describe('shutdown / poweroff / halt', () => {
+  it('shutdown returns shutdown flag', () => {
+    const result = executeCommand('shutdown', defaultState)
+    expect(result.shutdown).toBe(true)
+  })
+
+  it('poweroff returns shutdown flag', () => {
+    const result = executeCommand('poweroff', defaultState)
+    expect(result.shutdown).toBe(true)
+  })
+
+  it('halt returns shutdown flag', () => {
+    const result = executeCommand('halt', defaultState)
+    expect(result.shutdown).toBe(true)
+  })
+})
+
+describe('rm', () => {
+  it('returns "Nice try." for rm -rf /', () => {
+    const result = executeCommand('rm -rf /', defaultState)
+    expect(result.output).toBe('Nice try.')
+  })
+
+  it('returns "operation not permitted" for normal rm usage', () => {
+    const result = executeCommand('rm file.txt', defaultState)
+    expect(result.output).toContain('operation not permitted')
+  })
+})
+
+describe('getCommandNames', () => {
+  it('returns an array of strings', () => {
+    const names = getCommandNames()
+    expect(Array.isArray(names)).toBe(true)
+    expect(names.length).toBeGreaterThan(0)
+    names.forEach((name) => expect(typeof name).toBe('string'))
+  })
+
+  it('includes expected commands', () => {
+    const names = getCommandNames()
+    expect(names).toContain('ls')
+    expect(names).toContain('cd')
+    expect(names).toContain('cat')
+    expect(names).toContain('pwd')
+    expect(names).toContain('echo')
+    expect(names).toContain('whoami')
+    expect(names).toContain('vim')
+    expect(names).toContain('vi')
+    expect(names).toContain('help')
+    expect(names).toContain('sudo')
+    expect(names).toContain('rm')
+  })
+})

--- a/packages/app/src/components/fake-shell/commands.ts
+++ b/packages/app/src/components/fake-shell/commands.ts
@@ -1,10 +1,4 @@
-import {
-  resolve,
-  getNode,
-  listDir,
-  readFile,
-  HOME,
-} from './filesystem'
+import { resolve, getNode, listDir, readFile } from './filesystem'
 import { neofetch } from './neofetch'
 
 export interface ShellState {
@@ -141,8 +135,18 @@ function cmdDate(_args: string[], _state: ShellState): CommandResult {
   const now = new Date()
   const days = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat']
   const months = [
-    'Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun',
-    'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec',
+    'Jan',
+    'Feb',
+    'Mar',
+    'Apr',
+    'May',
+    'Jun',
+    'Jul',
+    'Aug',
+    'Sep',
+    'Oct',
+    'Nov',
+    'Dec',
   ]
 
   const day = days[now.getUTCDay()]

--- a/packages/app/src/components/fake-shell/commands.ts
+++ b/packages/app/src/components/fake-shell/commands.ts
@@ -1,0 +1,264 @@
+import {
+  resolve,
+  getNode,
+  listDir,
+  readFile,
+  HOME,
+} from './filesystem'
+import { neofetch } from './neofetch'
+
+export interface ShellState {
+  cwd: string // absolute path, starts at /home/edgar
+}
+
+export interface CommandResult {
+  output: string // text to display (may contain ANSI-like color tokens)
+  exit?: boolean // true = return to editor
+  shutdown?: boolean // true = trigger shutdown sequence
+  clear?: boolean // true = clear scrollback
+  newCwd?: string // if command changed directory
+}
+
+type CommandHandler = (args: string[], state: ShellState) => CommandResult
+
+// Color helpers
+const BLUE_BOLD = '\x1b[1;34m'
+const GREEN_BOLD = '\x1b[1;32m'
+const RESET = '\x1b[0m'
+
+function colorize(name: string, isDirectory: boolean): string {
+  if (isDirectory) return `${BLUE_BOLD}${name}${RESET}`
+  if (name.endsWith('.sh')) return `${GREEN_BOLD}${name}${RESET}`
+  return name
+}
+
+// -- Command implementations --
+
+function cmdLs(args: string[], state: ShellState): CommandResult {
+  let showAll = false
+  let longFormat = false
+  let targetPath: string | undefined
+
+  for (const arg of args) {
+    if (arg === '-a') {
+      showAll = true
+    } else if (arg === '-l') {
+      longFormat = true
+    } else if (arg === '-la' || arg === '-al') {
+      showAll = true
+      longFormat = true
+    } else if (!arg.startsWith('-')) {
+      targetPath = arg
+    }
+  }
+
+  const resolvedTarget = targetPath ? resolve(state.cwd, targetPath) : state.cwd
+  const node = getNode(resolvedTarget)
+  if (!node) {
+    return { output: `ls: cannot access '${targetPath}': No such file or directory` }
+  }
+  if (node.type !== 'directory') {
+    return { output: colorize(resolvedTarget.split('/').pop() ?? '', false) }
+  }
+
+  let entries = listDir(resolvedTarget)
+  if (!entries) {
+    return { output: `ls: cannot access '${targetPath}': No such file or directory` }
+  }
+
+  if (!showAll) {
+    entries = entries.filter((entry) => !entry.name.startsWith('.'))
+  }
+
+  if (longFormat) {
+    const lines = entries.map((entry) => {
+      const isDirectory = entry.node.type === 'directory'
+      const perms = entry.node.permissions ?? (isDirectory ? 'drwxr-xr-x' : '-rw-r--r--')
+      const size = String(entry.node.size ?? 0).padStart(5, ' ')
+      const coloredName = colorize(entry.name, isDirectory)
+      return `${perms}  1 edgar edgar ${size} Mar 15 13:37 ${coloredName}`
+    })
+    return { output: lines.join('\n') }
+  }
+
+  const colored = entries.map((entry) => {
+    return colorize(entry.name, entry.node.type === 'directory')
+  })
+  return { output: colored.join('  ') }
+}
+
+function cmdCd(args: string[], state: ShellState): CommandResult {
+  const target = args[0] ?? '~'
+  const resolved = resolve(state.cwd, target)
+  const node = getNode(resolved)
+
+  if (!node) {
+    return { output: `bash: cd: ${target}: No such file or directory` }
+  }
+  if (node.type !== 'directory') {
+    return { output: `bash: cd: ${target}: Not a directory` }
+  }
+
+  return { output: '', newCwd: resolved }
+}
+
+function cmdCat(args: string[], state: ShellState): CommandResult {
+  if (args.length === 0) {
+    return { output: '' }
+  }
+
+  const target = args[0]
+  const content = readFile(state.cwd, target)
+  if (content === null) {
+    const resolved = resolve(state.cwd, target)
+    const node = getNode(resolved)
+    if (node?.type === 'directory') {
+      return { output: `cat: ${target}: Is a directory` }
+    }
+    return { output: `cat: ${target}: No such file or directory` }
+  }
+
+  return { output: content }
+}
+
+function cmdPwd(_args: string[], state: ShellState): CommandResult {
+  return { output: state.cwd }
+}
+
+function cmdEcho(args: string[], _state: ShellState): CommandResult {
+  return { output: args.join(' ') }
+}
+
+function cmdWhoami(_args: string[], _state: ShellState): CommandResult {
+  return { output: 'edgar' }
+}
+
+function cmdUname(_args: string[], _state: ShellState): CommandResult {
+  return { output: 'PoeOS 6.6.6-poe #1 SMP PREEMPT_DYNAMIC Edgar x86_64 GNU/Linux' }
+}
+
+function cmdDate(_args: string[], _state: ShellState): CommandResult {
+  const now = new Date()
+  const days = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat']
+  const months = [
+    'Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun',
+    'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec',
+  ]
+
+  const day = days[now.getUTCDay()]
+  const month = months[now.getUTCMonth()]
+  const date = String(now.getUTCDate()).padStart(2, ' ')
+  const hours = String(now.getUTCHours()).padStart(2, '0')
+  const minutes = String(now.getUTCMinutes()).padStart(2, '0')
+  const seconds = String(now.getUTCSeconds()).padStart(2, '0')
+  const year = now.getUTCFullYear()
+
+  return { output: `${day} ${month} ${date} ${hours}:${minutes}:${seconds} UTC ${year}` }
+}
+
+function cmdClear(_args: string[], _state: ShellState): CommandResult {
+  return { output: '', clear: true }
+}
+
+function cmdExit(_args: string[], _state: ShellState): CommandResult {
+  return { output: '', exit: true }
+}
+
+function cmdVim(_args: string[], _state: ShellState): CommandResult {
+  return { output: 'You just left vim. Are you sure you want to go back?', exit: true }
+}
+
+function cmdNeofetch(_args: string[], _state: ShellState): CommandResult {
+  return { output: neofetch() }
+}
+
+function cmdHelp(_args: string[], _state: ShellState): CommandResult {
+  const lines = [
+    'Available commands:',
+    '  ls [path]        List directory contents',
+    '  cd [dir]         Change working directory',
+    '  cat <file>       Display file contents',
+    '  pwd              Print working directory',
+    '  echo [text...]   Print text to terminal',
+    '  whoami           Display current user',
+    '  uname [-a]       Print system information',
+    '  date             Display current date and time',
+    '  clear            Clear the terminal screen',
+    '  exit             Return to the editor',
+    '  vim / vi         Open vim (good luck)',
+    '  neofetch         Display system info with ASCII art',
+    '  help             Show this help message',
+    '  sudo <cmd>       Run command as root (not really)',
+    '  shutdown         Shut down the system',
+    '  rm               Remove files (disabled)',
+  ]
+  return { output: lines.join('\n') }
+}
+
+function cmdShutdown(_args: string[], _state: ShellState): CommandResult {
+  return { output: '', shutdown: true }
+}
+
+function cmdRm(args: string[], _state: ShellState): CommandResult {
+  const joined = args.join(' ')
+  if (joined.includes('-rf') && joined.includes('/')) {
+    return { output: 'Nice try.' }
+  }
+  return { output: 'rm: operation not permitted' }
+}
+
+// -- Command registry --
+
+const commands: Record<string, CommandHandler> = {
+  ls: cmdLs,
+  cd: cmdCd,
+  cat: cmdCat,
+  pwd: cmdPwd,
+  echo: cmdEcho,
+  whoami: cmdWhoami,
+  uname: cmdUname,
+  date: cmdDate,
+  clear: cmdClear,
+  exit: cmdExit,
+  vim: cmdVim,
+  vi: cmdVim,
+  neofetch: cmdNeofetch,
+  help: cmdHelp,
+  sudo: cmdSudo,
+  shutdown: cmdShutdown,
+  poweroff: cmdShutdown,
+  halt: cmdShutdown,
+  rm: cmdRm,
+}
+
+// sudo is special: it strips itself and re-dispatches
+function cmdSudo(args: string[], state: ShellState): CommandResult {
+  if (args.length === 0) {
+    return { output: 'usage: sudo <command>' }
+  }
+  return executeCommand(args.join(' '), state)
+}
+
+// -- Public API --
+
+export function executeCommand(input: string, state: ShellState): CommandResult {
+  const trimmed = input.trim()
+  if (trimmed === '') {
+    return { output: '' }
+  }
+
+  const parts = trimmed.split(/\s+/)
+  const cmdName = parts[0]
+  const args = parts.slice(1)
+
+  const handler = commands[cmdName]
+  if (!handler) {
+    return { output: `bash: ${cmdName}: command not found` }
+  }
+
+  return handler(args, state)
+}
+
+export function getCommandNames(): string[] {
+  return Object.keys(commands)
+}

--- a/packages/app/src/components/fake-shell/filesystem.test.ts
+++ b/packages/app/src/components/fake-shell/filesystem.test.ts
@@ -1,0 +1,157 @@
+import { describe, it, expect } from 'vitest'
+import {
+  resolve,
+  getNode,
+  listDir,
+  readFile,
+  isDir,
+  completePath,
+  HOME,
+} from './filesystem'
+
+describe('resolve', () => {
+  it('returns absolute paths as-is (after normalization)', () => {
+    expect(resolve('/home/edgar', '/tmp')).toBe('/tmp')
+    expect(resolve('/home/edgar', '/home/edgar/poems')).toBe('/home/edgar/poems')
+  })
+
+  it('resolves relative paths against cwd', () => {
+    expect(resolve('/home/edgar', 'poems')).toBe('/home/edgar/poems')
+    expect(resolve('/home/edgar', 'documents')).toBe('/home/edgar/documents')
+  })
+
+  it('resolves ~ to /home/edgar', () => {
+    expect(resolve('/tmp', '~')).toBe(HOME)
+    expect(resolve('/tmp', '~/poems')).toBe('/home/edgar/poems')
+  })
+
+  it('resolves .. by going up one level', () => {
+    expect(resolve('/home/edgar/poems', '..')).toBe('/home/edgar')
+    expect(resolve('/home/edgar', '../..')).toBe('/')
+  })
+
+  it('treats . as a no-op', () => {
+    expect(resolve('/home/edgar', '.')).toBe('/home/edgar')
+    expect(resolve('/home/edgar', './poems')).toBe('/home/edgar/poems')
+  })
+
+  it('stays at / when .. is used from root', () => {
+    expect(resolve('/', '..')).toBe('/')
+    expect(resolve('/', '../../..')).toBe('/')
+  })
+
+  it('handles combined paths like ~/poems/../todo.txt', () => {
+    expect(resolve('/tmp', '~/poems/../todo.txt')).toBe('/home/edgar/todo.txt')
+  })
+})
+
+describe('getNode', () => {
+  it('returns the root directory for /', () => {
+    const node = getNode('/')
+    expect(node).not.toBeNull()
+    expect(node!.type).toBe('directory')
+    expect(node!.children).toHaveProperty('home')
+  })
+
+  it('returns a file node for a valid file path', () => {
+    const node = getNode('/home/edgar/todo.txt')
+    expect(node).not.toBeNull()
+    expect(node!.type).toBe('file')
+    expect(node!.content).toContain('touch grass')
+  })
+
+  it('returns a directory node for a valid directory path', () => {
+    const node = getNode('/home/edgar/poems')
+    expect(node).not.toBeNull()
+    expect(node!.type).toBe('directory')
+  })
+
+  it('returns null for a non-existent path', () => {
+    expect(getNode('/home/edgar/nope.txt')).toBeNull()
+    expect(getNode('/nonexistent')).toBeNull()
+  })
+})
+
+describe('listDir', () => {
+  it('lists entries in a directory', () => {
+    const entries = listDir('/home/edgar', 'poems')
+    expect(entries).not.toBeNull()
+    const names = entries!.map((e) => e.name)
+    expect(names).toContain('the-raven.md')
+  })
+
+  it('returns null for a file path', () => {
+    expect(listDir('/home/edgar', 'todo.txt')).toBeNull()
+  })
+
+  it('returns null for a non-existent path', () => {
+    expect(listDir('/home/edgar', 'nope')).toBeNull()
+  })
+
+  it('lists cwd when no path arg is provided', () => {
+    const entries = listDir('/home/edgar')
+    expect(entries).not.toBeNull()
+    const names = entries!.map((e) => e.name)
+    expect(names).toContain('todo.txt')
+    expect(names).toContain('poems')
+  })
+
+  it('resolves path relative to cwd', () => {
+    const entries = listDir('/home', 'edgar/poems')
+    expect(entries).not.toBeNull()
+    expect(entries!.map((e) => e.name)).toContain('the-raven.md')
+  })
+})
+
+describe('readFile', () => {
+  it('returns file content for a valid file', () => {
+    const content = readFile('/home/edgar', 'todo.txt')
+    expect(content).not.toBeNull()
+    expect(content).toContain('figure out how to exit vim')
+  })
+
+  it('returns null for a directory', () => {
+    expect(readFile('/home/edgar', 'poems')).toBeNull()
+  })
+
+  it('returns null for a non-existent path', () => {
+    expect(readFile('/home/edgar', 'ghost.txt')).toBeNull()
+  })
+})
+
+describe('isDir', () => {
+  it('returns true for directories', () => {
+    expect(isDir('/home/edgar', 'poems')).toBe(true)
+    expect(isDir('/', 'home')).toBe(true)
+  })
+
+  it('returns false for files', () => {
+    expect(isDir('/home/edgar', 'todo.txt')).toBe(false)
+  })
+
+  it('returns false for non-existent paths', () => {
+    expect(isDir('/home/edgar', 'nope')).toBe(false)
+  })
+})
+
+describe('completePath', () => {
+  it('completes filenames in cwd', () => {
+    const results = completePath('/home/edgar', 'to')
+    expect(results).toContain('todo.txt')
+  })
+
+  it('completes with a path prefix', () => {
+    const results = completePath('/home/edgar', 'documents/def')
+    expect(results).toContain('documents/definitely-not-a-virus.sh')
+  })
+
+  it('adds / suffix for directory matches', () => {
+    const results = completePath('/home/edgar', 'po')
+    expect(results).toContain('poems/')
+  })
+
+  it('returns empty array for a non-existent directory', () => {
+    const results = completePath('/home/edgar', 'nope/foo')
+    expect(results).toEqual([])
+  })
+})

--- a/packages/app/src/components/fake-shell/filesystem.test.ts
+++ b/packages/app/src/components/fake-shell/filesystem.test.ts
@@ -1,13 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import {
-  resolve,
-  getNode,
-  listDir,
-  readFile,
-  isDir,
-  completePath,
-  HOME,
-} from './filesystem'
+import { resolve, getNode, listDir, readFile, isDir, completePath, HOME } from './filesystem'
 
 describe('resolve', () => {
   it('returns absolute paths as-is (after normalization)', () => {

--- a/packages/app/src/components/fake-shell/filesystem.ts
+++ b/packages/app/src/components/fake-shell/filesystem.ts
@@ -30,9 +30,7 @@ const fs: FSNode = dir({
       }),
       '.bashrc': file("# ~/.bashrc\nalias vim='echo just use poe-editor'"),
       '.vimrc': file('" finally escaped vim\n" or did I?'),
-      'todo.txt': file(
-        '1. finish this editor\n2. touch grass\n3. figure out how to exit vim'
-      ),
+      'todo.txt': file('1. finish this editor\n2. touch grass\n3. figure out how to exit vim'),
       'README.md': file(
         'You found the secret terminal!\n\nThere is nothing useful here. Go back to writing.'
       ),
@@ -42,7 +40,7 @@ const fs: FSNode = dir({
             'Once upon a midnight dreary, while I pondered, weak and weary,',
             'Over many a quaint and curious volume of forgotten lore,',
             'While I nodded, nearly napping, suddenly there came a tapping,',
-            "As of some one gently rapping, rapping at my chamber door.",
+            'As of some one gently rapping, rapping at my chamber door.',
             '"\'Tis some visitor," I muttered, "tapping at my chamber door;',
             'Only this and nothing more."',
           ].join('\n')
@@ -106,10 +104,7 @@ export function getNode(absolutePath: string): FSNode | null {
  * List entries in a directory. If no path is provided, lists the cwd.
  * Returns null if the target is not a directory or does not exist.
  */
-export function listDir(
-  cwd: string,
-  path?: string
-): { name: string; node: FSNode }[] | null {
+export function listDir(cwd: string, path?: string): { name: string; node: FSNode }[] | null {
   const target = path !== undefined ? resolve(cwd, path) : cwd
   const node = getNode(target)
 

--- a/packages/app/src/components/fake-shell/filesystem.ts
+++ b/packages/app/src/components/fake-shell/filesystem.ts
@@ -1,0 +1,172 @@
+export interface FSNode {
+  type: 'file' | 'directory'
+  content?: string
+  children?: Record<string, FSNode>
+  permissions?: string
+  size?: number
+}
+
+export const HOME = '/home/edgar'
+
+function file(content: string, permissions = '-rw-r--r--'): FSNode {
+  return { type: 'file', content, permissions, size: content.length }
+}
+
+function dir(children: Record<string, FSNode> = {}, permissions = 'drwxr-xr-x'): FSNode {
+  return { type: 'directory', children, permissions, size: 4096 }
+}
+
+function executableFile(content: string): FSNode {
+  return file(content, '-rwxr-xr-x')
+}
+
+const fs: FSNode = dir({
+  home: dir({
+    edgar: dir({
+      documents: dir({
+        'definitely-not-a-virus.sh': executableFile(
+          "#!/bin/bash\necho 'You have been hacked!'\necho 'Just kidding.'"
+        ),
+      }),
+      '.bashrc': file("# ~/.bashrc\nalias vim='echo just use poe-editor'"),
+      '.vimrc': file('" finally escaped vim\n" or did I?'),
+      'todo.txt': file(
+        '1. finish this editor\n2. touch grass\n3. figure out how to exit vim'
+      ),
+      'README.md': file(
+        'You found the secret terminal!\n\nThere is nothing useful here. Go back to writing.'
+      ),
+      poems: dir({
+        'the-raven.md': file(
+          [
+            'Once upon a midnight dreary, while I pondered, weak and weary,',
+            'Over many a quaint and curious volume of forgotten lore,',
+            'While I nodded, nearly napping, suddenly there came a tapping,',
+            "As of some one gently rapping, rapping at my chamber door.",
+            '"\'Tis some visitor," I muttered, "tapping at my chamber door;',
+            'Only this and nothing more."',
+          ].join('\n')
+        ),
+      }),
+    }),
+  }),
+  bin: dir(),
+  etc: dir(),
+  tmp: dir(),
+  var: dir(),
+})
+
+/**
+ * Resolve a relative, absolute, or ~-prefixed path against a working directory.
+ * Returns a normalized absolute path (no trailing slash, except for root "/").
+ */
+export function resolve(cwd: string, path: string): string {
+  let segments: string[]
+
+  if (path.startsWith('~')) {
+    segments = (HOME + path.slice(1)).split('/').filter(Boolean)
+  } else if (path.startsWith('/')) {
+    segments = path.split('/').filter(Boolean)
+  } else {
+    segments = cwd.split('/').filter(Boolean).concat(path.split('/').filter(Boolean))
+  }
+
+  const resolved: string[] = []
+  for (const seg of segments) {
+    if (seg === '.') continue
+    if (seg === '..') {
+      resolved.pop()
+    } else {
+      resolved.push(seg)
+    }
+  }
+
+  return '/' + resolved.join('/')
+}
+
+/**
+ * Traverse the filesystem tree and return the node at the given absolute path.
+ * Returns null if the path does not exist.
+ */
+export function getNode(absolutePath: string): FSNode | null {
+  const segments = absolutePath.split('/').filter(Boolean)
+  let node: FSNode = fs
+
+  for (const seg of segments) {
+    if (node.type !== 'directory' || !node.children?.[seg]) {
+      return null
+    }
+    node = node.children[seg]
+  }
+
+  return node
+}
+
+/**
+ * List entries in a directory. If no path is provided, lists the cwd.
+ * Returns null if the target is not a directory or does not exist.
+ */
+export function listDir(
+  cwd: string,
+  path?: string
+): { name: string; node: FSNode }[] | null {
+  const target = path !== undefined ? resolve(cwd, path) : cwd
+  const node = getNode(target)
+
+  if (!node || node.type !== 'directory' || !node.children) {
+    return null
+  }
+
+  return Object.entries(node.children).map(([name, child]) => ({
+    name,
+    node: child,
+  }))
+}
+
+/**
+ * Read the content of a file. Returns null if the path does not exist or is a directory.
+ */
+export function readFile(cwd: string, path: string): string | null {
+  const abs = resolve(cwd, path)
+  const node = getNode(abs)
+
+  if (!node || node.type !== 'file') {
+    return null
+  }
+
+  return node.content ?? ''
+}
+
+/**
+ * Check whether a path resolves to a directory.
+ */
+export function isDir(cwd: string, path: string): boolean {
+  const abs = resolve(cwd, path)
+  const node = getNode(abs)
+  return node?.type === 'directory'
+}
+
+/**
+ * Return matching filenames/directory names for tab completion.
+ * The partial string may include a path prefix (e.g. "documents/def").
+ * Returns completions relative to that same prefix.
+ */
+export function completePath(cwd: string, partial: string): string[] {
+  const lastSlash = partial.lastIndexOf('/')
+  const dirPart = lastSlash >= 0 ? partial.slice(0, lastSlash + 1) : ''
+  const prefix = lastSlash >= 0 ? partial.slice(lastSlash + 1) : partial
+
+  const dirPath = dirPart ? resolve(cwd, dirPart) : cwd
+  const node = getNode(dirPath)
+
+  if (!node || node.type !== 'directory' || !node.children) {
+    return []
+  }
+
+  return Object.entries(node.children)
+    .filter(([name]) => name.startsWith(prefix))
+    .map(([name, child]) => {
+      const suffix = child.type === 'directory' ? '/' : ''
+      return dirPart + name + suffix
+    })
+}

--- a/packages/app/src/components/fake-shell/neofetch.test.ts
+++ b/packages/app/src/components/fake-shell/neofetch.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect } from 'vitest'
+import { neofetch } from './neofetch'
+
+describe('neofetch', () => {
+  it('returns a non-empty string', () => {
+    const result = neofetch()
+    expect(result).toBeTruthy()
+    expect(typeof result).toBe('string')
+    expect(result.length).toBeGreaterThan(0)
+  })
+
+  it('contains "edgar@poe-editor"', () => {
+    const result = neofetch()
+    expect(result).toContain('edgar@poe-editor')
+  })
+
+  it('contains expected system info fields', () => {
+    const result = neofetch()
+    const fields = ['OS:', 'Host:', 'Kernel:', 'Shell:', 'Editor:', 'Theme:', 'Uptime:', 'Packages:', 'Memory:']
+    for (const field of fields) {
+      expect(result).toContain(field)
+    }
+  })
+
+  it('contains ANSI escape codes', () => {
+    const result = neofetch()
+    expect(result).toContain('\x1b[')
+  })
+})

--- a/packages/app/src/components/fake-shell/neofetch.test.ts
+++ b/packages/app/src/components/fake-shell/neofetch.test.ts
@@ -16,7 +16,17 @@ describe('neofetch', () => {
 
   it('contains expected system info fields', () => {
     const result = neofetch()
-    const fields = ['OS:', 'Host:', 'Kernel:', 'Shell:', 'Editor:', 'Theme:', 'Uptime:', 'Packages:', 'Memory:']
+    const fields = [
+      'OS:',
+      'Host:',
+      'Kernel:',
+      'Shell:',
+      'Editor:',
+      'Theme:',
+      'Uptime:',
+      'Packages:',
+      'Memory:',
+    ]
     for (const field of fields) {
       expect(result).toContain(field)
     }

--- a/packages/app/src/components/fake-shell/neofetch.ts
+++ b/packages/app/src/components/fake-shell/neofetch.ts
@@ -1,0 +1,39 @@
+const GREEN = '\x1b[1;32m'
+const WHITE = '\x1b[1;37m'
+const RESET = '\x1b[0m'
+
+export function neofetch(): string {
+  const art = [
+    '         ___       ',
+    '        (o o)      ',
+    '       (  V  )     ',
+    '       /|   |\\     ',
+    '      / |   | \\    ',
+    '         m m       ',
+    '                   ',
+    '                   ',
+    '                   ',
+    '                   ',
+    '                   ',
+  ]
+
+  const info = [
+    `${GREEN}edgar@poe-editor${RESET}`,
+    `${GREEN}----------------${RESET}`,
+    `${WHITE}OS:${RESET} PoeOS 6.6.6`,
+    `${WHITE}Host:${RESET} poe-editor`,
+    `${WHITE}Kernel:${RESET} 6.6.6-poe`,
+    `${WHITE}Shell:${RESET} bash 5.2`,
+    `${WHITE}Editor:${RESET} vim (escaped)`,
+    `${WHITE}Theme:${RESET} Matrix Green`,
+    `${WHITE}Uptime:${RESET} since you typed :q`,
+    `${WHITE}Packages:${RESET} 0 (npm)`,
+    `${WHITE}Memory:${RESET} 640K (ought to be enough)`,
+  ]
+
+  const lines = art.map((artLine, i) => {
+    return `${GREEN}${artLine}${RESET}${info[i]}`
+  })
+
+  return lines.join('\n')
+}


### PR DESCRIPTION
Typing `:q`, `:wq`, or `:x` in vim mode now drops users into a full-screen fake Linux terminal with a Matrix green-on-black aesthetic. The terminal supports a small set of commands, tab completion, command history, and a Poe-themed fake filesystem with easter egg files. Typing `exit` returns to the editor; `shutdown` triggers a systemd-style power-off animation ending in a permanent black screen (reload required)[^1].

[^1]: The shell is built entirely with React + inline styles on top of the existing `monaco-vim` `defineEx` API. No external dependencies were added. Editor state is fully preserved across shell entry/exit since all document state lives in the URL hash.

- Users can explore a fake filesystem rooted at `/home/edgar` containing poems, dotfiles, and joke files (e.g. `todo.txt`, `definitely-not-a-virus.sh`, first stanza of *The Raven*).
- Commands include `ls` (with `-la`), `cd`, `cat`, `pwd`, `echo`, `whoami`, `uname`, `date`, `neofetch` (ASCII raven art), `help`, and more.
- `vim`/`vi` returns to the editor with a cheeky message; `rm -rf /` responds with "Nice try.".
- `shutdown`, `poweroff`, or `halt` plays a staggered systemd shutdown sequence before going to a permanent black screen.
- Tab completion works for both command names (first token) and filesystem paths (subsequent tokens).
- Arrow keys navigate command history; `Ctrl+C` cancels input; `Ctrl+L` clears the screen.