### PR TITLE
[ISSUE-377] refactor(transformer): Remove GUI JSON sync effect writes

### DIFF
--- a/packages/app/src/components/transformer/TransformerWorkbench.tsx
+++ b/packages/app/src/components/transformer/TransformerWorkbench.tsx
@@ -57,13 +57,9 @@ export function TransformerWorkbench({
   const prevStepsRef = useRef<PipelineStep[]>(steps)
   const cursorPositionRef = useRef<number>(0) // Track line number
 
-  // Sync steps to JSON when opening JSON mode or when steps change while in JSON mode (optional, but good for keeping sync)
+  // In JSON mode, merge toolbox additions into the JSON buffer while preserving in-progress edits.
   useEffect(() => {
-    if (mode === 'gui') {
-      setJsonValue(JSON.stringify(steps, null, 2))
-      setIsValidJson(true)
-      setValidationError(null)
-    } else {
+    if (mode === 'json') {
       // In JSON mode, if steps changed, it might be due to an add operation from the toolbox
       const prevSteps = prevStepsRef.current
       if (steps.length > prevSteps.length) {


### PR DESCRIPTION
This PR keeps the transformer JSON editor buffer out of the GUI-mode sync effect while preserving JSON-mode insertion behaviour.[^1]

- Developers can run lint without the GUI-mode `react-x/set-state-in-effect` warnings in `TransformerWorkbench`.
- Users can still switch from GUI mode to JSON mode with the current pipeline serialised into the JSON editor.
- JSON-mode toolbox insertion, validation state handling, cursor insertion, and vim initialisation remain unchanged.

Fixes #377.

[^1]: The GUI-to-JSON toggle already serialises `steps` before switching mode, so the effect only needs to handle JSON-mode toolbox additions.