### PR TITLE
[ISSUE-376] fix(app): Remove unused cursor position state

### DIFF
--- a/packages/app/src/components/PoeEditor.tsx
+++ b/packages/app/src/components/PoeEditor.tsx
@@ -57,10 +57,6 @@ export function PoeEditor({ onReady }: PoeEditorProps): ReactElement {
   const [showImportExport, setShowImportExport] = useState(false)
   const [editingPipeline, setEditingPipeline] = useState<TransformationPipeline | null>(null)
   const [selectedText, setSelectedText] = useState<string | undefined>(undefined)
-  const [, setCursorPosition] = useState({
-    lineNumber: 1,
-    column: 1,
-  })
   const [isInTable, setIsInTable] = useState(false)
 
   const documentMenuRef = useRef<HTMLButtonElement>(null)
@@ -309,7 +305,6 @@ export function PoeEditor({ onReady }: PoeEditorProps): ReactElement {
 
   const handleCursorChange = useCallback(
     (position: { lineNumber: number; column: number; isInTable: boolean }): void => {
-      setCursorPosition(position)
       setIsInTable(position.isInTable ?? false)
     },
     []


### PR DESCRIPTION
Removes the discarded cursor-position state write from `PoeEditor` while keeping cursor-derived table detection wired to the toolbar.

- Developers no longer see the `react-x/use-state` warning for the discarded `cursorPosition` state in `PoeEditor`.
- Toolbar behaviour can still reflect whether the cursor is currently inside a markdown table.
- Cursor movement no longer stores unused line and column values in React state.

Closes #376.