### PR TITLE
feat(table): Add format-all-tables action

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -61,11 +61,12 @@ Poe includes standard Markdown editor functionality and a set of unique features
 
 ### Markdown Table
 
-| Feature                         | Notes                                                       |
-| ------------------------------- | ----------------------------------------------------------- |
-| Markdown table editing toolkit  | Insert/delete rows and columns, plus a format-table action. |
-| Table keyboard navigation       | `Tab` / `Shift+Tab` navigate table cells in-editor.         |
-| CJK/emoji-aware table alignment | Table formatter accounts for wide character display width.  |
+| Feature                         | Notes                                                                                 |
+| ------------------------------- | ------------------------------------------------------------------------------------- |
+| Markdown table editing toolkit  | Insert/delete rows and columns, plus a format-table action.                           |
+| Format all tables               | Format every markdown table in the document in one action via the Table toolbar menu. |
+| Table keyboard navigation       | `Tab` / `Shift+Tab` navigate table cells in-editor.                                   |
+| CJK/emoji-aware table alignment | Table formatter accounts for wide character display width.                            |
 
 ### Text Transformation
 

--- a/packages/app/src/components/EditorToolbar.test.tsx
+++ b/packages/app/src/components/EditorToolbar.test.tsx
@@ -33,6 +33,7 @@ describe('EditorToolbar', () => {
     onFormatTaskList: vi.fn(),
     onFormatCodeBlock: vi.fn(),
     onTableAction: vi.fn(),
+    onFormatAllTables: vi.fn(),
     isInTable: false,
     toggleVimMode: vi.fn(),
     toggleTheme: vi.fn(),

--- a/packages/app/src/components/EditorToolbar.tsx
+++ b/packages/app/src/components/EditorToolbar.tsx
@@ -35,6 +35,7 @@ export function EditorToolbar({
   onFormatTaskList,
   onFormatCodeBlock,
   onTableAction,
+  onFormatAllTables,
   isInTable,
   toggleVimMode,
   toggleTheme,
@@ -98,6 +99,7 @@ export function EditorToolbar({
         onFormatTaskList={onFormatTaskList}
         onFormatCodeBlock={onFormatCodeBlock}
         onTableAction={onTableAction}
+        onFormatAllTables={onFormatAllTables}
         isInTable={isInTable}
         onOpenTransformer={onOpenTransformer}
         pipelines={pipelines}

--- a/packages/app/src/components/PoeEditor.tsx
+++ b/packages/app/src/components/PoeEditor.tsx
@@ -108,6 +108,7 @@ export function PoeEditor({ onReady }: PoeEditorProps): ReactElement {
     handleFormatNumberedList,
     handleFormatTaskList,
     handleFormatTable,
+    handleFormatAllTables,
     handleTableAction,
     handleFormat,
   } = useFormattingHandlers({
@@ -375,6 +376,7 @@ export function PoeEditor({ onReady }: PoeEditorProps): ReactElement {
     onFormatTaskList: handleFormatTaskList,
     onFormatCodeBlock: handleFormatCodeBlock,
     onTableAction: handleTableAction,
+    onFormatAllTables: handleFormatAllTables,
     isInTable,
     toggleVimMode,
     toggleTheme,

--- a/packages/app/src/components/editor-toolbar/FormattingToolbarGroup.tsx
+++ b/packages/app/src/components/editor-toolbar/FormattingToolbarGroup.tsx
@@ -65,6 +65,7 @@ type FormattingToolbarGroupProps = Pick<
   | 'onFormatTaskList'
   | 'onFormatCodeBlock'
   | 'onTableAction'
+  | 'onFormatAllTables'
   | 'isInTable'
   | 'onOpenTransformer'
   | 'pipelines'
@@ -124,6 +125,7 @@ export function FormattingToolbarGroup({
   onFormatTaskList,
   onFormatCodeBlock,
   onTableAction,
+  onFormatAllTables,
   isInTable,
   onOpenTransformer,
   pipelines,
@@ -247,10 +249,16 @@ export function FormattingToolbarGroup({
         </DropdownMenuTrigger>
         <DropdownMenuContent>
           {!isInTable ? (
-            <DropdownMenuItem onClick={() => onTableAction('insert-table')}>
-              <Plus className="size-4" />
-              Insert Table
-            </DropdownMenuItem>
+            <>
+              <DropdownMenuItem onClick={() => onTableAction('insert-table')}>
+                <Plus className="size-4" />
+                Insert Table
+              </DropdownMenuItem>
+              <DropdownMenuSeparator />
+              <DropdownMenuItem onClick={onFormatAllTables}>
+                <AlignLeft className="size-4" /> Format All Tables
+              </DropdownMenuItem>
+            </>
           ) : (
             <>
               <DropdownMenuSub>
@@ -273,6 +281,9 @@ export function FormattingToolbarGroup({
               <DropdownMenuSeparator />
               <DropdownMenuItem onClick={() => onTableAction('format-table')}>
                 <AlignLeft className="size-4" /> Format Table
+              </DropdownMenuItem>
+              <DropdownMenuItem onClick={onFormatAllTables}>
+                <AlignLeft className="size-4" /> Format All Tables
               </DropdownMenuItem>
             </>
           )}

--- a/packages/app/src/components/editor-toolbar/types.ts
+++ b/packages/app/src/components/editor-toolbar/types.ts
@@ -25,6 +25,7 @@ export interface EditorToolbarProps {
   onFormatTaskList: () => void
   onFormatCodeBlock: () => void
   onTableAction: (action: TableAction) => void
+  onFormatAllTables: () => void
   isInTable: boolean
   toggleVimMode: () => void
   toggleTheme: () => void

--- a/packages/app/src/components/editor/editorPaneTypes.ts
+++ b/packages/app/src/components/editor/editorPaneTypes.ts
@@ -71,6 +71,8 @@ export interface EditorPaneHandle {
   onScroll: (callback: () => void) => { dispose: () => void }
   /** Format the table at the current cursor position */
   formatTable: () => void
+  /** Format all tables in the document */
+  formatAllTables: () => void
   /** Focus the editor */
   focus: () => void
   /** Perform a table action */

--- a/packages/app/src/components/editor/hooks/useEditorHandle.ts
+++ b/packages/app/src/components/editor/hooks/useEditorHandle.ts
@@ -4,6 +4,7 @@ import type { editor } from 'monaco-editor'
 import { toast } from '@/hooks/useToast'
 import {
   formatMarkdownTable,
+  formatAllTables,
   insertRow,
   insertColumn,
   deleteRow,
@@ -174,6 +175,33 @@ export function useEditorHandle({
         editorRef.current.executeEdits('format-table', [
           {
             range,
+            text: formatted,
+            forceMoveMarkers: true,
+          },
+        ])
+      }
+    },
+
+    formatAllTables: () => {
+      const editor = editorRef.current
+      if (!editor) return
+
+      const model = editor.getModel()
+      if (!model) return
+
+      const fullText = model.getValue()
+      const formatted = formatAllTables(fullText)
+
+      if (formatted !== fullText) {
+        const lineCount = model.getLineCount()
+        editor.executeEdits('format-all-tables', [
+          {
+            range: {
+              startLineNumber: 1,
+              startColumn: 1,
+              endLineNumber: lineCount,
+              endColumn: model.getLineMaxColumn(lineCount),
+            },
             text: formatted,
             forceMoveMarkers: true,
           },

--- a/packages/app/src/components/poe-editor/useFormattingHandlers.ts
+++ b/packages/app/src/components/poe-editor/useFormattingHandlers.ts
@@ -29,6 +29,7 @@ interface FormattingHandlers {
   handleFormatNumberedList: () => void
   handleFormatTaskList: () => void
   handleFormatTable: () => void
+  handleFormatAllTables: () => void
   handleTableAction: (action: TableAction) => void
   handleFormat: (type: 'bold' | 'italic' | 'link' | 'code') => void
 }
@@ -88,6 +89,10 @@ export function useFormattingHandlers({
     sourceRef.current?.performTableAction('format-table')
   }, [sourceRef])
 
+  const handleFormatAllTables = useCallback((): void => {
+    sourceRef.current?.formatAllTables()
+  }, [sourceRef])
+
   const handleTableAction = useCallback(
     (action: TableAction): void => {
       sourceRef.current?.performTableAction(action)
@@ -127,6 +132,7 @@ export function useFormattingHandlers({
     handleFormatNumberedList,
     handleFormatTaskList,
     handleFormatTable,
+    handleFormatAllTables,
     handleTableAction,
     handleFormat,
   }

--- a/packages/app/src/utils/markdownTable.test.ts
+++ b/packages/app/src/utils/markdownTable.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from 'vitest'
 import {
   isMarkdownTable,
   formatMarkdownTable,
+  formatAllTables,
   insertRow,
   insertColumn,
   deleteRow,
@@ -28,6 +29,52 @@ describe('markdownTable', () => {
     expect(formatted).toContain('| h1  | h2  |')
     expect(formatted).toContain('| --- | --- |')
     expect(formatted).toContain('| c1  | c2  |')
+  })
+
+  describe('formatAllTables', () => {
+    it('formats multiple tables in a document', () => {
+      const doc = [
+        '# Title',
+        '',
+        '|h1|h2|',
+        '|---|---|',
+        '|c1|c2|',
+        '',
+        'Some text',
+        '',
+        '|a|b|c|',
+        '|---|---|---|',
+        '|d|e|f|',
+      ].join('\n')
+
+      const result = formatAllTables(doc)
+      expect(result).toContain('| h1  | h2  |')
+      expect(result).toContain('| a   | b   | c   |')
+      expect(result).toContain('# Title')
+      expect(result).toContain('Some text')
+    })
+
+    it('returns text unchanged when there are no tables', () => {
+      const doc = '# Hello\n\nJust some text.'
+      expect(formatAllTables(doc)).toBe(doc)
+    })
+
+    it('handles a single table', () => {
+      const doc = '|h1|h2|\n|---|---|\n|c1|c2|'
+      const result = formatAllTables(doc)
+      expect(result).toContain('| h1  | h2  |')
+    })
+
+    it('preserves lines containing pipe that are not valid tables', () => {
+      const doc = 'a | b is not a table'
+      expect(formatAllTables(doc)).toBe(doc)
+    })
+
+    it('does not alter already-formatted tables', () => {
+      const formatted = '| h1  | h2  |\n| --- | --- |\n| c1  | c2  |'
+      const doc = `# Doc\n\n${formatted}\n\nEnd`
+      expect(formatAllTables(doc)).toBe(doc)
+    })
   })
 
   describe('table manipulation', () => {

--- a/packages/app/src/utils/markdownTable.ts
+++ b/packages/app/src/utils/markdownTable.ts
@@ -267,6 +267,38 @@ export function deleteColumn(text: string, colIndex: number): string {
   return deleteColumns(text, [colIndex])
 }
 
+/**
+ * Formats every markdown table in a document while preserving non-table content.
+ * @param text - The full document text.
+ * @returns The document with all tables formatted.
+ */
+export function formatAllTables(text: string): string {
+  const lines = text.split('\n')
+  const segments: string[] = []
+  let i = 0
+
+  while (i < lines.length) {
+    if (lines[i].includes('|')) {
+      const tableStart = i
+      while (i < lines.length && lines[i].includes('|')) {
+        i++
+      }
+      const tableText = lines.slice(tableStart, i).join('\n')
+
+      if (isMarkdownTable(tableText)) {
+        segments.push(formatMarkdownTable(tableText))
+      } else {
+        segments.push(tableText)
+      }
+    } else {
+      segments.push(lines[i])
+      i++
+    }
+  }
+
+  return segments.join('\n')
+}
+
 function formatTableFromRows(rows: string[][]): string {
   // Reuse the logic from formatMarkdownTable but starting from rows
   if (rows.length === 0) return ''


### PR DESCRIPTION
Format every markdown table in the document in one action, accessible from the Table toolbar menu regardless of cursor position.

- "Format All Tables" option is available in the Table dropdown menu whether the cursor is inside a table or not.
- Existing non-table content and already-formatted tables are left unchanged.
- CJK/emoji-aware column alignment is applied consistently across all tables, matching the existing single-table formatter.
- Covered by unit tests for multi-table documents, no-table documents, and idempotent formatting.