### PR TITLE
chore: resolve dependency validation warnings

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6975,9 +6975,9 @@
       "license": "MIT"
     },
     "node_modules/dompurify": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.3.3.tgz",
-      "integrity": "sha512-Oj6pzI2+RqBfFG+qOaOLbFXLQ90ARpcGG6UePL82bJLtdsa6CYJD7nmiU8MW9nQNOtCHV3lZ/Bzq1X0QYbBZCA==",
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.2.tgz",
+      "integrity": "sha512-lHeS9SA/IKeIFFyYciHBr2n0v1VMPlSj843HdLOwjb2OxNwdq9Xykxqhk+FE42MzAdHvInbAolSE4mhahPpjXA==",
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"

--- a/package.json
+++ b/package.json
@@ -46,8 +46,11 @@
     "lint-staged": "^17.0.2"
   },
   "overrides": {
-    "dompurify": "3.3.3",
+    "dompurify": "3.4.2",
     "lodash-es": "4.18.1",
+    "monaco-editor": {
+      "dompurify": "3.4.2"
+    },
     "smol-toml": "1.6.1"
   },
   "optionalDependencies": {

--- a/packages/app/src/components/transformer/TransformerWorkbench.tsx
+++ b/packages/app/src/components/transformer/TransformerWorkbench.tsx
@@ -58,7 +58,6 @@ export function TransformerWorkbench({
   const cursorPositionRef = useRef<number>(0) // Track line number
 
   // In JSON mode, merge toolbox additions into the JSON buffer while preserving in-progress edits.
-  /* eslint-disable react-x/set-state-in-effect -- The JSON editor mirrors external step changes while it is mounted. */
   useEffect(() => {
     if (mode === 'json') {
       // In JSON mode, if steps changed, it might be due to an add operation from the toolbox
@@ -246,8 +245,6 @@ export function TransformerWorkbench({
     // Update ref
     prevStepsRef.current = steps
   }, [steps, mode, isValidJson, jsonValue])
-  /* eslint-enable react-x/set-state-in-effect */
-
   // Handle vim mode initialization on mode/prop change
   useEffect(() => {
     // Initialize Vim mode


### PR DESCRIPTION
## Summary
- bump the existing DOMPurify override to 3.4.2 so npm audit is clean
- remove stale eslint disable/enable comments surfaced by updated linting

## Validation
- npm run format
- npm run lint
- npm run tsc
- npm test
- npm run build
- env -u NO_COLOR -u FORCE_COLOR npm run test:e2e
- npm audit --json