### PR TITLE
[ISSUE-378] refactor(ui): Remove forwardRef wrappers for React 19

### DIFF
--- a/packages/app/src/components/MermaidDiagram.tsx
+++ b/packages/app/src/components/MermaidDiagram.tsx
@@ -40,6 +40,7 @@ export function MermaidDiagram({
   const containerRef = useRef<HTMLDivElement>(null)
   const copyControlsRef = useRef<HTMLDivElement>(null)
   const copyResetTimeoutRef = useRef<number | null>(null)
+  const isCopyMenuOpen = menuOpen && Boolean(svg) && !error
 
   useEffect(() => {
     let cancelled = false
@@ -76,7 +77,7 @@ export function MermaidDiagram({
 
   useEffect(() => {
     if (!interactive) return
-    if (!menuOpen) return
+    if (!isCopyMenuOpen) return
 
     const handlePointerDown = (event: MouseEvent): void => {
       const target = event.target
@@ -90,13 +91,7 @@ export function MermaidDiagram({
     return () => {
       document.removeEventListener('mousedown', handlePointerDown)
     }
-  }, [interactive, menuOpen])
-
-  useEffect(() => {
-    if (!svg || error) {
-      setMenuOpen(false)
-    }
-  }, [svg, error])
+  }, [interactive, isCopyMenuOpen])
 
   const setCopiedStatus = (status: 'code' | 'image'): void => {
     setCopyStatus(status)
@@ -168,7 +163,7 @@ export function MermaidDiagram({
       <div
         ref={copyControlsRef}
         className="preview-mermaid-copy-controls"
-        data-open={menuOpen ? 'true' : undefined}
+        data-open={isCopyMenuOpen ? 'true' : undefined}
       >
         <button
           type="button"
@@ -189,13 +184,13 @@ export function MermaidDiagram({
           className="preview-mermaid-copy-menu-button"
           aria-label="Mermaid copy options"
           aria-haspopup="menu"
-          aria-expanded={menuOpen}
+          aria-expanded={isCopyMenuOpen}
           onClick={() => setMenuOpen((open) => !open)}
         >
           <ChevronDown className="h-3.5 w-3.5" />
         </button>
 
-        {menuOpen && (
+        {isCopyMenuOpen && (
           <div className="preview-mermaid-copy-menu" role="menu" aria-label="Mermaid copy options">
             <button
               type="button"

--- a/packages/app/src/components/SplashScreen.tsx
+++ b/packages/app/src/components/SplashScreen.tsx
@@ -35,14 +35,11 @@ export function SplashScreen({
 }: SplashScreenProps): ReactElement | null {
   const [isVisible, setIsVisible] = useState(true)
   const [isFading, setIsFading] = useState(false)
-  const [showLoading, setShowLoading] = useState(isLoading)
+  const [debugShowLoading, setDebugShowLoading] = useState<boolean | null>(null)
   const [tagline, setTagline] = useState(
     () => TAGLINES[Math.floor(Math.random() * TAGLINES.length)]
   )
-
-  useEffect(() => {
-    setShowLoading(isLoading)
-  }, [isLoading])
+  const showLoading = debug ? (debugShowLoading ?? isLoading) : isLoading
 
   useEffect(() => {
     // Start fade out when loading is complete
@@ -73,7 +70,7 @@ export function SplashScreen({
             onComplete()
           }, 500)
         } else if (e.key === 'l' || e.key === 'L') {
-          setShowLoading((prev) => !prev)
+          setDebugShowLoading((prev) => !(prev ?? isLoading))
         } else if (e.key === 'r' || e.key === 'R') {
           setTagline(TAGLINES[Math.floor(Math.random() * TAGLINES.length)])
         }
@@ -81,7 +78,7 @@ export function SplashScreen({
       window.addEventListener('keydown', handleEscape)
       return () => window.removeEventListener('keydown', handleEscape)
     }
-  }, [debug, isVisible, onComplete])
+  }, [debug, isLoading, isVisible, onComplete])
 
   if (!isVisible) {
     return null

--- a/packages/app/src/components/editor-toolbar/ToolbarButton.tsx
+++ b/packages/app/src/components/editor-toolbar/ToolbarButton.tsx
@@ -23,7 +23,7 @@ interface ToolbarButtonProps {
  * @param props - Component props.
  * @returns Toolbar button element.
  */
-export function ToolbarButton({
+export const ToolbarButton = ({
   icon: Icon,
   label,
   ref,
@@ -34,7 +34,7 @@ export function ToolbarButton({
   dragAttributes,
   dragListeners,
   tooltipDisabled,
-}: ToolbarButtonProps): ReactElement {
+}: ToolbarButtonProps): ReactElement => {
   const button = (
     <Button
       ref={ref}

--- a/packages/app/src/components/editor-toolbar/ToolbarButton.tsx
+++ b/packages/app/src/components/editor-toolbar/ToolbarButton.tsx
@@ -1,4 +1,4 @@
-import { type ElementType, forwardRef } from 'react'
+import { type ElementType, type ReactElement, type Ref } from 'react'
 import type { DraggableAttributes } from '@dnd-kit/core'
 import type { SyntheticListenerMap } from '@dnd-kit/core/dist/hooks/utilities'
 import { Button } from '@/components/ui/button'
@@ -8,6 +8,7 @@ import { cn } from '@/utils/classnames'
 interface ToolbarButtonProps {
   icon: ElementType
   label: string
+  ref?: Ref<HTMLButtonElement>
   onClick?: () => void
   active?: boolean
   allowDrag?: boolean
@@ -22,52 +23,47 @@ interface ToolbarButtonProps {
  * @param props - Component props.
  * @returns Toolbar button element.
  */
-export const ToolbarButton = forwardRef<HTMLButtonElement, ToolbarButtonProps>(
-  (
-    {
-      icon: Icon,
-      label,
-      onClick,
-      active = false,
-      allowDrag = false,
-      className,
-      dragAttributes,
-      dragListeners,
-      tooltipDisabled,
-    },
-    ref
-  ) => {
-    const button = (
-      <Button
-        ref={ref}
-        variant="ghost"
-        size="icon-sm"
-        onClick={onClick}
-        onMouseDown={allowDrag ? undefined : (event) => event.preventDefault()}
-        style={{ touchAction: allowDrag ? 'none' : undefined }}
-        className={cn(
-          'text-muted-foreground hover:text-foreground',
-          active && 'bg-accent text-foreground',
-          className
-        )}
-        {...dragAttributes}
-        {...dragListeners}
-      >
-        <Icon className="size-4" />
-        <span className="sr-only">{label}</span>
-      </Button>
-    )
+export function ToolbarButton({
+  icon: Icon,
+  label,
+  ref,
+  onClick,
+  active = false,
+  allowDrag = false,
+  className,
+  dragAttributes,
+  dragListeners,
+  tooltipDisabled,
+}: ToolbarButtonProps): ReactElement {
+  const button = (
+    <Button
+      ref={ref}
+      variant="ghost"
+      size="icon-sm"
+      onClick={onClick}
+      onMouseDown={allowDrag ? undefined : (event) => event.preventDefault()}
+      style={{ touchAction: allowDrag ? 'none' : undefined }}
+      className={cn(
+        'text-muted-foreground hover:text-foreground',
+        active && 'bg-accent text-foreground',
+        className
+      )}
+      {...dragAttributes}
+      {...dragListeners}
+    >
+      <Icon className="size-4" />
+      <span className="sr-only">{label}</span>
+    </Button>
+  )
 
-    if (tooltipDisabled) {
-      return button
-    }
-
-    return (
-      <Tooltip>
-        <TooltipTrigger asChild>{button}</TooltipTrigger>
-        <TooltipContent>{label}</TooltipContent>
-      </Tooltip>
-    )
+  if (tooltipDisabled) {
+    return button
   }
-)
-ToolbarButton.displayName = 'ToolbarButton'
+
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>{button}</TooltipTrigger>
+      <TooltipContent>{label}</TooltipContent>
+    </Tooltip>
+  )
+}

--- a/packages/app/src/components/editor/EditorPane.tsx
+++ b/packages/app/src/components/editor/EditorPane.tsx
@@ -1,4 +1,4 @@
-import { useRef, useEffect, useMemo, forwardRef, useState } from 'react'
+import { useRef, useEffect, useMemo, useState, type ReactElement } from 'react'
 import Editor, { type OnMount } from '@monaco-editor/react'
 import type { editor } from 'monaco-editor'
 import * as monaco from 'monaco-editor'
@@ -18,7 +18,7 @@ import { countWords } from './countWords'
 import { getEmojiShortcodeQueryAtCursor } from './emojiPickerQuery'
 import { EditorPaneActionButtons } from './EditorPaneActionButtons'
 import { EditorPaneEmojiPicker } from './EditorPaneEmojiPicker'
-import type { EditorPaneProps, EditorPaneHandle, EmojiPickerState } from './editorPaneTypes'
+import type { EditorPaneProps, EmojiPickerState } from './editorPaneTypes'
 export type { EditorPaneHandle, TableAction } from './editorPaneTypes'
 
 /**
@@ -28,417 +28,406 @@ export type { EditorPaneHandle, TableAction } from './editorPaneTypes'
  * @param props - Component properties
  * @returns React component
  */
-export const EditorPane = forwardRef<EditorPaneHandle, EditorPaneProps>(
-  (
-    {
-      value,
-      onChange,
-      onCursorChange,
-      theme = 'light',
-      onFormat,
-      onCodeBlock,
-      vimMode,
-      displayLineMotion = false,
-      showWordCount,
-      showLineNumbers,
-      viewMode,
-      onToggleLayout,
-      spellCheck = false,
-      onSpellCheckChange,
-      emojiPickerEnabled = true,
-    },
-    ref
-  ) => {
-    const [editorInstance, setEditorInstance] = useState<editor.IStandaloneCodeEditor | null>(null)
-    const editorRef = useRef<editor.IStandaloneCodeEditor | null>(null)
-    const editorContainerRef = useRef<HTMLDivElement | null>(null)
-    const vimInstanceRef = useRef<VimAdapter | null>(null)
-    const statusBarRef = useRef<HTMLDivElement | null>(null)
-    const monacoRef = useRef<typeof monaco | null>(null)
-    const pendingScrollCallbacks = useRef<
-      Array<{ callback: () => void; resolve: (disposable: { dispose: () => void }) => void }>
-    >([])
-    const emojiPickerRef = useRef<HTMLDivElement | null>(null)
-    const emojiPickerStateRef = useRef<EmojiPickerState | null>(null)
-    const filteredEmojiEntriesRef = useRef<Array<{ shortcode: string; emoji: string }>>([])
-    const selectedEmojiIndexRef = useRef(0)
-    const emojiLoadRequestRef = useRef(0)
-    const emojiPickerEnabledRef = useRef(emojiPickerEnabled)
-    const hasLoadedEmojiEntriesRef = useRef(false)
-    const isEmojiLoadingRef = useRef(false)
-    const [copied, setCopied] = useState(false)
-    const [emojiPickerState, setEmojiPickerState] = useState<EmojiPickerState | null>(null)
-    const [emojiEntries, setEmojiEntries] = useState<Array<{ shortcode: string; emoji: string }>>(
-      []
-    )
-    const [isEmojiLoading, setIsEmojiLoading] = useState(false)
-    const [emojiLoadError, setEmojiLoadError] = useState<string | null>(null)
-    const [selectedEmojiIndex, setSelectedEmojiIndex] = useState(0)
+export function EditorPane({
+  value,
+  onChange,
+  ref,
+  onCursorChange,
+  theme = 'light',
+  onFormat,
+  onCodeBlock,
+  vimMode,
+  displayLineMotion = false,
+  showWordCount,
+  showLineNumbers,
+  viewMode,
+  onToggleLayout,
+  spellCheck = false,
+  onSpellCheckChange,
+  emojiPickerEnabled = true,
+}: EditorPaneProps): ReactElement {
+  const [editorInstance, setEditorInstance] = useState<editor.IStandaloneCodeEditor | null>(null)
+  const editorRef = useRef<editor.IStandaloneCodeEditor | null>(null)
+  const editorContainerRef = useRef<HTMLDivElement | null>(null)
+  const vimInstanceRef = useRef<VimAdapter | null>(null)
+  const statusBarRef = useRef<HTMLDivElement | null>(null)
+  const monacoRef = useRef<typeof monaco | null>(null)
+  const pendingScrollCallbacks = useRef<
+    Array<{ callback: () => void; resolve: (disposable: { dispose: () => void }) => void }>
+  >([])
+  const emojiPickerRef = useRef<HTMLDivElement | null>(null)
+  const emojiPickerStateRef = useRef<EmojiPickerState | null>(null)
+  const filteredEmojiEntriesRef = useRef<Array<{ shortcode: string; emoji: string }>>([])
+  const selectedEmojiIndexRef = useRef(0)
+  const emojiLoadRequestRef = useRef(0)
+  const emojiPickerEnabledRef = useRef(emojiPickerEnabled)
+  const hasLoadedEmojiEntriesRef = useRef(false)
+  const isEmojiLoadingRef = useRef(false)
+  const [copied, setCopied] = useState(false)
+  const [emojiPickerState, setEmojiPickerState] = useState<EmojiPickerState | null>(null)
+  const [emojiEntries, setEmojiEntries] = useState<Array<{ shortcode: string; emoji: string }>>([])
+  const [isEmojiLoading, setIsEmojiLoading] = useState(false)
+  const [emojiLoadError, setEmojiLoadError] = useState<string | null>(null)
+  const [selectedEmojiIndex, setSelectedEmojiIndex] = useState(0)
 
-    const filteredEmojiEntries = useMemo(() => {
-      if (!emojiPickerState) return []
-      return filterEmojiShortcodeEntries(emojiEntries, emojiPickerState.query, 24)
-    }, [emojiEntries, emojiPickerState])
-    const activeSelectedEmojiIndex =
-      filteredEmojiEntries.length === 0
-        ? 0
-        : Math.min(selectedEmojiIndex, filteredEmojiEntries.length - 1)
+  const filteredEmojiEntries = useMemo(() => {
+    if (!emojiPickerState) return []
+    return filterEmojiShortcodeEntries(emojiEntries, emojiPickerState.query, 24)
+  }, [emojiEntries, emojiPickerState])
+  const activeSelectedEmojiIndex =
+    filteredEmojiEntries.length === 0
+      ? 0
+      : Math.min(selectedEmojiIndex, filteredEmojiEntries.length - 1)
 
-    const ensureEmojiEntriesLoaded = (): void => {
-      if (hasLoadedEmojiEntriesRef.current || isEmojiLoadingRef.current) return
+  const ensureEmojiEntriesLoaded = (): void => {
+    if (hasLoadedEmojiEntriesRef.current || isEmojiLoadingRef.current) return
 
-      const requestId = emojiLoadRequestRef.current + 1
-      emojiLoadRequestRef.current = requestId
-      isEmojiLoadingRef.current = true
-      setIsEmojiLoading(true)
-      setEmojiLoadError(null)
+    const requestId = emojiLoadRequestRef.current + 1
+    emojiLoadRequestRef.current = requestId
+    isEmojiLoadingRef.current = true
+    setIsEmojiLoading(true)
+    setEmojiLoadError(null)
 
-      void getEmojiShortcodeEntries()
-        .then((entries) => {
-          if (emojiLoadRequestRef.current !== requestId) return
-          hasLoadedEmojiEntriesRef.current = true
-          setEmojiEntries(entries)
-        })
-        .catch(() => {
-          if (emojiLoadRequestRef.current !== requestId) return
-          setEmojiLoadError('Unable to load emoji list')
-        })
-        .finally(() => {
-          if (emojiLoadRequestRef.current !== requestId) return
-          isEmojiLoadingRef.current = false
-          setIsEmojiLoading(false)
-        })
-    }
-
-    const checkIsInTable = (model: editor.ITextModel, lineNumber: number): boolean => {
-      const lineContent = model.getLineContent(lineNumber)
-      if (!lineContent.includes('|')) return false
-      return !!getTableAtCursor(model, { lineNumber, column: 1 })
-    }
-
-    const handleInsertEmojiShortcode = (shortcode: string): void => {
-      const activeEditor = editorRef.current
-      const activePicker = emojiPickerStateRef.current
-      if (!activeEditor || !activePicker) return
-
-      const replacement = `:${shortcode}:`
-      activeEditor.executeEdits('emoji-picker', [
-        {
-          range: new monaco.Range(
-            activePicker.lineNumber,
-            activePicker.startColumn,
-            activePicker.lineNumber,
-            activePicker.endColumn
-          ),
-          text: replacement,
-          forceMoveMarkers: true,
-        },
-      ])
-
-      activeEditor.setPosition({
-        lineNumber: activePicker.lineNumber,
-        column: activePicker.startColumn + replacement.length,
+    void getEmojiShortcodeEntries()
+      .then((entries) => {
+        if (emojiLoadRequestRef.current !== requestId) return
+        hasLoadedEmojiEntriesRef.current = true
+        setEmojiEntries(entries)
       })
-      activeEditor.focus()
+      .catch(() => {
+        if (emojiLoadRequestRef.current !== requestId) return
+        setEmojiLoadError('Unable to load emoji list')
+      })
+      .finally(() => {
+        if (emojiLoadRequestRef.current !== requestId) return
+        isEmojiLoadingRef.current = false
+        setIsEmojiLoading(false)
+      })
+  }
+
+  const checkIsInTable = (model: editor.ITextModel, lineNumber: number): boolean => {
+    const lineContent = model.getLineContent(lineNumber)
+    if (!lineContent.includes('|')) return false
+    return !!getTableAtCursor(model, { lineNumber, column: 1 })
+  }
+
+  const handleInsertEmojiShortcode = (shortcode: string): void => {
+    const activeEditor = editorRef.current
+    const activePicker = emojiPickerStateRef.current
+    if (!activeEditor || !activePicker) return
+
+    const replacement = `:${shortcode}:`
+    activeEditor.executeEdits('emoji-picker', [
+      {
+        range: new monaco.Range(
+          activePicker.lineNumber,
+          activePicker.startColumn,
+          activePicker.lineNumber,
+          activePicker.endColumn
+        ),
+        text: replacement,
+        forceMoveMarkers: true,
+      },
+    ])
+
+    activeEditor.setPosition({
+      lineNumber: activePicker.lineNumber,
+      column: activePicker.startColumn + replacement.length,
+    })
+    activeEditor.focus()
+    setEmojiPickerState(null)
+    setSelectedEmojiIndex(0)
+  }
+
+  const handleEditorDidMount: OnMount = (editor, monacoInstance): void => {
+    editorRef.current = editor
+    setEditorInstance(editor)
+    monacoRef.current = monacoInstance
+
+    // Focus on initial mount whenever the editor pane is visible.
+    if (viewMode !== 'preview') {
+      editor.focus()
+    }
+
+    // Drain any scroll callbacks that were queued before Monaco mounted
+    for (const { callback, resolve } of pendingScrollCallbacks.current) {
+      const disposable = editor.onDidScrollChange(() => callback())
+      resolve(disposable)
+    }
+    pendingScrollCallbacks.current = []
+
+    // Initialize context key for table detection
+    const isInTableContext = editor.createContextKey<boolean>('isInTable', false)
+
+    const updateEmojiPickerFromCursor = (): void => {
+      if (!emojiPickerEnabledRef.current) {
+        setEmojiPickerState(null)
+        setSelectedEmojiIndex(0)
+        return
+      }
+
+      const model = editor.getModel()
+      const position = editor.getPosition()
+      if (!model || !position) {
+        setEmojiPickerState(null)
+        setSelectedEmojiIndex(0)
+        return
+      }
+
+      const shortcodeQuery = getEmojiShortcodeQueryAtCursor(model, position)
+      if (!shortcodeQuery) {
+        setEmojiPickerState(null)
+        setSelectedEmojiIndex(0)
+        return
+      }
+
+      const visiblePosition = editor.getScrolledVisiblePosition(position)
+      if (!visiblePosition) {
+        setEmojiPickerState(null)
+        setSelectedEmojiIndex(0)
+        return
+      }
+
+      const layout = editor.getLayoutInfo()
+      const pickerWidth = 320
+      const sidePadding = 12
+      const maxLeft = Math.max(sidePadding, layout.width - pickerWidth - sidePadding)
+      const left = Math.min(Math.max(sidePadding, visiblePosition.left), maxLeft)
+      const top = visiblePosition.top + visiblePosition.height + 8
+
+      if (emojiPickerStateRef.current?.query !== shortcodeQuery.query) {
+        setSelectedEmojiIndex(0)
+      }
+      setEmojiPickerState({
+        ...shortcodeQuery,
+        top,
+        left,
+      })
+      ensureEmojiEntriesLoaded()
+    }
+
+    editor.onDidChangeCursorPosition((e) => {
+      const model = editor.getModel()
+      const isInTable = model ? checkIsInTable(model, e.position.lineNumber) : false
+      isInTableContext.set(isInTable)
+
+      if (onCursorChange) {
+        onCursorChange({
+          lineNumber: e.position.lineNumber,
+          column: e.position.column,
+          isInTable,
+        })
+      }
+
+      updateEmojiPickerFromCursor()
+    })
+
+    editor.onDidChangeModelContent(() => {
+      updateEmojiPickerFromCursor()
+    })
+
+    registerEditorKeybindings({ editor, onFormat, onCodeBlock })
+    updateEmojiPickerFromCursor()
+
+    // Handle Enter key for auto-continuation of lists and quotes
+    editor.onKeyDown((e) => {
+      if (emojiPickerStateRef.current) {
+        if (e.keyCode === monaco.KeyCode.Escape) {
+          e.preventDefault()
+          e.stopPropagation()
+          setEmojiPickerState(null)
+          setSelectedEmojiIndex(0)
+          return
+        }
+
+        if (e.keyCode === monaco.KeyCode.DownArrow && filteredEmojiEntriesRef.current.length > 0) {
+          e.preventDefault()
+          e.stopPropagation()
+          const nextIndex =
+            (selectedEmojiIndexRef.current + 1) % filteredEmojiEntriesRef.current.length
+          setSelectedEmojiIndex(nextIndex)
+          return
+        }
+
+        if (e.keyCode === monaco.KeyCode.UpArrow && filteredEmojiEntriesRef.current.length > 0) {
+          e.preventDefault()
+          e.stopPropagation()
+          const nextIndex =
+            (selectedEmojiIndexRef.current - 1 + filteredEmojiEntriesRef.current.length) %
+            filteredEmojiEntriesRef.current.length
+          setSelectedEmojiIndex(nextIndex)
+          return
+        }
+
+        if (
+          (e.keyCode === monaco.KeyCode.Enter || e.keyCode === monaco.KeyCode.Space) &&
+          filteredEmojiEntriesRef.current.length > 0
+        ) {
+          e.preventDefault()
+          e.stopPropagation()
+          const clampedIndex = Math.min(
+            selectedEmojiIndexRef.current,
+            filteredEmojiEntriesRef.current.length - 1
+          )
+          const selectedEntry = filteredEmojiEntriesRef.current[clampedIndex]
+          if (selectedEntry) {
+            handleInsertEmojiShortcode(selectedEntry.shortcode)
+            return
+          }
+        }
+      }
+
+      if (e.keyCode === monaco.KeyCode.Enter) {
+        const position = editor.getPosition()
+        if (!position) return
+
+        const model = editor.getModel()
+        if (!model) return
+
+        const lineContent = model.getLineContent(position.lineNumber)
+        const result = getAutoContinueEdit(lineContent, position.column)
+
+        if (result) {
+          e.preventDefault()
+          e.stopPropagation()
+
+          if (result.action === 'exit' || result.action === 'continue') {
+            editor.executeEdits('auto-continue', [
+              {
+                range: new monaco.Range(
+                  position.lineNumber,
+                  result.range.startColumn,
+                  position.lineNumber,
+                  result.range.endColumn
+                ),
+                text: result.text || '',
+                forceMoveMarkers: true,
+              },
+            ])
+          }
+        }
+      }
+    })
+  }
+
+  useEditorVim({
+    editorInstance,
+    editorRef,
+    vimInstanceRef,
+    statusBarRef,
+    vimMode,
+    displayLineMotion,
+  })
+  useEditorSpellCheck({
+    editorRef,
+    monacoRef,
+    spellCheck,
+    vimMode,
+    onSpellCheckChange,
+    editorInstance,
+  })
+  useEditorHandle({ ref, editorRef, pendingScrollCallbacks })
+
+  useEffect(() => {
+    emojiPickerEnabledRef.current = emojiPickerEnabled
+  }, [emojiPickerEnabled])
+
+  useEffect(() => {
+    emojiPickerStateRef.current = emojiPickerEnabled ? emojiPickerState : null
+  }, [emojiPickerEnabled, emojiPickerState])
+
+  useEffect(() => {
+    filteredEmojiEntriesRef.current = filteredEmojiEntries
+  }, [filteredEmojiEntries])
+
+  useEffect(() => {
+    selectedEmojiIndexRef.current = activeSelectedEmojiIndex
+  }, [activeSelectedEmojiIndex])
+
+  useEffect(() => {
+    if (!emojiPickerState) return
+
+    const handleClickOutside = (event: MouseEvent): void => {
+      const target = event.target
+      if (!(target instanceof Node)) return
+      if (emojiPickerRef.current?.contains(target)) return
+      if (editorContainerRef.current?.contains(target)) return
       setEmojiPickerState(null)
       setSelectedEmojiIndex(0)
     }
 
-    const handleEditorDidMount: OnMount = (editor, monacoInstance): void => {
-      editorRef.current = editor
-      setEditorInstance(editor)
-      monacoRef.current = monacoInstance
+    window.addEventListener('mousedown', handleClickOutside)
+    return () => window.removeEventListener('mousedown', handleClickOutside)
+  }, [emojiPickerState])
 
-      // Focus on initial mount whenever the editor pane is visible.
-      if (viewMode !== 'preview') {
-        editor.focus()
-      }
-
-      // Drain any scroll callbacks that were queued before Monaco mounted
-      for (const { callback, resolve } of pendingScrollCallbacks.current) {
-        const disposable = editor.onDidScrollChange(() => callback())
-        resolve(disposable)
-      }
-      pendingScrollCallbacks.current = []
-
-      // Initialize context key for table detection
-      const isInTableContext = editor.createContextKey<boolean>('isInTable', false)
-
-      const updateEmojiPickerFromCursor = (): void => {
-        if (!emojiPickerEnabledRef.current) {
-          setEmojiPickerState(null)
-          setSelectedEmojiIndex(0)
-          return
-        }
-
-        const model = editor.getModel()
-        const position = editor.getPosition()
-        if (!model || !position) {
-          setEmojiPickerState(null)
-          setSelectedEmojiIndex(0)
-          return
-        }
-
-        const shortcodeQuery = getEmojiShortcodeQueryAtCursor(model, position)
-        if (!shortcodeQuery) {
-          setEmojiPickerState(null)
-          setSelectedEmojiIndex(0)
-          return
-        }
-
-        const visiblePosition = editor.getScrolledVisiblePosition(position)
-        if (!visiblePosition) {
-          setEmojiPickerState(null)
-          setSelectedEmojiIndex(0)
-          return
-        }
-
-        const layout = editor.getLayoutInfo()
-        const pickerWidth = 320
-        const sidePadding = 12
-        const maxLeft = Math.max(sidePadding, layout.width - pickerWidth - sidePadding)
-        const left = Math.min(Math.max(sidePadding, visiblePosition.left), maxLeft)
-        const top = visiblePosition.top + visiblePosition.height + 8
-
-        if (emojiPickerStateRef.current?.query !== shortcodeQuery.query) {
-          setSelectedEmojiIndex(0)
-        }
-        setEmojiPickerState({
-          ...shortcodeQuery,
-          top,
-          left,
-        })
-        ensureEmojiEntriesLoaded()
-      }
-
-      editor.onDidChangeCursorPosition((e) => {
-        const model = editor.getModel()
-        const isInTable = model ? checkIsInTable(model, e.position.lineNumber) : false
-        isInTableContext.set(isInTable)
-
-        if (onCursorChange) {
-          onCursorChange({
-            lineNumber: e.position.lineNumber,
-            column: e.position.column,
-            isInTable,
-          })
-        }
-
-        updateEmojiPickerFromCursor()
-      })
-
-      editor.onDidChangeModelContent(() => {
-        updateEmojiPickerFromCursor()
-      })
-
-      registerEditorKeybindings({ editor, onFormat, onCodeBlock })
-      updateEmojiPickerFromCursor()
-
-      // Handle Enter key for auto-continuation of lists and quotes
-      editor.onKeyDown((e) => {
-        if (emojiPickerStateRef.current) {
-          if (e.keyCode === monaco.KeyCode.Escape) {
-            e.preventDefault()
-            e.stopPropagation()
-            setEmojiPickerState(null)
-            setSelectedEmojiIndex(0)
-            return
-          }
-
-          if (
-            e.keyCode === monaco.KeyCode.DownArrow &&
-            filteredEmojiEntriesRef.current.length > 0
-          ) {
-            e.preventDefault()
-            e.stopPropagation()
-            const nextIndex =
-              (selectedEmojiIndexRef.current + 1) % filteredEmojiEntriesRef.current.length
-            setSelectedEmojiIndex(nextIndex)
-            return
-          }
-
-          if (e.keyCode === monaco.KeyCode.UpArrow && filteredEmojiEntriesRef.current.length > 0) {
-            e.preventDefault()
-            e.stopPropagation()
-            const nextIndex =
-              (selectedEmojiIndexRef.current - 1 + filteredEmojiEntriesRef.current.length) %
-              filteredEmojiEntriesRef.current.length
-            setSelectedEmojiIndex(nextIndex)
-            return
-          }
-
-          if (
-            (e.keyCode === monaco.KeyCode.Enter || e.keyCode === monaco.KeyCode.Space) &&
-            filteredEmojiEntriesRef.current.length > 0
-          ) {
-            e.preventDefault()
-            e.stopPropagation()
-            const clampedIndex = Math.min(
-              selectedEmojiIndexRef.current,
-              filteredEmojiEntriesRef.current.length - 1
-            )
-            const selectedEntry = filteredEmojiEntriesRef.current[clampedIndex]
-            if (selectedEntry) {
-              handleInsertEmojiShortcode(selectedEntry.shortcode)
-              return
-            }
-          }
-        }
-
-        if (e.keyCode === monaco.KeyCode.Enter) {
-          const position = editor.getPosition()
-          if (!position) return
-
-          const model = editor.getModel()
-          if (!model) return
-
-          const lineContent = model.getLineContent(position.lineNumber)
-          const result = getAutoContinueEdit(lineContent, position.column)
-
-          if (result) {
-            e.preventDefault()
-            e.stopPropagation()
-
-            if (result.action === 'exit' || result.action === 'continue') {
-              editor.executeEdits('auto-continue', [
-                {
-                  range: new monaco.Range(
-                    position.lineNumber,
-                    result.range.startColumn,
-                    position.lineNumber,
-                    result.range.endColumn
-                  ),
-                  text: result.text || '',
-                  forceMoveMarkers: true,
-                },
-              ])
-            }
-          }
-        }
+  const handleCopy = async (): Promise<void> => {
+    try {
+      await copyToClipboard(value)
+      setCopied(true)
+      toast({ description: 'Markdown copied to clipboard' })
+      setTimeout(() => setCopied(false), 2000)
+    } catch {
+      toast({
+        description: 'Failed to copy to clipboard',
+        variant: 'destructive',
       })
     }
-
-    useEditorVim({
-      editorInstance,
-      editorRef,
-      vimInstanceRef,
-      statusBarRef,
-      vimMode,
-      displayLineMotion,
-    })
-    useEditorSpellCheck({
-      editorRef,
-      monacoRef,
-      spellCheck,
-      vimMode,
-      onSpellCheckChange,
-      editorInstance,
-    })
-    useEditorHandle({ ref, editorRef, pendingScrollCallbacks })
-
-    useEffect(() => {
-      emojiPickerEnabledRef.current = emojiPickerEnabled
-    }, [emojiPickerEnabled])
-
-    useEffect(() => {
-      emojiPickerStateRef.current = emojiPickerEnabled ? emojiPickerState : null
-    }, [emojiPickerEnabled, emojiPickerState])
-
-    useEffect(() => {
-      filteredEmojiEntriesRef.current = filteredEmojiEntries
-    }, [filteredEmojiEntries])
-
-    useEffect(() => {
-      selectedEmojiIndexRef.current = activeSelectedEmojiIndex
-    }, [activeSelectedEmojiIndex])
-
-    useEffect(() => {
-      if (!emojiPickerState) return
-
-      const handleClickOutside = (event: MouseEvent): void => {
-        const target = event.target
-        if (!(target instanceof Node)) return
-        if (emojiPickerRef.current?.contains(target)) return
-        if (editorContainerRef.current?.contains(target)) return
-        setEmojiPickerState(null)
-        setSelectedEmojiIndex(0)
-      }
-
-      window.addEventListener('mousedown', handleClickOutside)
-      return () => window.removeEventListener('mousedown', handleClickOutside)
-    }, [emojiPickerState])
-
-    const handleCopy = async (): Promise<void> => {
-      try {
-        await copyToClipboard(value)
-        setCopied(true)
-        toast({ description: 'Markdown copied to clipboard' })
-        setTimeout(() => setCopied(false), 2000)
-      } catch {
-        toast({
-          description: 'Failed to copy to clipboard',
-          variant: 'destructive',
-        })
-      }
-    }
-
-    return (
-      <div className="relative h-full group bg-background flex flex-col overflow-hidden rounded-lg border border-border">
-        <div className="flex-1 min-h-0">
-          <div ref={editorContainerRef} className="relative h-full">
-            <EditorPaneActionButtons
-              copied={copied}
-              viewMode={viewMode}
-              onCopy={handleCopy}
-              onToggleLayout={onToggleLayout}
-            />
-
-            <EditorPaneEmojiPicker
-              enabled={emojiPickerEnabled}
-              state={emojiPickerState}
-              pickerRef={emojiPickerRef}
-              isLoading={isEmojiLoading}
-              loadError={emojiLoadError}
-              entries={filteredEmojiEntries}
-              selectedIndex={activeSelectedEmojiIndex}
-              onHoverIndex={setSelectedEmojiIndex}
-              onSelectShortcode={handleInsertEmojiShortcode}
-            />
-
-            <Editor
-              height="100%"
-              language="markdown"
-              value={value}
-              onChange={(value) => onChange(value ?? '')}
-              onMount={handleEditorDidMount}
-              theme={theme === 'dark' ? 'vs-dark' : 'light'}
-              options={buildEditorOptions(showLineNumbers ?? true)}
-            />
-          </div>
-        </div>
-        {showWordCount && (
-          <div
-            className={`absolute right-4 z-10 pointer-events-none transition-all duration-300 ${
-              vimMode ? 'bottom-10' : 'bottom-4'
-            }`}
-          >
-            <span className="bg-black/50 text-white px-2 py-1 rounded text-xs backdrop-blur-sm">
-              {countWords(value)} words
-            </span>
-          </div>
-        )}
-        {vimMode && (
-          <div
-            ref={statusBarRef}
-            className="vim-status-bar h-6 border-t border-border bg-background font-mono text-xs flex items-center overflow-hidden"
-            style={{
-              fontFamily: "'SF Mono', 'Monaco', 'Menlo', 'Consolas', 'Courier New', monospace",
-            }}
-          />
-        )}
-      </div>
-    )
   }
-)
 
-EditorPane.displayName = 'EditorPane'
+  return (
+    <div className="relative h-full group bg-background flex flex-col overflow-hidden rounded-lg border border-border">
+      <div className="flex-1 min-h-0">
+        <div ref={editorContainerRef} className="relative h-full">
+          <EditorPaneActionButtons
+            copied={copied}
+            viewMode={viewMode}
+            onCopy={handleCopy}
+            onToggleLayout={onToggleLayout}
+          />
+
+          <EditorPaneEmojiPicker
+            enabled={emojiPickerEnabled}
+            state={emojiPickerState}
+            pickerRef={emojiPickerRef}
+            isLoading={isEmojiLoading}
+            loadError={emojiLoadError}
+            entries={filteredEmojiEntries}
+            selectedIndex={activeSelectedEmojiIndex}
+            onHoverIndex={setSelectedEmojiIndex}
+            onSelectShortcode={handleInsertEmojiShortcode}
+          />
+
+          <Editor
+            height="100%"
+            language="markdown"
+            value={value}
+            onChange={(value) => onChange(value ?? '')}
+            onMount={handleEditorDidMount}
+            theme={theme === 'dark' ? 'vs-dark' : 'light'}
+            options={buildEditorOptions(showLineNumbers ?? true)}
+          />
+        </div>
+      </div>
+      {showWordCount && (
+        <div
+          className={`absolute right-4 z-10 pointer-events-none transition-all duration-300 ${
+            vimMode ? 'bottom-10' : 'bottom-4'
+          }`}
+        >
+          <span className="bg-black/50 text-white px-2 py-1 rounded text-xs backdrop-blur-sm">
+            {countWords(value)} words
+          </span>
+        </div>
+      )}
+      {vimMode && (
+        <div
+          ref={statusBarRef}
+          className="vim-status-bar h-6 border-t border-border bg-background font-mono text-xs flex items-center overflow-hidden"
+          style={{
+            fontFamily: "'SF Mono', 'Monaco', 'Menlo', 'Consolas', 'Courier New', monospace",
+          }}
+        />
+      )}
+    </div>
+  )
+}

--- a/packages/app/src/components/editor/EditorPane.tsx
+++ b/packages/app/src/components/editor/EditorPane.tsx
@@ -28,7 +28,7 @@ export type { EditorPaneHandle, TableAction } from './editorPaneTypes'
  * @param props - Component properties
  * @returns React component
  */
-export function EditorPane({
+export const EditorPane = ({
   value,
   onChange,
   ref,
@@ -45,7 +45,7 @@ export function EditorPane({
   spellCheck = false,
   onSpellCheckChange,
   emojiPickerEnabled = true,
-}: EditorPaneProps): ReactElement {
+}: EditorPaneProps): ReactElement => {
   const [editorInstance, setEditorInstance] = useState<editor.IStandaloneCodeEditor | null>(null)
   const editorRef = useRef<editor.IStandaloneCodeEditor | null>(null)
   const editorContainerRef = useRef<HTMLDivElement | null>(null)

--- a/packages/app/src/components/editor/editorPaneTypes.ts
+++ b/packages/app/src/components/editor/editorPaneTypes.ts
@@ -1,8 +1,10 @@
+import type { Ref } from 'react'
 import type { EmojiShortcodeMatch } from './emojiPickerQuery'
 
 export interface EditorPaneProps {
   value: string
   onChange: (value: string) => void
+  ref?: Ref<EditorPaneHandle>
   onCursorChange?: (position: { lineNumber: number; column: number; isInTable: boolean }) => void
   theme?: 'light' | 'dark'
   onFormat?: (type: 'bold' | 'italic' | 'link' | 'code') => void

--- a/packages/app/src/components/editor/hooks/useEditorHandle.ts
+++ b/packages/app/src/components/editor/hooks/useEditorHandle.ts
@@ -1,5 +1,4 @@
-import type React from 'react'
-import { useImperativeHandle } from 'react'
+import { useImperativeHandle, type MutableRefObject, type Ref, type RefObject } from 'react'
 import type { editor } from 'monaco-editor'
 import { toast } from '@/hooks/useToast'
 import {
@@ -16,9 +15,9 @@ import { getTableAtCursor, getTableSelection } from '../table'
 import type { TableAction, EditorPaneHandle } from '../EditorPane'
 
 interface UseEditorHandleParams {
-  ref: React.ForwardedRef<EditorPaneHandle>
-  editorRef: React.RefObject<editor.IStandaloneCodeEditor | null>
-  pendingScrollCallbacks: React.MutableRefObject<
+  ref?: Ref<EditorPaneHandle>
+  editorRef: RefObject<editor.IStandaloneCodeEditor | null>
+  pendingScrollCallbacks: MutableRefObject<
     Array<{ callback: () => void; resolve: (disposable: { dispose: () => void }) => void }>
   >
 }

--- a/packages/app/src/components/transformer/TransformerWorkbench.tsx
+++ b/packages/app/src/components/transformer/TransformerWorkbench.tsx
@@ -58,6 +58,7 @@ export function TransformerWorkbench({
   const cursorPositionRef = useRef<number>(0) // Track line number
 
   // In JSON mode, merge toolbox additions into the JSON buffer while preserving in-progress edits.
+  /* eslint-disable react-x/set-state-in-effect -- The JSON editor mirrors external step changes while it is mounted. */
   useEffect(() => {
     if (mode === 'json') {
       // In JSON mode, if steps changed, it might be due to an add operation from the toolbox
@@ -245,6 +246,7 @@ export function TransformerWorkbench({
     // Update ref
     prevStepsRef.current = steps
   }, [steps, mode, isValidJson, jsonValue])
+  /* eslint-enable react-x/set-state-in-effect */
 
   // Handle vim mode initialization on mode/prop change
   useEffect(() => {

--- a/packages/app/src/components/ui/alert-dialog.tsx
+++ b/packages/app/src/components/ui/alert-dialog.tsx
@@ -1,4 +1,10 @@
-import { type ComponentProps, type ReactElement, type ElementRef, forwardRef } from 'react'
+import {
+  type ComponentProps,
+  type ComponentPropsWithoutRef,
+  type ElementRef,
+  type ReactElement,
+  type Ref,
+} from 'react'
 import * as AlertDialogPrimitive from '@radix-ui/react-alert-dialog'
 
 import { cn } from '@/utils/classnames'
@@ -101,31 +107,35 @@ function AlertDialogDescription({
   )
 }
 
-const AlertDialogAction = forwardRef<
-  ElementRef<typeof AlertDialogPrimitive.Action>,
-  ComponentProps<typeof AlertDialogPrimitive.Action>
->(({ className, ...props }, ref) => (
-  <AlertDialogPrimitive.Action
-    ref={ref}
-    data-slot="alert-dialog-action"
-    className={cn(buttonVariants(), className)}
-    {...props}
-  />
-))
-AlertDialogAction.displayName = AlertDialogPrimitive.Action.displayName
+type AlertDialogActionProps = ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Action> & {
+  ref?: Ref<ElementRef<typeof AlertDialogPrimitive.Action>>
+}
 
-const AlertDialogCancel = forwardRef<
-  ElementRef<typeof AlertDialogPrimitive.Cancel>,
-  ComponentProps<typeof AlertDialogPrimitive.Cancel>
->(({ className, ...props }, ref) => (
-  <AlertDialogPrimitive.Cancel
-    ref={ref}
-    data-slot="alert-dialog-cancel"
-    className={cn(buttonVariants({ variant: 'outline' }), className)}
-    {...props}
-  />
-))
-AlertDialogCancel.displayName = AlertDialogPrimitive.Cancel.displayName
+function AlertDialogAction({ className, ref, ...props }: AlertDialogActionProps): ReactElement {
+  return (
+    <AlertDialogPrimitive.Action
+      ref={ref}
+      data-slot="alert-dialog-action"
+      className={cn(buttonVariants(), className)}
+      {...props}
+    />
+  )
+}
+
+type AlertDialogCancelProps = ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Cancel> & {
+  ref?: Ref<ElementRef<typeof AlertDialogPrimitive.Cancel>>
+}
+
+function AlertDialogCancel({ className, ref, ...props }: AlertDialogCancelProps): ReactElement {
+  return (
+    <AlertDialogPrimitive.Cancel
+      ref={ref}
+      data-slot="alert-dialog-cancel"
+      className={cn(buttonVariants({ variant: 'outline' }), className)}
+      {...props}
+    />
+  )
+}
 
 export {
   AlertDialog,

--- a/packages/app/src/components/ui/alert-dialog.tsx
+++ b/packages/app/src/components/ui/alert-dialog.tsx
@@ -111,7 +111,7 @@ type AlertDialogActionProps = ComponentPropsWithoutRef<typeof AlertDialogPrimiti
   ref?: Ref<ElementRef<typeof AlertDialogPrimitive.Action>>
 }
 
-function AlertDialogAction({ className, ref, ...props }: AlertDialogActionProps): ReactElement {
+const AlertDialogAction = ({ className, ref, ...props }: AlertDialogActionProps): ReactElement => {
   return (
     <AlertDialogPrimitive.Action
       ref={ref}
@@ -126,7 +126,7 @@ type AlertDialogCancelProps = ComponentPropsWithoutRef<typeof AlertDialogPrimiti
   ref?: Ref<ElementRef<typeof AlertDialogPrimitive.Cancel>>
 }
 
-function AlertDialogCancel({ className, ref, ...props }: AlertDialogCancelProps): ReactElement {
+const AlertDialogCancel = ({ className, ref, ...props }: AlertDialogCancelProps): ReactElement => {
   return (
     <AlertDialogPrimitive.Cancel
       ref={ref}

--- a/packages/app/src/components/ui/input.tsx
+++ b/packages/app/src/components/ui/input.tsx
@@ -1,10 +1,12 @@
-import { forwardRef, type InputHTMLAttributes } from 'react'
+import { type InputHTMLAttributes, type ReactElement, type Ref } from 'react'
 
 import { cn } from '@/utils/classnames'
 
-export type InputProps = InputHTMLAttributes<HTMLInputElement>
+export type InputProps = InputHTMLAttributes<HTMLInputElement> & {
+  ref?: Ref<HTMLInputElement>
+}
 
-const Input = forwardRef<HTMLInputElement, InputProps>(({ className, type, ...props }, ref) => {
+function Input({ className, type, ref, ...props }: InputProps): ReactElement {
   return (
     <input
       type={type}
@@ -16,7 +18,6 @@ const Input = forwardRef<HTMLInputElement, InputProps>(({ className, type, ...pr
       {...props}
     />
   )
-})
-Input.displayName = 'Input'
+}
 
 export { Input }

--- a/packages/app/src/components/ui/input.tsx
+++ b/packages/app/src/components/ui/input.tsx
@@ -6,7 +6,7 @@ export type InputProps = InputHTMLAttributes<HTMLInputElement> & {
   ref?: Ref<HTMLInputElement>
 }
 
-function Input({ className, type, ref, ...props }: InputProps): ReactElement {
+const Input = ({ className, type, ref, ...props }: InputProps): ReactElement => {
   return (
     <input
       type={type}

--- a/packages/app/src/components/ui/popover.tsx
+++ b/packages/app/src/components/ui/popover.tsx
@@ -13,13 +13,13 @@ type PopoverContentProps = ComponentPropsWithoutRef<typeof PopoverPrimitive.Cont
   ref?: Ref<ElementRef<typeof PopoverPrimitive.Content>>
 }
 
-function PopoverContent({
+const PopoverContent = ({
   className,
   align = 'center',
   sideOffset = 4,
   ref,
   ...props
-}: PopoverContentProps): ReactElement {
+}: PopoverContentProps): ReactElement => {
   return (
     <PopoverPrimitive.Portal>
       <PopoverPrimitive.Content

--- a/packages/app/src/components/ui/popover.tsx
+++ b/packages/app/src/components/ui/popover.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { forwardRef, type ElementRef, type ComponentPropsWithoutRef } from 'react'
+import { type ComponentPropsWithoutRef, type ElementRef, type ReactElement, type Ref } from 'react'
 import * as PopoverPrimitive from '@radix-ui/react-popover'
 
 import { cn } from '@/utils/classnames'
@@ -9,23 +9,31 @@ const Popover = PopoverPrimitive.Root
 
 const PopoverTrigger = PopoverPrimitive.Trigger
 
-const PopoverContent = forwardRef<
-  ElementRef<typeof PopoverPrimitive.Content>,
-  ComponentPropsWithoutRef<typeof PopoverPrimitive.Content>
->(({ className, align = 'center', sideOffset = 4, ...props }, ref) => (
-  <PopoverPrimitive.Portal>
-    <PopoverPrimitive.Content
-      ref={ref}
-      align={align}
-      sideOffset={sideOffset}
-      className={cn(
-        'z-50 w-72 rounded-md border bg-popover p-4 text-popover-foreground shadow-md outline-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2',
-        className
-      )}
-      {...props}
-    />
-  </PopoverPrimitive.Portal>
-))
-PopoverContent.displayName = PopoverPrimitive.Content.displayName
+type PopoverContentProps = ComponentPropsWithoutRef<typeof PopoverPrimitive.Content> & {
+  ref?: Ref<ElementRef<typeof PopoverPrimitive.Content>>
+}
+
+function PopoverContent({
+  className,
+  align = 'center',
+  sideOffset = 4,
+  ref,
+  ...props
+}: PopoverContentProps): ReactElement {
+  return (
+    <PopoverPrimitive.Portal>
+      <PopoverPrimitive.Content
+        ref={ref}
+        align={align}
+        sideOffset={sideOffset}
+        className={cn(
+          'z-50 w-72 rounded-md border bg-popover p-4 text-popover-foreground shadow-md outline-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2',
+          className
+        )}
+        {...props}
+      />
+    </PopoverPrimitive.Portal>
+  )
+}
 
 export { Popover, PopoverTrigger, PopoverContent }

--- a/packages/app/src/components/ui/select.tsx
+++ b/packages/app/src/components/ui/select.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { forwardRef, type ElementRef, type ComponentPropsWithoutRef } from 'react'
+import { type ComponentPropsWithoutRef, type ElementRef, type ReactElement, type Ref } from 'react'
 import * as SelectPrimitive from '@radix-ui/react-select'
 import { Check, ChevronDown, ChevronUp } from 'lucide-react'
 
@@ -12,131 +12,161 @@ const SelectGroup = SelectPrimitive.Group
 
 const SelectValue = SelectPrimitive.Value
 
-const SelectTrigger = forwardRef<
-  ElementRef<typeof SelectPrimitive.Trigger>,
-  ComponentPropsWithoutRef<typeof SelectPrimitive.Trigger>
->(({ className, children, ...props }, ref) => (
-  <SelectPrimitive.Trigger
-    ref={ref}
-    className={cn(
-      'flex h-9 w-full items-center justify-between rounded-md border border-input bg-transparent px-3 py-2 text-sm shadow-sm ring-offset-background placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-ring disabled:cursor-not-allowed disabled:opacity-50',
-      className
-    )}
-    {...props}
-  >
-    {children}
-    <SelectPrimitive.Icon asChild>
-      <ChevronDown className="h-4 w-4 opacity-50" />
-    </SelectPrimitive.Icon>
-  </SelectPrimitive.Trigger>
-))
-SelectTrigger.displayName = SelectPrimitive.Trigger.displayName
+type SelectTriggerProps = ComponentPropsWithoutRef<typeof SelectPrimitive.Trigger> & {
+  ref?: Ref<ElementRef<typeof SelectPrimitive.Trigger>>
+}
 
-const SelectScrollUpButton = forwardRef<
-  ElementRef<typeof SelectPrimitive.ScrollUpButton>,
-  ComponentPropsWithoutRef<typeof SelectPrimitive.ScrollUpButton>
->(({ className, ...props }, ref) => (
-  <SelectPrimitive.ScrollUpButton
-    ref={ref}
-    className={cn('flex cursor-default items-center justify-center py-1', className)}
-    {...props}
-  >
-    <ChevronUp className="h-4 w-4" />
-  </SelectPrimitive.ScrollUpButton>
-))
-SelectScrollUpButton.displayName = SelectPrimitive.ScrollUpButton.displayName
-
-const SelectScrollDownButton = forwardRef<
-  ElementRef<typeof SelectPrimitive.ScrollDownButton>,
-  ComponentPropsWithoutRef<typeof SelectPrimitive.ScrollDownButton>
->(({ className, ...props }, ref) => (
-  <SelectPrimitive.ScrollDownButton
-    ref={ref}
-    className={cn('flex cursor-default items-center justify-center py-1', className)}
-    {...props}
-  >
-    <ChevronDown className="h-4 w-4" />
-  </SelectPrimitive.ScrollDownButton>
-))
-SelectScrollDownButton.displayName = SelectPrimitive.ScrollDownButton.displayName
-
-const SelectContent = forwardRef<
-  ElementRef<typeof SelectPrimitive.Content>,
-  ComponentPropsWithoutRef<typeof SelectPrimitive.Content>
->(({ className, children, position = 'popper', ...props }, ref) => (
-  <SelectPrimitive.Portal>
-    <SelectPrimitive.Content
+function SelectTrigger({ className, children, ref, ...props }: SelectTriggerProps): ReactElement {
+  return (
+    <SelectPrimitive.Trigger
       ref={ref}
       className={cn(
-        'relative z-50 max-h-96 min-w-[8rem] overflow-hidden rounded-md border bg-popover text-popover-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2',
-        position === 'popper' &&
-          'data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1',
+        'flex h-9 w-full items-center justify-between rounded-md border border-input bg-transparent px-3 py-2 text-sm shadow-sm ring-offset-background placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-ring disabled:cursor-not-allowed disabled:opacity-50',
         className
       )}
-      position={position}
       {...props}
     >
-      <SelectScrollUpButton />
-      <SelectPrimitive.Viewport
+      {children}
+      <SelectPrimitive.Icon asChild>
+        <ChevronDown className="h-4 w-4 opacity-50" />
+      </SelectPrimitive.Icon>
+    </SelectPrimitive.Trigger>
+  )
+}
+
+type SelectScrollUpButtonProps = ComponentPropsWithoutRef<typeof SelectPrimitive.ScrollUpButton> & {
+  ref?: Ref<ElementRef<typeof SelectPrimitive.ScrollUpButton>>
+}
+
+function SelectScrollUpButton({
+  className,
+  ref,
+  ...props
+}: SelectScrollUpButtonProps): ReactElement {
+  return (
+    <SelectPrimitive.ScrollUpButton
+      ref={ref}
+      className={cn('flex cursor-default items-center justify-center py-1', className)}
+      {...props}
+    >
+      <ChevronUp className="h-4 w-4" />
+    </SelectPrimitive.ScrollUpButton>
+  )
+}
+
+type SelectScrollDownButtonProps = ComponentPropsWithoutRef<
+  typeof SelectPrimitive.ScrollDownButton
+> & {
+  ref?: Ref<ElementRef<typeof SelectPrimitive.ScrollDownButton>>
+}
+
+function SelectScrollDownButton({
+  className,
+  ref,
+  ...props
+}: SelectScrollDownButtonProps): ReactElement {
+  return (
+    <SelectPrimitive.ScrollDownButton
+      ref={ref}
+      className={cn('flex cursor-default items-center justify-center py-1', className)}
+      {...props}
+    >
+      <ChevronDown className="h-4 w-4" />
+    </SelectPrimitive.ScrollDownButton>
+  )
+}
+
+type SelectContentProps = ComponentPropsWithoutRef<typeof SelectPrimitive.Content> & {
+  ref?: Ref<ElementRef<typeof SelectPrimitive.Content>>
+}
+
+function SelectContent({
+  className,
+  children,
+  position = 'popper',
+  ref,
+  ...props
+}: SelectContentProps): ReactElement {
+  return (
+    <SelectPrimitive.Portal>
+      <SelectPrimitive.Content
+        ref={ref}
         className={cn(
-          'p-1',
+          'relative z-50 max-h-96 min-w-[8rem] overflow-hidden rounded-md border bg-popover text-popover-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2',
           position === 'popper' &&
-            'h-[var(--radix-select-trigger-height)] w-full min-w-[var(--radix-select-trigger-width)]'
+            'data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1',
+          className
         )}
+        position={position}
+        {...props}
       >
-        {children}
-      </SelectPrimitive.Viewport>
-      <SelectScrollDownButton />
-    </SelectPrimitive.Content>
-  </SelectPrimitive.Portal>
-))
-SelectContent.displayName = SelectPrimitive.Content.displayName
+        <SelectScrollUpButton />
+        <SelectPrimitive.Viewport
+          className={cn(
+            'p-1',
+            position === 'popper' &&
+              'h-[var(--radix-select-trigger-height)] w-full min-w-[var(--radix-select-trigger-width)]'
+          )}
+        >
+          {children}
+        </SelectPrimitive.Viewport>
+        <SelectScrollDownButton />
+      </SelectPrimitive.Content>
+    </SelectPrimitive.Portal>
+  )
+}
 
-const SelectLabel = forwardRef<
-  ElementRef<typeof SelectPrimitive.Label>,
-  ComponentPropsWithoutRef<typeof SelectPrimitive.Label>
->(({ className, ...props }, ref) => (
-  <SelectPrimitive.Label
-    ref={ref}
-    className={cn('px-2 py-1.5 text-sm font-semibold', className)}
-    {...props}
-  />
-))
-SelectLabel.displayName = SelectPrimitive.Label.displayName
+type SelectLabelProps = ComponentPropsWithoutRef<typeof SelectPrimitive.Label> & {
+  ref?: Ref<ElementRef<typeof SelectPrimitive.Label>>
+}
 
-const SelectItem = forwardRef<
-  ElementRef<typeof SelectPrimitive.Item>,
-  ComponentPropsWithoutRef<typeof SelectPrimitive.Item>
->(({ className, children, ...props }, ref) => (
-  <SelectPrimitive.Item
-    ref={ref}
-    className={cn(
-      'relative flex w-full cursor-default select-none items-center rounded-sm py-1.5 pl-2 pr-8 text-sm outline-none focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50',
-      className
-    )}
-    {...props}
-  >
-    <span className="absolute right-2 flex h-3.5 w-3.5 items-center justify-center">
-      <SelectPrimitive.ItemIndicator>
-        <Check className="h-4 w-4" />
-      </SelectPrimitive.ItemIndicator>
-    </span>
-    <SelectPrimitive.ItemText>{children}</SelectPrimitive.ItemText>
-  </SelectPrimitive.Item>
-))
-SelectItem.displayName = SelectPrimitive.Item.displayName
+function SelectLabel({ className, ref, ...props }: SelectLabelProps): ReactElement {
+  return (
+    <SelectPrimitive.Label
+      ref={ref}
+      className={cn('px-2 py-1.5 text-sm font-semibold', className)}
+      {...props}
+    />
+  )
+}
 
-const SelectSeparator = forwardRef<
-  ElementRef<typeof SelectPrimitive.Separator>,
-  ComponentPropsWithoutRef<typeof SelectPrimitive.Separator>
->(({ className, ...props }, ref) => (
-  <SelectPrimitive.Separator
-    ref={ref}
-    className={cn('-mx-1 my-1 h-px bg-muted', className)}
-    {...props}
-  />
-))
-SelectSeparator.displayName = SelectPrimitive.Separator.displayName
+type SelectItemProps = ComponentPropsWithoutRef<typeof SelectPrimitive.Item> & {
+  ref?: Ref<ElementRef<typeof SelectPrimitive.Item>>
+}
+
+function SelectItem({ className, children, ref, ...props }: SelectItemProps): ReactElement {
+  return (
+    <SelectPrimitive.Item
+      ref={ref}
+      className={cn(
+        'relative flex w-full cursor-default select-none items-center rounded-sm py-1.5 pl-2 pr-8 text-sm outline-none focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50',
+        className
+      )}
+      {...props}
+    >
+      <span className="absolute right-2 flex h-3.5 w-3.5 items-center justify-center">
+        <SelectPrimitive.ItemIndicator>
+          <Check className="h-4 w-4" />
+        </SelectPrimitive.ItemIndicator>
+      </span>
+      <SelectPrimitive.ItemText>{children}</SelectPrimitive.ItemText>
+    </SelectPrimitive.Item>
+  )
+}
+
+type SelectSeparatorProps = ComponentPropsWithoutRef<typeof SelectPrimitive.Separator> & {
+  ref?: Ref<ElementRef<typeof SelectPrimitive.Separator>>
+}
+
+function SelectSeparator({ className, ref, ...props }: SelectSeparatorProps): ReactElement {
+  return (
+    <SelectPrimitive.Separator
+      ref={ref}
+      className={cn('-mx-1 my-1 h-px bg-muted', className)}
+      {...props}
+    />
+  )
+}
 
 export {
   Select,

--- a/packages/app/src/components/ui/select.tsx
+++ b/packages/app/src/components/ui/select.tsx
@@ -16,7 +16,12 @@ type SelectTriggerProps = ComponentPropsWithoutRef<typeof SelectPrimitive.Trigge
   ref?: Ref<ElementRef<typeof SelectPrimitive.Trigger>>
 }
 
-function SelectTrigger({ className, children, ref, ...props }: SelectTriggerProps): ReactElement {
+const SelectTrigger = ({
+  className,
+  children,
+  ref,
+  ...props
+}: SelectTriggerProps): ReactElement => {
   return (
     <SelectPrimitive.Trigger
       ref={ref}
@@ -38,11 +43,11 @@ type SelectScrollUpButtonProps = ComponentPropsWithoutRef<typeof SelectPrimitive
   ref?: Ref<ElementRef<typeof SelectPrimitive.ScrollUpButton>>
 }
 
-function SelectScrollUpButton({
+const SelectScrollUpButton = ({
   className,
   ref,
   ...props
-}: SelectScrollUpButtonProps): ReactElement {
+}: SelectScrollUpButtonProps): ReactElement => {
   return (
     <SelectPrimitive.ScrollUpButton
       ref={ref}
@@ -60,11 +65,11 @@ type SelectScrollDownButtonProps = ComponentPropsWithoutRef<
   ref?: Ref<ElementRef<typeof SelectPrimitive.ScrollDownButton>>
 }
 
-function SelectScrollDownButton({
+const SelectScrollDownButton = ({
   className,
   ref,
   ...props
-}: SelectScrollDownButtonProps): ReactElement {
+}: SelectScrollDownButtonProps): ReactElement => {
   return (
     <SelectPrimitive.ScrollDownButton
       ref={ref}
@@ -80,13 +85,13 @@ type SelectContentProps = ComponentPropsWithoutRef<typeof SelectPrimitive.Conten
   ref?: Ref<ElementRef<typeof SelectPrimitive.Content>>
 }
 
-function SelectContent({
+const SelectContent = ({
   className,
   children,
   position = 'popper',
   ref,
   ...props
-}: SelectContentProps): ReactElement {
+}: SelectContentProps): ReactElement => {
   return (
     <SelectPrimitive.Portal>
       <SelectPrimitive.Content
@@ -120,7 +125,7 @@ type SelectLabelProps = ComponentPropsWithoutRef<typeof SelectPrimitive.Label> &
   ref?: Ref<ElementRef<typeof SelectPrimitive.Label>>
 }
 
-function SelectLabel({ className, ref, ...props }: SelectLabelProps): ReactElement {
+const SelectLabel = ({ className, ref, ...props }: SelectLabelProps): ReactElement => {
   return (
     <SelectPrimitive.Label
       ref={ref}
@@ -134,7 +139,7 @@ type SelectItemProps = ComponentPropsWithoutRef<typeof SelectPrimitive.Item> & {
   ref?: Ref<ElementRef<typeof SelectPrimitive.Item>>
 }
 
-function SelectItem({ className, children, ref, ...props }: SelectItemProps): ReactElement {
+const SelectItem = ({ className, children, ref, ...props }: SelectItemProps): ReactElement => {
   return (
     <SelectPrimitive.Item
       ref={ref}
@@ -158,7 +163,7 @@ type SelectSeparatorProps = ComponentPropsWithoutRef<typeof SelectPrimitive.Sepa
   ref?: Ref<ElementRef<typeof SelectPrimitive.Separator>>
 }
 
-function SelectSeparator({ className, ref, ...props }: SelectSeparatorProps): ReactElement {
+const SelectSeparator = ({ className, ref, ...props }: SelectSeparatorProps): ReactElement => {
   return (
     <SelectPrimitive.Separator
       ref={ref}

--- a/packages/app/src/components/ui/switch.tsx
+++ b/packages/app/src/components/ui/switch.tsx
@@ -1,29 +1,31 @@
 'use client'
 
-import { forwardRef, type ElementRef, type ComponentPropsWithoutRef } from 'react'
+import { type ComponentPropsWithoutRef, type ElementRef, type ReactElement, type Ref } from 'react'
 import * as SwitchPrimitives from '@radix-ui/react-switch'
 
 import { cn } from '@/utils/classnames'
 
-const Switch = forwardRef<
-  ElementRef<typeof SwitchPrimitives.Root>,
-  ComponentPropsWithoutRef<typeof SwitchPrimitives.Root>
->(({ className, ...props }, ref) => (
-  <SwitchPrimitives.Root
-    className={cn(
-      'peer inline-flex h-5 w-9 shrink-0 cursor-pointer items-center rounded-full border-2 border-transparent shadow-sm transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-primary data-[state=unchecked]:bg-input',
-      className
-    )}
-    {...props}
-    ref={ref}
-  >
-    <SwitchPrimitives.Thumb
+type SwitchProps = ComponentPropsWithoutRef<typeof SwitchPrimitives.Root> & {
+  ref?: Ref<ElementRef<typeof SwitchPrimitives.Root>>
+}
+
+function Switch({ className, ref, ...props }: SwitchProps): ReactElement {
+  return (
+    <SwitchPrimitives.Root
       className={cn(
-        'pointer-events-none block h-4 w-4 rounded-full bg-background shadow-lg ring-0 transition-transform data-[state=checked]:translate-x-4 data-[state=unchecked]:translate-x-0'
+        'peer inline-flex h-5 w-9 shrink-0 cursor-pointer items-center rounded-full border-2 border-transparent shadow-sm transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-primary data-[state=unchecked]:bg-input',
+        className
       )}
-    />
-  </SwitchPrimitives.Root>
-))
-Switch.displayName = SwitchPrimitives.Root.displayName
+      {...props}
+      ref={ref}
+    >
+      <SwitchPrimitives.Thumb
+        className={cn(
+          'pointer-events-none block h-4 w-4 rounded-full bg-background shadow-lg ring-0 transition-transform data-[state=checked]:translate-x-4 data-[state=unchecked]:translate-x-0'
+        )}
+      />
+    </SwitchPrimitives.Root>
+  )
+}
 
 export { Switch }

--- a/packages/app/src/components/ui/switch.tsx
+++ b/packages/app/src/components/ui/switch.tsx
@@ -9,7 +9,7 @@ type SwitchProps = ComponentPropsWithoutRef<typeof SwitchPrimitives.Root> & {
   ref?: Ref<ElementRef<typeof SwitchPrimitives.Root>>
 }
 
-function Switch({ className, ref, ...props }: SwitchProps): ReactElement {
+const Switch = ({ className, ref, ...props }: SwitchProps): ReactElement => {
   return (
     <SwitchPrimitives.Root
       className={cn(

--- a/packages/app/src/components/ui/textarea.tsx
+++ b/packages/app/src/components/ui/textarea.tsx
@@ -5,7 +5,7 @@ export type TextareaProps = TextareaHTMLAttributes<HTMLTextAreaElement> & {
   ref?: Ref<HTMLTextAreaElement>
 }
 
-function Textarea({ className, ref, ...props }: TextareaProps): ReactElement {
+const Textarea = ({ className, ref, ...props }: TextareaProps): ReactElement => {
   return (
     <textarea
       className={cn(

--- a/packages/app/src/components/ui/textarea.tsx
+++ b/packages/app/src/components/ui/textarea.tsx
@@ -1,9 +1,11 @@
-import { forwardRef, type TextareaHTMLAttributes } from 'react'
+import { type ReactElement, type Ref, type TextareaHTMLAttributes } from 'react'
 import { cn } from '@/utils/classnames'
 
-export type TextareaProps = TextareaHTMLAttributes<HTMLTextAreaElement>
+export type TextareaProps = TextareaHTMLAttributes<HTMLTextAreaElement> & {
+  ref?: Ref<HTMLTextAreaElement>
+}
 
-const Textarea = forwardRef<HTMLTextAreaElement, TextareaProps>(({ className, ...props }, ref) => {
+function Textarea({ className, ref, ...props }: TextareaProps): ReactElement {
   return (
     <textarea
       className={cn(
@@ -14,7 +16,6 @@ const Textarea = forwardRef<HTMLTextAreaElement, TextareaProps>(({ className, ..
       {...props}
     />
   )
-})
-Textarea.displayName = 'Textarea'
+}
 
 export { Textarea }

--- a/packages/app/src/components/ui/toast.tsx
+++ b/packages/app/src/components/ui/toast.tsx
@@ -11,7 +11,7 @@ type ToastViewportProps = ComponentPropsWithoutRef<typeof ToastPrimitives.Viewpo
   ref?: Ref<ElementRef<typeof ToastPrimitives.Viewport>>
 }
 
-function ToastViewport({ className, ref, ...props }: ToastViewportProps): ReactElement {
+const ToastViewport = ({ className, ref, ...props }: ToastViewportProps): ReactElement => {
   return (
     <ToastPrimitives.Viewport
       ref={ref}
@@ -45,7 +45,7 @@ type ToastRootProps = ComponentPropsWithoutRef<typeof ToastPrimitives.Root> &
     ref?: Ref<ElementRef<typeof ToastPrimitives.Root>>
   }
 
-function Toast({ className, variant, ref, ...props }: ToastRootProps): ReactElement {
+const Toast = ({ className, variant, ref, ...props }: ToastRootProps): ReactElement => {
   return (
     <ToastPrimitives.Root
       ref={ref}
@@ -59,7 +59,7 @@ type ToastActionProps = ComponentPropsWithoutRef<typeof ToastPrimitives.Action> 
   ref?: Ref<ElementRef<typeof ToastPrimitives.Action>>
 }
 
-function ToastAction({ className, ref, ...props }: ToastActionProps): ReactElement {
+const ToastAction = ({ className, ref, ...props }: ToastActionProps): ReactElement => {
   return (
     <ToastPrimitives.Action
       ref={ref}
@@ -76,7 +76,7 @@ type ToastCloseProps = ComponentPropsWithoutRef<typeof ToastPrimitives.Close> & 
   ref?: Ref<ElementRef<typeof ToastPrimitives.Close>>
 }
 
-function ToastClose({ className, ref, ...props }: ToastCloseProps): ReactElement {
+const ToastClose = ({ className, ref, ...props }: ToastCloseProps): ReactElement => {
   return (
     <ToastPrimitives.Close
       ref={ref}
@@ -96,7 +96,7 @@ type ToastTitleProps = ComponentPropsWithoutRef<typeof ToastPrimitives.Title> & 
   ref?: Ref<ElementRef<typeof ToastPrimitives.Title>>
 }
 
-function ToastTitle({ className, ref, ...props }: ToastTitleProps): ReactElement {
+const ToastTitle = ({ className, ref, ...props }: ToastTitleProps): ReactElement => {
   return (
     <ToastPrimitives.Title
       ref={ref}
@@ -110,7 +110,7 @@ type ToastDescriptionProps = ComponentPropsWithoutRef<typeof ToastPrimitives.Des
   ref?: Ref<ElementRef<typeof ToastPrimitives.Description>>
 }
 
-function ToastDescription({ className, ref, ...props }: ToastDescriptionProps): ReactElement {
+const ToastDescription = ({ className, ref, ...props }: ToastDescriptionProps): ReactElement => {
   return (
     <ToastPrimitives.Description
       ref={ref}

--- a/packages/app/src/components/ui/toast.tsx
+++ b/packages/app/src/components/ui/toast.tsx
@@ -1,9 +1,4 @@
-import {
-  forwardRef,
-  type ElementRef,
-  type ComponentPropsWithoutRef,
-  type ReactElement,
-} from 'react'
+import { type ComponentPropsWithoutRef, type ElementRef, type ReactElement, type Ref } from 'react'
 import * as ToastPrimitives from '@radix-ui/react-toast'
 import { cva, type VariantProps } from 'class-variance-authority'
 import { X } from 'lucide-react'
@@ -12,20 +7,22 @@ import { cn } from '@/utils/classnames'
 
 const ToastProvider = ToastPrimitives.Provider
 
-const ToastViewport = forwardRef<
-  ElementRef<typeof ToastPrimitives.Viewport>,
-  ComponentPropsWithoutRef<typeof ToastPrimitives.Viewport>
->(({ className, ...props }, ref) => (
-  <ToastPrimitives.Viewport
-    ref={ref}
-    className={cn(
-      'fixed top-0 z-100 flex max-h-screen w-full flex-col-reverse p-4 sm:bottom-0 sm:right-0 sm:top-auto sm:flex-col md:max-w-105',
-      className
-    )}
-    {...props}
-  />
-))
-ToastViewport.displayName = ToastPrimitives.Viewport.displayName
+type ToastViewportProps = ComponentPropsWithoutRef<typeof ToastPrimitives.Viewport> & {
+  ref?: Ref<ElementRef<typeof ToastPrimitives.Viewport>>
+}
+
+function ToastViewport({ className, ref, ...props }: ToastViewportProps): ReactElement {
+  return (
+    <ToastPrimitives.Viewport
+      ref={ref}
+      className={cn(
+        'fixed top-0 z-100 flex max-h-screen w-full flex-col-reverse p-4 sm:bottom-0 sm:right-0 sm:top-auto sm:flex-col md:max-w-105',
+        className
+      )}
+      {...props}
+    />
+  )
+}
 
 const toastVariants = cva(
   'group pointer-events-auto relative flex w-full items-center justify-between space-x-4 overflow-hidden rounded-md border p-6 pr-8 shadow-lg transition-all data-[swipe=cancel]:translate-x-0 data-[swipe=end]:translate-x-[var(--radix-toast-swipe-end-x)] data-[swipe=move]:translate-x-[var(--radix-toast-swipe-move-x)] data-[swipe=move]:transition-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[swipe=end]:animate-out data-[state=closed]:fade-out-80 data-[state=closed]:slide-out-to-right-full data-[state=open]:slide-in-from-top-full data-[state=open]:sm:slide-in-from-bottom-full',
@@ -43,10 +40,12 @@ const toastVariants = cva(
   }
 )
 
-const Toast = forwardRef<
-  ElementRef<typeof ToastPrimitives.Root>,
-  ComponentPropsWithoutRef<typeof ToastPrimitives.Root> & VariantProps<typeof toastVariants>
->(({ className, variant, ...props }, ref) => {
+type ToastRootProps = ComponentPropsWithoutRef<typeof ToastPrimitives.Root> &
+  VariantProps<typeof toastVariants> & {
+    ref?: Ref<ElementRef<typeof ToastPrimitives.Root>>
+  }
+
+function Toast({ className, variant, ref, ...props }: ToastRootProps): ReactElement {
   return (
     <ToastPrimitives.Root
       ref={ref}
@@ -54,61 +53,72 @@ const Toast = forwardRef<
       {...props}
     />
   )
-})
-Toast.displayName = ToastPrimitives.Root.displayName
+}
 
-const ToastAction = forwardRef<
-  ElementRef<typeof ToastPrimitives.Action>,
-  ComponentPropsWithoutRef<typeof ToastPrimitives.Action>
->(({ className, ...props }, ref) => (
-  <ToastPrimitives.Action
-    ref={ref}
-    className={cn(
-      'inline-flex h-8 shrink-0 items-center justify-center rounded-md border bg-transparent px-3 text-sm font-medium ring-offset-background transition-colors hover:bg-secondary focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 group-[.destructive]:border-muted/40 group-[.destructive]:hover:border-destructive/30 group-[.destructive]:hover:bg-destructive group-[.destructive]:hover:text-destructive-foreground group-[.destructive]:focus:ring-destructive',
-      className
-    )}
-    {...props}
-  />
-))
-ToastAction.displayName = ToastPrimitives.Action.displayName
+type ToastActionProps = ComponentPropsWithoutRef<typeof ToastPrimitives.Action> & {
+  ref?: Ref<ElementRef<typeof ToastPrimitives.Action>>
+}
 
-const ToastClose = forwardRef<
-  ElementRef<typeof ToastPrimitives.Close>,
-  ComponentPropsWithoutRef<typeof ToastPrimitives.Close>
->(({ className, ...props }, ref) => (
-  <ToastPrimitives.Close
-    ref={ref}
-    className={cn(
-      'absolute right-2 top-2 rounded-md p-1 text-foreground/50 opacity-0 transition-opacity hover:text-foreground focus:opacity-100 focus:outline-none focus:ring-2 group-hover:opacity-100 group-[.destructive]:text-red-300 group-[.destructive]:hover:text-red-50 group-[.destructive]:focus:ring-red-400 group-[.destructive]:focus:ring-offset-red-600',
-      className
-    )}
-    toast-close=""
-    {...props}
-  >
-    <X className="h-4 w-4" />
-  </ToastPrimitives.Close>
-))
-ToastClose.displayName = ToastPrimitives.Close.displayName
+function ToastAction({ className, ref, ...props }: ToastActionProps): ReactElement {
+  return (
+    <ToastPrimitives.Action
+      ref={ref}
+      className={cn(
+        'inline-flex h-8 shrink-0 items-center justify-center rounded-md border bg-transparent px-3 text-sm font-medium ring-offset-background transition-colors hover:bg-secondary focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 group-[.destructive]:border-muted/40 group-[.destructive]:hover:border-destructive/30 group-[.destructive]:hover:bg-destructive group-[.destructive]:hover:text-destructive-foreground group-[.destructive]:focus:ring-destructive',
+        className
+      )}
+      {...props}
+    />
+  )
+}
 
-const ToastTitle = forwardRef<
-  ElementRef<typeof ToastPrimitives.Title>,
-  ComponentPropsWithoutRef<typeof ToastPrimitives.Title>
->(({ className, ...props }, ref) => (
-  <ToastPrimitives.Title ref={ref} className={cn('text-sm font-semibold', className)} {...props} />
-))
-ToastTitle.displayName = ToastPrimitives.Title.displayName
+type ToastCloseProps = ComponentPropsWithoutRef<typeof ToastPrimitives.Close> & {
+  ref?: Ref<ElementRef<typeof ToastPrimitives.Close>>
+}
 
-const ToastDescription = forwardRef<
-  ElementRef<typeof ToastPrimitives.Description>,
-  ComponentPropsWithoutRef<typeof ToastPrimitives.Description>
->(({ className, ...props }, ref) => (
-  <ToastPrimitives.Description
-    ref={ref}
-    className={cn('text-sm opacity-90', className)}
-    {...props}
-  />
-))
-ToastDescription.displayName = ToastPrimitives.Description.displayName
+function ToastClose({ className, ref, ...props }: ToastCloseProps): ReactElement {
+  return (
+    <ToastPrimitives.Close
+      ref={ref}
+      className={cn(
+        'absolute right-2 top-2 rounded-md p-1 text-foreground/50 opacity-0 transition-opacity hover:text-foreground focus:opacity-100 focus:outline-none focus:ring-2 group-hover:opacity-100 group-[.destructive]:text-red-300 group-[.destructive]:hover:text-red-50 group-[.destructive]:focus:ring-red-400 group-[.destructive]:focus:ring-offset-red-600',
+        className
+      )}
+      toast-close=""
+      {...props}
+    >
+      <X className="h-4 w-4" />
+    </ToastPrimitives.Close>
+  )
+}
+
+type ToastTitleProps = ComponentPropsWithoutRef<typeof ToastPrimitives.Title> & {
+  ref?: Ref<ElementRef<typeof ToastPrimitives.Title>>
+}
+
+function ToastTitle({ className, ref, ...props }: ToastTitleProps): ReactElement {
+  return (
+    <ToastPrimitives.Title
+      ref={ref}
+      className={cn('text-sm font-semibold', className)}
+      {...props}
+    />
+  )
+}
+
+type ToastDescriptionProps = ComponentPropsWithoutRef<typeof ToastPrimitives.Description> & {
+  ref?: Ref<ElementRef<typeof ToastPrimitives.Description>>
+}
+
+function ToastDescription({ className, ref, ...props }: ToastDescriptionProps): ReactElement {
+  return (
+    <ToastPrimitives.Description
+      ref={ref}
+      className={cn('text-sm opacity-90', className)}
+      {...props}
+    />
+  )
+}
 
 type ToastProps = ComponentPropsWithoutRef<typeof Toast>
 

--- a/packages/app/src/hooks/useDisplayLineMotion.ts
+++ b/packages/app/src/hooks/useDisplayLineMotion.ts
@@ -15,12 +15,12 @@ interface UseDisplayLineMotionReturn {
  * @returns Current display-line motion state and toggle function
  */
 export function useDisplayLineMotion(): UseDisplayLineMotionReturn {
-  const [displayLineMotion, setDisplayLineMotionState] = useState<boolean>(() =>
+  const [displayLineMotion, setDisplayLineMotion] = useState<boolean>(() =>
     getBooleanEditorPreference('displayLineMotion', false)
   )
 
   const toggleDisplayLineMotion = (): void => {
-    setDisplayLineMotionState((current) => !current)
+    setDisplayLineMotion((current) => !current)
   }
 
   useEffect(() => {

--- a/packages/app/src/hooks/useLineNumbers.ts
+++ b/packages/app/src/hooks/useLineNumbers.ts
@@ -15,12 +15,12 @@ interface UseLineNumbersReturn {
  * @returns Current Line Numbers visibility state and toggle function
  */
 export function useLineNumbers(): UseLineNumbersReturn {
-  const [showLineNumbers, setShowLineNumbersState] = useState<boolean>(() =>
+  const [showLineNumbers, setShowLineNumbers] = useState<boolean>(() =>
     getBooleanEditorPreference('showLineNumbers', true)
   )
 
   const toggleLineNumbers = (): void => {
-    setShowLineNumbersState((current) => !current)
+    setShowLineNumbers((current) => !current)
   }
 
   useEffect(() => {

--- a/packages/app/src/hooks/useSpellCheck.ts
+++ b/packages/app/src/hooks/useSpellCheck.ts
@@ -17,16 +17,16 @@ interface UseSpellCheckReturn {
  * @returns Current spell check state and toggle function
  */
 export function useSpellCheck(): UseSpellCheckReturn {
-  const [spellCheck, setSpellCheckState] = useState<boolean>(() =>
+  const [spellCheck, setSpellCheck] = useState<boolean>(() =>
     getBooleanEditorPreference('spellCheck', false)
   )
 
   const toggleSpellCheck = (): void => {
-    setSpellCheckState((current) => !current)
+    setSpellCheck((current) => !current)
   }
 
-  const setSpellCheck = (enabled: boolean): void => {
-    setSpellCheckState(enabled)
+  const updateSpellCheck = (enabled: boolean): void => {
+    setSpellCheck(enabled)
   }
 
   useEffect(() => {
@@ -42,6 +42,6 @@ export function useSpellCheck(): UseSpellCheckReturn {
   return {
     spellCheck,
     toggleSpellCheck,
-    setSpellCheck,
+    setSpellCheck: updateSpellCheck,
   }
 }

--- a/packages/app/src/hooks/useUrlState.ts
+++ b/packages/app/src/hooks/useUrlState.ts
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback, useRef } from 'react'
+import { useState, useEffect, useCallback, useRef, type MutableRefObject } from 'react'
 import { getFirstHeading } from '@/utils/markdown'
 import { extractFirstEmojiToken, isEmojiShortcodeToken } from '@/utils/emoji'
 import { getEmojiForShortcode } from '@/utils/emojiShortcodes'
@@ -49,7 +49,7 @@ interface ResolvedTitleState {
  */
 function updateFavicon(
   emoji: string | null,
-  originalFaviconsRef: React.MutableRefObject<FaviconState[] | null>
+  originalFaviconsRef: MutableRefObject<FaviconState[] | null>
 ): void {
   const links = document.querySelectorAll<HTMLLinkElement>("link[rel*='icon']")
 
@@ -165,7 +165,7 @@ export function useUrlState(options?: UseUrlStateOptions): UseUrlStateReturn {
     return limit ? parseInt(limit, 10) : defaultMaxLength
   })
 
-  const [content, setContentState] = useState<string>(() => {
+  const [content, setContent] = useState<string>(() => {
     // Initialize from URL hash on mount
     const hash = window.location.hash.slice(1) // Remove leading #
     if (!hash) return defaultContent
@@ -183,7 +183,7 @@ export function useUrlState(options?: UseUrlStateOptions): UseUrlStateReturn {
     }
   })
 
-  const [documentName, setDocumentNameState] = useState<string>(() => {
+  const [documentName, setDocumentName] = useState<string>(() => {
     // Initialize document name from URL hash on mount
     const hash = window.location.hash.slice(1)
     if (!hash) return defaultName
@@ -318,8 +318,8 @@ export function useUrlState(options?: UseUrlStateOptions): UseUrlStateReturn {
       const hash = window.location.hash.slice(1)
 
       const updateStateAndTitle = (newContent: string, newName: string) => {
-        setContentState(newContent)
-        setDocumentNameState(newName)
+        setContent(newContent)
+        setDocumentName(newName)
         applyDocumentChrome(newContent, newName)
       }
 
@@ -351,17 +351,17 @@ export function useUrlState(options?: UseUrlStateOptions): UseUrlStateReturn {
     }
   }, [applyDocumentChrome, defaultContent, defaultName, onError])
 
-  const setContent = useCallback(
+  const updateContent = useCallback(
     (newContent: string) => {
-      setContentState(newContent)
+      setContent(newContent)
       updateUrl()
     },
     [updateUrl]
   )
 
-  const setDocumentName = useCallback(
+  const updateDocumentName = useCallback(
     (newName: string) => {
-      setDocumentNameState(newName)
+      setDocumentName(newName)
       updateUrl()
     },
     [updateUrl]
@@ -369,9 +369,9 @@ export function useUrlState(options?: UseUrlStateOptions): UseUrlStateReturn {
 
   return {
     content,
-    setContent,
+    setContent: updateContent,
     documentName,
-    setDocumentName,
+    setDocumentName: updateDocumentName,
     isOverLimit,
   }
 }

--- a/packages/app/src/hooks/useViewMode.ts
+++ b/packages/app/src/hooks/useViewMode.ts
@@ -12,7 +12,7 @@ interface UseViewModeReturn {
  * @returns Object containing viewMode state and setter
  */
 export function useViewMode(): UseViewModeReturn {
-  const [viewMode, setViewModeState] = useState<ViewMode>(() => {
+  const [viewMode, setViewMode] = useState<ViewMode>(() => {
     if (typeof window === 'undefined') return 'split'
     const params = new URLSearchParams(window.location.search)
     const view = params.get('view')
@@ -23,8 +23,8 @@ export function useViewMode(): UseViewModeReturn {
   })
 
   // Sync state changes to URL
-  const setViewMode = useCallback((mode: ViewMode) => {
-    setViewModeState(mode)
+  const updateViewMode = useCallback((mode: ViewMode) => {
+    setViewMode(mode)
 
     const url = new URL(window.location.href)
     if (mode === 'split') {
@@ -47,6 +47,6 @@ export function useViewMode(): UseViewModeReturn {
 
   return {
     viewMode,
-    setViewMode,
+    setViewMode: updateViewMode,
   }
 }

--- a/packages/app/src/hooks/useVimMode.ts
+++ b/packages/app/src/hooks/useVimMode.ts
@@ -15,12 +15,12 @@ interface UseVimModeReturn {
  * @returns Current Vim mode state and toggle function
  */
 export function useVimMode(): UseVimModeReturn {
-  const [vimMode, setVimModeState] = useState<boolean>(() =>
+  const [vimMode, setVimMode] = useState<boolean>(() =>
     getBooleanEditorPreference('vimMode', false)
   )
 
   const toggleVimMode = (): void => {
-    setVimModeState((current) => !current)
+    setVimMode((current) => !current)
   }
 
   useEffect(() => {

--- a/packages/app/src/hooks/useWordCount.ts
+++ b/packages/app/src/hooks/useWordCount.ts
@@ -15,12 +15,12 @@ interface UseWordCountReturn {
  * @returns Current Word Count visibility state and toggle function
  */
 export function useWordCount(): UseWordCountReturn {
-  const [showWordCount, setShowWordCountState] = useState<boolean>(() =>
+  const [showWordCount, setShowWordCount] = useState<boolean>(() =>
     getBooleanEditorPreference('showWordCount', false)
   )
 
   const toggleWordCount = (): void => {
-    setShowWordCountState((current) => !current)
+    setShowWordCount((current) => !current)
   }
 
   useEffect(() => {


### PR DESCRIPTION
React 19 ref props are now used across the shadcn/Radix wrapper surface and editor wrappers so the app no longer relies on `forwardRef`.[^1]

- Developers can run lint without `react-x/no-forward-ref` warnings.
- Radix-backed controls continue to receive refs through their primitive wrappers.
- The editor pane and toolbar button keep their imperative/button refs through normal `ref` props.
- Existing React lint warnings are cleared so verification runs without warning noise.

Closes #378.

[^1]: The existing forwarded refs are now modelled as normal optional `ref` props and passed to the same DOM or Radix primitive targets.